### PR TITLE
fix(kafka): #5744 【V3.1】数据开发，mysql--kafka，源表的字段是 空值 或者 null  ,该字段没有同步…

### DIFF
--- a/connectors-common/kafka-core/src/main/java/io/tapdata/connector/kafka/KafkaService.java
+++ b/connectors-common/kafka-core/src/main/java/io/tapdata/connector/kafka/KafkaService.java
@@ -386,7 +386,7 @@ public class KafkaService extends AbstractMqService {
                                 map.remove("after");
                             }
                             res.put("data",map);
-                            body = jsonParser.toJsonBytes(res.get("data"));
+                            body = jsonParser.toJsonBytes(res.get("data"), JsonParser.ToJsonFeature.WriteMapNullValue);
                         }else {
                             body = obj.toString().getBytes();
                         }


### PR DESCRIPTION
…到kafka中

Closes #148746