### PR TITLE
fix: update python version to 3.7 and requirement.txt

### DIFF
--- a/build/image/Dockerfile
+++ b/build/image/Dockerfile
@@ -1,5 +1,12 @@
 FROM tapdata-docker.pkg.coding.net/tapdata/tldp/runtime:0.1
 
+RUN apt-get install -y python3.7 && \
+    update-alternatives --install /usr/bin/python python /usr/bin/python3.7 1 && \
+    update-alternatives --set python /usr/bin/python3.7 && \
+    curl -s https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
+    python get-pip.py --force-reinstall && \
+    rm get-pip.py
+
 COPY manager /tapdata/apps/manager
 COPY iengine /tapdata/apps/iengine
 RUN mkdir -p /tapdata/apps/plugin-kit /tapdata/apps/connectors-common /tapdata/apps/connectors /tapdata/apps/build

--- a/tapshell/register-all-connectors.sh
+++ b/tapshell/register-all-connectors.sh
@@ -2,8 +2,8 @@
 basepath=$(cd `dirname $0`; pwd)
 cd $basepath
 
-server=`cat conf.json |grep "server"|awk -F '"' '{print $4}'`
-access_code=`cat conf.json |grep "access_code"|awk -F '"' '{print $4}'`
+server=`cat $basepath/config.ini |grep "server"|awk -F ' ' '{print $3}'`
+access_code=`cat $basepath/config.ini |grep "access_code"|awk -F ' ' '{print $3}'`
 
 if [[ -f ".register" ]]; then
     echo "init connectors register finished, if you want to register your own connector, please run below command:"


### PR DESCRIPTION
Many third parties of tapshell rely on python3.7, but the python version of docker image is python3.6, which leads to the failure of image construction.