### PR TITLE
fix pom version

### DIFF
--- a/iengine/iengine-common/pom.xml
+++ b/iengine/iengine-common/pom.xml
@@ -354,6 +354,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
+                <version>4.2.1</version>
                 <extensions>true</extensions>
             </plugin>
         </plugins>


### PR DESCRIPTION
mvn clean  install get error:

```
Unresolveable build extension: Error resolving version for plugin 'org.apache.felix:maven-bundle-plugin' from the repositories
```