### PR TITLE
[HA] 数据源名字过长, 导致共享挖掘任务报错]

### DIFF
--- a/iengine/api/pom.xml
+++ b/iengine/api/pom.xml
@@ -40,6 +40,18 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-mongodb</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <distributionManagement>

--- a/iengine/api/src/main/java/io/tapdata/common/sharecdc/ShareCdcUtil.java
+++ b/iengine/api/src/main/java/io/tapdata/common/sharecdc/ShareCdcUtil.java
@@ -12,6 +12,7 @@ import io.tapdata.common.SettingService;
 import io.tapdata.entity.event.dml.TapRecordEvent;
 import io.tapdata.entity.utils.DataMap;
 import io.tapdata.pdk.apis.functions.connector.source.ConnectionConfigWithTables;
+import org.apache.commons.collections4.MapUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -82,6 +83,19 @@ public class ShareCdcUtil {
 			return new ArrayList<>(tableNames);
 		}
 		return logCollectorNode.getTableNames();
+	}
+
+	public static List<LogCollecotrConnConfig> getLogCollectorConfigs(LogCollectorNode logCollectorNode) {
+		List<LogCollecotrConnConfig> connConfigs = new ArrayList<>();
+		if (MapUtils.isNotEmpty(logCollectorNode.getLogCollectorConnConfigs())) {
+			connConfigs.addAll(logCollectorNode.getLogCollectorConnConfigs().values());
+		}else{
+			List<String> tableNames = logCollectorNode.getTableNames();
+			String connectionId = logCollectorNode.getConnectionIds().get(0);
+			LogCollecotrConnConfig logCollecotrConnConfig = new LogCollecotrConnConfig(connectionId, logCollectorNode.getTableNames());
+			connConfigs.add(logCollecotrConnConfig);
+		}
+		return connConfigs;
 	}
 
 	public static void fillConfigNamespace(LogCollectorNode logCollectorNode, Function<String, Connections> findConnection) {

--- a/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/node/hazelcast/data/pdk/HazelcastTargetPdkShareCDCNode.java
+++ b/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/node/hazelcast/data/pdk/HazelcastTargetPdkShareCDCNode.java
@@ -9,8 +9,10 @@ import com.tapdata.entity.TapdataShareLogEvent;
 import com.tapdata.entity.sharecdc.LogContent;
 import com.tapdata.entity.task.context.DataProcessorContext;
 import com.tapdata.tm.commons.dag.Node;
+import com.tapdata.tm.commons.dag.logCollector.LogCollecotrConnConfig;
 import com.tapdata.tm.commons.dag.logCollector.LogCollectorNode;
 import com.tapdata.tm.commons.task.dto.TaskDto;
+import com.tapdata.tm.shareCdcTableMapping.ShareCdcTableMappingDto;
 import com.tapdata.tm.shareCdcTableMetrics.ShareCdcTableMetricsDto;
 import io.tapdata.aspect.*;
 import io.tapdata.aspect.utils.AspectUtils;
@@ -40,18 +42,20 @@ import io.tapdata.pdk.apis.entity.WriteListResult;
 import io.tapdata.pdk.core.utils.CommonUtils;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
-import org.apache.commons.collections.map.LRUMap;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.bson.Document;
 import org.bson.types.ObjectId;
 import org.jetbrains.annotations.NotNull;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
 
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 
 /**
  * @author samuel
@@ -67,24 +71,16 @@ public class HazelcastTargetPdkShareCDCNode extends HazelcastTargetPdkBaseNode {
 	public static final String TAG = HazelcastTargetPdkShareCDCNode.class.getSimpleName();
 	private final static ObjectSerializable OBJECT_SERIALIZABLE = InstanceFactory.instance(ObjectSerializable.class);
 	private final Logger logger = LogManager.getLogger(HazelcastTargetPdkShareCDCNode.class);
-	/*private final PersistentLRUMap constructMap = new PersistentLRUMap(100, entry -> {
-		if (entry instanceof ConstructRingBuffer) {
-			try {
-				((ConstructRingBuffer<?>) entry).destroy();
-			} catch (Exception e) {
-				logger.warn("Destroy construct ring buffer failed: {}", e.getMessage());
-			}
-		}
-	});*/
-	private final Map<String, ConstructRingBuffer<?>> constructMap = new ConcurrentHashMap<>();
+	/*private final Map<String, ConstructRingBuffer<Document>> constructMap = new ConcurrentHashMap<>();*/
+	private final Map<String, HazelcastConstruct<Document>> constructMap = new ConcurrentHashMap<>();
 	private final AtomicReference<String> constructReferenceId = new AtomicReference<>();
-	private List<String> tableNames;
-	private Map<String, List<Document>> batchCacheData;
+	private List<LogCollecotrConnConfig> logCollecotrConnConfigs;
+	private Map<String, Map<String, List<Document>>> batchCacheData;
 	private LinkedBlockingQueue<ShareCdcTableMetricsDto> tableMetricsQueue = new LinkedBlockingQueue<>(1024);
 	private ExecutorService flushShareCdcTableMetricsThreadPool;
 	private List<ShareCdcTableMetricsDto> cacheMetricsList = new ArrayList<>();
 	private final AtomicLong lastFlushMetricsTimeMs = new AtomicLong();
-	private Map<String, ShareCdcTableMetricsDto> shareCdcTableMetricsDtoMap;
+	private Map<String, Map<String, ShareCdcTableMetricsDto>> shareCdcTableMetricsDtoMap;
 	private ClassHandlers ddlEventHandlers;
 	private final AtomicReference<LogContent> ddlLogContent = new AtomicReference<>();
 
@@ -102,26 +98,31 @@ public class HazelcastTargetPdkShareCDCNode extends HazelcastTargetPdkBaseNode {
 		externalStorageDto.setTtlDay(shareCdcTtlDay);
 		LogContent startTimeSign = LogContent.createStartTimeSign();
 		Document document = MapUtil.obj2Document(startTimeSign);
-		obsLogger.info("Init share log storage, table count: " + tableNames.size());
 		List<CompletableFuture<?>> completableFutures = new ArrayList<>();
-		for (String tableName : tableNames) {
-			completableFutures.add(CompletableFuture.runAsync(() -> {
-				try {
-					HazelcastConstruct<Document> construct = getConstruct(tableName);
-					if (construct.isEmpty()) {
-						construct.insert(document);
-					}
-				} catch (Exception e) {
-					throw new RuntimeException(e);
-				}
-			}));
-		}
-		CompletableFuture.allOf(completableFutures.toArray(new CompletableFuture<?>[0])).whenComplete((v, e) -> {
-			if (null != e) {
-				throw new RuntimeException(e);
+		for (LogCollecotrConnConfig logCollecotrConnConfig : logCollecotrConnConfigs) {
+			AtomicReference<String> tableNamePrefix = new AtomicReference<>();
+			if (CollectionUtils.isNotEmpty(logCollecotrConnConfig.getNamespace())) {
+				tableNamePrefix.set(ShareCdcUtil.joinNamespaces(logCollecotrConnConfig.getNamespace()));
 			}
-		}).join();
-		this.batchCacheData = new LinkedHashMap<>();
+			for (String tableName : logCollecotrConnConfig.getTableNames()) {
+				completableFutures.add(CompletableFuture.runAsync(() -> {
+					HazelcastConstruct<Document> construct;
+					if (null != tableNamePrefix.get()) {
+						construct = getConstruct(ShareCdcUtil.joinNamespaces(Arrays.asList(tableNamePrefix.get(), tableName)), logCollecotrConnConfig.getConnectionId());
+					} else {
+						construct = getConstruct(tableName, logCollecotrConnConfig.getConnectionId());
+					}
+					if (construct.isEmpty()) {
+						try {
+							construct.insert(document);
+						} catch (Exception e) {
+							throw new RuntimeException(e);
+						}
+					}
+				}));
+			}
+		}
+		this.batchCacheData = new ConcurrentHashMap<>();
 		this.flushShareCdcTableMetricsThreadPool = new ThreadPoolExecutor(1, 1, 0L, TimeUnit.SECONDS, new SynchronousQueue<>(),
 				r -> new Thread(r, "Flush-Share-Cdc-Table-Metrics-Consumer-"
 						+ dataProcessorContext.getTaskDto().getId().toHexString() + "-" + getNode().getId()));
@@ -320,7 +321,7 @@ public class HazelcastTargetPdkShareCDCNode extends HazelcastTargetPdkBaseNode {
 		}
 		String tableId = logContent.getFromTable();
 		Document document = logContent2Document(logContent);
-		HazelcastConstruct<Document> construct = getConstruct(tableId);
+		HazelcastConstruct<Document> construct = getConstruct(tableId, document.getString("connectionId"));
 		try {
 			construct.insert(document);
 		} catch (Exception e) {
@@ -330,6 +331,7 @@ public class HazelcastTargetPdkShareCDCNode extends HazelcastTargetPdkBaseNode {
 
 	private <E extends TapEvent> WriteListResult<E> writeLogContents(List<LogContent> logContents) {
 		WriteListResult<E> writeListResult = new WriteListResult<>();
+		Map<String, List<Document>> batchCacheData = findInMapByThreadName(this.batchCacheData, tn -> new LinkedHashMap<>());
 		for (LogContent logContent : logContents) {
 			String tableId = ShareCdcUtil.getTableId(logContent);
 			Document document = logContent2Document(logContent);
@@ -380,6 +382,11 @@ public class HazelcastTargetPdkShareCDCNode extends HazelcastTargetPdkBaseNode {
 		}
 		LogContent logContent = null;
 		String op = TapEventUtil.getOp(tapEvent);
+		Object connIdObj = tapdataShareLogEvent.getInfo(TapdataEvent.CONNECTION_ID_INFO_KEY);
+		String connectionId = "";
+		if (connIdObj instanceof String) {
+			connectionId = (String) connIdObj;
+		}
 		if (tapdataShareLogEvent.isDML()) {
 			Map<String, Object> before = TapEventUtil.getBefore(tapEvent);
 			handleData(before);
@@ -395,6 +402,7 @@ public class HazelcastTargetPdkShareCDCNode extends HazelcastTargetPdkBaseNode {
 					offsetStr
 			);
 			logContent.setTableNamespaces(TapEventUtil.getNamespaces(tapEvent));
+			logContent.setConnectionId(connectionId);
 		} else if (tapdataShareLogEvent.isDDL()) {
 			verifyDDL(tapEvent, tableId, op, timestamp, offsetStr);
 			byte[] bytes = OBJECT_SERIALIZABLE.fromObject(tapEvent);
@@ -406,6 +414,7 @@ public class HazelcastTargetPdkShareCDCNode extends HazelcastTargetPdkBaseNode {
 					bytes
 			);
 			logContent.setTableNamespaces(TapEventUtil.getNamespaces(tapEvent));
+			logContent.setConnectionId(connectionId);
 		}
 		return logContent;
 	}
@@ -445,7 +454,7 @@ public class HazelcastTargetPdkShareCDCNode extends HazelcastTargetPdkBaseNode {
 		if (CollectionUtils.isNotEmpty(predecessors)) {
 			LogCollectorNode logCollectorNode = (LogCollectorNode) predecessors.get(0);
 			shareCdcTtlDay = logCollectorNode.getStorageTime();
-			tableNames = ShareCdcUtil.getTableNames(logCollectorNode);
+			logCollecotrConnConfigs = ShareCdcUtil.getLogCollectorConfigs(logCollectorNode);
 		}
 		if (null == shareCdcTtlDay || shareCdcTtlDay.compareTo(0) <= 0) {
 			shareCdcTtlDay = DEFAULT_SHARE_CDC_TTL_DAY;
@@ -453,20 +462,25 @@ public class HazelcastTargetPdkShareCDCNode extends HazelcastTargetPdkBaseNode {
 		return shareCdcTtlDay;
 	}
 
-	private HazelcastConstruct<Document> getConstruct(String tableName) {
-		Object construct = constructMap.get(tableName);
-		if (null == construct) {
-			synchronized (constructMap) {
-				construct = constructMap.computeIfAbsent(tableName, k -> new ConstructRingBuffer<>(
-						jetContext.hazelcastInstance(),
-						constructReferenceId.get(),
-						ShareCdcUtil.getConstructName(processorBaseContext.getTaskDto(), tableName),
-						externalStorageDto,
-						PersistenceStorage.SequenceMode.HAZELCAST
-				));
+	private HazelcastConstruct<Document> getConstruct(String tableName, String connectionId) {
+		return constructMap.computeIfAbsent(tableName, k -> {
+			String taskId = processorBaseContext.getTaskDto().getId().toHexString();
+			String[] split = tableName.split("\\.");
+			String sign = ShareCdcTableMappingDto.genSign(taskId, connectionId, split[split.length - 1]);
+			Query query = Query.query(Criteria.where("sign").is(sign));
+			ShareCdcTableMappingDto shareCdcTableMappingDto = clientMongoOperator.findOne(query, ConnectorConstant.SHARE_CDC_TABLE_MAPPING_COLLECTION, ShareCdcTableMappingDto.class);
+			if (null == shareCdcTableMappingDto) {
+				throw new RuntimeException("Share cdc table mapping not found, sign: " + sign);
 			}
-		}
-		return (HazelcastConstruct<Document>) construct;
+			externalStorageDto.setTable(shareCdcTableMappingDto.getExternalStorageTableName());
+			return new ConstructRingBuffer<>(
+					jetContext.hazelcastInstance(),
+					constructReferenceId.get(),
+					ShareCdcUtil.getConstructName(processorBaseContext.getTaskDto(), tableName),
+					externalStorageDto,
+					PersistenceStorage.SequenceMode.HAZELCAST
+			);
+		});
 	}
 
 	private void incrementTableMetrics(List<TapdataShareLogEvent> tapdataShareLogEvents) {
@@ -496,16 +510,17 @@ public class HazelcastTargetPdkShareCDCNode extends HazelcastTargetPdkBaseNode {
 			}
 			String key = getTableMetricsKey(connectionId, nodeId, tableId);
 			ShareCdcTableMetricsDto shareCdcTableMetricsDto;
-			if (!shareCdcTableMetricsDtoMap.containsKey(key)) {
+			Map<String, ShareCdcTableMetricsDto> metricsMap = findInMapByThreadName(this.shareCdcTableMetricsDtoMap, tn -> new LinkedHashMap<>());
+			if (!metricsMap.containsKey(key)) {
 				shareCdcTableMetricsDto = new ShareCdcTableMetricsDto();
 				shareCdcTableMetricsDto.setTaskId(dataProcessorContext.getTaskDto().getId().toHexString());
 				shareCdcTableMetricsDto.setConnectionId(connectionId);
 				shareCdcTableMetricsDto.setNodeId(nodeId);
 				shareCdcTableMetricsDto.setTableName(tableId);
 				shareCdcTableMetricsDto.setCount(1L);
-				shareCdcTableMetricsDtoMap.put(key, shareCdcTableMetricsDto);
+				metricsMap.put(key, shareCdcTableMetricsDto);
 			} else {
-				shareCdcTableMetricsDto = shareCdcTableMetricsDtoMap.get(key);
+				shareCdcTableMetricsDto = metricsMap.get(key);
 				shareCdcTableMetricsDto.setCount(shareCdcTableMetricsDto.getCount() + 1L);
 			}
 			shareCdcTableMetricsDto.setFirstEventTime(tapdataShareLogEvent.getSourceTime());
@@ -523,7 +538,8 @@ public class HazelcastTargetPdkShareCDCNode extends HazelcastTargetPdkBaseNode {
 		if (MapUtils.isEmpty(shareCdcTableMetricsDtoMap)) {
 			return;
 		}
-		Collection<ShareCdcTableMetricsDto> shareCdcTableMetricsDtoList = shareCdcTableMetricsDtoMap.values();
+		Map<String, ShareCdcTableMetricsDto> metricsMap = findInMapByThreadName(this.shareCdcTableMetricsDtoMap, tn -> new LinkedHashMap<>());
+		Collection<ShareCdcTableMetricsDto> shareCdcTableMetricsDtoList = metricsMap.values();
 		for (ShareCdcTableMetricsDto shareCdcTableMetricsDto : shareCdcTableMetricsDtoList) {
 			while (isRunning()) {
 				try {
@@ -535,13 +551,18 @@ public class HazelcastTargetPdkShareCDCNode extends HazelcastTargetPdkBaseNode {
 				}
 			}
 		}
-		shareCdcTableMetricsDtoMap.clear();
+		metricsMap.clear();
 	}
 
 	private void insertMany(String tableId) {
 		try {
-			HazelcastConstruct<Document> construct = getConstruct(tableId);
-			construct.insertMany(batchCacheData.get(tableId), unused -> !isRunning());
+			List<Document> documents = findInMapByThreadName(this.batchCacheData, tn -> new LinkedHashMap<>()).get(tableId);
+			if (CollectionUtils.isEmpty(documents)) {
+				return;
+			}
+			String connectionId = documents.get(0).getString("connectionId");
+			HazelcastConstruct<Document> construct = getConstruct(tableId, connectionId);
+			construct.insertMany(documents, unused -> !isRunning());
 			if (logger.isDebugEnabled()) {
 				Ringbuffer ringbuffer = ((ConstructRingBuffer) construct).getRingbuffer();
 				logger.debug("Write ring buffer, head sequence: {}, tail sequence: {}, last data: {}", ringbuffer.headSequence(), ringbuffer.tailSequence(), ringbuffer.readOne(ringbuffer.tailSequence()));
@@ -607,6 +628,10 @@ public class HazelcastTargetPdkShareCDCNode extends HazelcastTargetPdkBaseNode {
 		if (StringUtils.isBlank(offsetStr)) {
 			obsLogger.warn("Invalid offset string: " + offsetStr);
 		}
+	}
+
+	private <V> Map<String, V> findInMapByThreadName(Map<String, Map<String, V>> map, Function<String, ? extends Map<String, V>> mappingFunction) {
+		return map.computeIfAbsent(Thread.currentThread().getName(), mappingFunction);
 	}
 
 	@Override

--- a/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/sharecdc/impl/ShareCdcPDKTaskReader.java
+++ b/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/sharecdc/impl/ShareCdcPDKTaskReader.java
@@ -14,6 +14,7 @@ import com.tapdata.entity.sharecdc.LogContent;
 import com.tapdata.entity.task.NodeUtil;
 import com.tapdata.tm.commons.externalStorage.ExternalStorageDto;
 import com.tapdata.tm.commons.task.dto.TaskDto;
+import com.tapdata.tm.shareCdcTableMapping.ShareCdcTableMappingDto;
 import io.tapdata.common.sharecdc.ShareCdcUtil;
 import io.tapdata.construct.ConstructIterator;
 import io.tapdata.construct.HazelcastConstruct;
@@ -267,10 +268,17 @@ public class ShareCdcPDKTaskReader extends ShareCdcHZReader implements Serializa
 		} else {
 			constructName = ShareCdcUtil.getConstructName(this.logCollectorTaskDto, tableName);
 		}
-		// Use different construct, but same collection name
-		tableName = ExternalStorageUtil.EXTERNAL_STORAGE_TABLE_NAME_PREFIX + constructName;
-		logCollectorExternalStorage.setTable(tableName);
 		constructName = constructName + "_" + ((ShareCdcTaskPdkContext) shareCdcContext).getTaskDto().getName();
+
+		String connId = ((ShareCdcTaskPdkContext) shareCdcContext).getConnections().getId();
+		String sign = ShareCdcTableMappingDto.genSign(logCollectorTaskDto.getId().toHexString(), connId, tableName);
+		Query query = Query.query(where("sign").is(sign));
+		ShareCdcTableMappingDto shareCdcTableMappingDto = clientMongoOperator.findOne(query, ConnectorConstant.SHARE_CDC_TABLE_MAPPING_COLLECTION, ShareCdcTableMappingDto.class);
+		if (null == shareCdcTableMappingDto) {
+			throw new RuntimeException("Share cdc table mapping not found, sign: " + sign);
+		}
+		tableName = shareCdcTableMappingDto.getExternalStorageTableName();
+		logCollectorExternalStorage.setTable(tableName);
 		logCollectorExternalStorage.setTtlDay(null);
 
 		return new ConstructRingBuffer<>(

--- a/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/sharecdc/impl/ShareCdcPDKTaskReader.java
+++ b/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/sharecdc/impl/ShareCdcPDKTaskReader.java
@@ -424,12 +424,12 @@ public class ShareCdcPDKTaskReader extends ShareCdcHZReader implements Serializa
 			this.readerResourceMap = new HashMap<>();
 			for (String tableName : tableNames) {
 				ConstructRingBuffer<Document> constructRingBuffer = getConstruct(tableName);
+				obsLogger.info("[{}] Successfully obtained construct, name: {}, external storage name: {}", LOG_PREFIX, constructRingBuffer.getName(), logCollectorExternalStorage.getTable());
 				ShareCdcReaderResource shareCdcReaderResource = new ShareCdcReaderResource(constructRingBuffer);
 				if (null != sequenceMap && sequenceMap.containsKey(tableName)) {
 					shareCdcReaderResource.sequence(sequenceMap.get(tableName));
 					if (logger.isDebugEnabled()) {
-						logger.debug("Found share cdc table[{}] offset, sequence: {}", tableNames, sequenceMap.get(tableName));
-						shareCdcContext.getObsLogger().debug("Found share cdc table[{}] offset, sequence: {}", tableNames, sequenceMap.get(tableName));
+						obsLogger.debug("[{}] Found share cdc table[{}] offset, sequence: {}", LOG_PREFIX, tableNames, sequenceMap.get(tableName));
 					}
 				}
 				readerResourceMap.put(tableName, shareCdcReaderResource);
@@ -438,7 +438,7 @@ public class ShareCdcPDKTaskReader extends ShareCdcHZReader implements Serializa
 
 		public void read() {
 			Thread.currentThread().setName(THREAD_NAME_PREFIX + "-" + taskDto.getName() + "-" + index);
-			shareCdcContext.getObsLogger().info(logWrapper("Starting read log from hazelcast construct, tables: " + tableNames));
+			obsLogger.info(logWrapper("Starting read log from hazelcast construct, tables: " + tableNames));
 			/*while (running.get()) {
 				if (null == future || future.isDone()) {
 					break;

--- a/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/util/SkipIdleProcessor.java
+++ b/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/util/SkipIdleProcessor.java
@@ -1,5 +1,8 @@
 package io.tapdata.flow.engine.V2.util;
 
+import io.tapdata.entity.memory.MemoryFetcher;
+import io.tapdata.entity.utils.DataMap;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -13,7 +16,7 @@ import java.util.function.Supplier;
  * @author <a href="mailto:harsen_lin@163.com">Harsen</a>
  * @version v1.0 2023/5/31 15:41 Create
  */
-public class SkipIdleProcessor<T> implements AutoCloseable {
+public class SkipIdleProcessor<T> implements AutoCloseable, MemoryFetcher {
 	private final static Logger logger = LogManager.getLogger(SkipIdleProcessor.class);
 
 	private final static int SLEEP_INTERVAL = 100;
@@ -109,6 +112,22 @@ public class SkipIdleProcessor<T> implements AutoCloseable {
 			th.interrupt();
 			th = null;
 		}
+	}
+
+	@Override
+	public DataMap memory(String keyRegex, String memoryLevel) {
+		DataMap dataMap = new DataMap();
+		try {
+			dataMap.kv("idle", idleList);
+		} catch (Exception e) {
+			dataMap.kv("idle error", e.getMessage() + "; Stack: " + ExceptionUtils.getStackTrace(e));
+		}
+		try {
+			dataMap.kv("process queue", queue);
+		} catch (Exception e) {
+			dataMap.kv("process queue error", e.getMessage() + "; Stack: " + ExceptionUtils.getStackTrace(e));
+		}
+		return dataMap;
 	}
 
 	public interface IFn<T, P, V> {

--- a/iengine/iengine-common/src/main/java/com/tapdata/constant/ConnectorConstant.java
+++ b/iengine/iengine-common/src/main/java/com/tapdata/constant/ConnectorConstant.java
@@ -107,6 +107,7 @@ public class ConnectorConstant {
 	public static final String AGENT_INFO_COLLECTION = "agentEnvironment";
 
 	public static final String EXTERNAL_STORAGE_COLLECTION = "ExternalStorage";
+	public static final String SHARE_CDC_TABLE_MAPPING_COLLECTION = "ShareCdcTableMapping";
 
 	public static final String JOB_STATUS_FIELD = "status";
 

--- a/iengine/iengine-common/src/main/java/com/tapdata/entity/sharecdc/LogContent.java
+++ b/iengine/iengine-common/src/main/java/com/tapdata/entity/sharecdc/LogContent.java
@@ -39,6 +39,7 @@ public class LogContent implements Serializable {
 	private String offsetString;
 	private String type = LogContentType.DATA.name();
 	private byte[] tapDDLEvent;
+	private String connectionId;
 
 	public LogContent() {
 	}
@@ -205,6 +206,14 @@ public class LogContent implements Serializable {
 		return tapDDLEvent;
 	}
 
+	public String getConnectionId() {
+		return connectionId;
+	}
+
+	public void setConnectionId(String connectionId) {
+		this.connectionId = connectionId;
+	}
+
 	public static LogContent valueOf(Document document) {
 		LogContent logContent = new LogContent();
 		logContent.setFromTable(document.getOrDefault("fromTable", "").toString());
@@ -262,6 +271,7 @@ public class LogContent implements Serializable {
 				"\n  ddl event=" + (null != tapDDLEventObj ? tapDDLEventObj : "") +
 				"\n  offsetString=" + offsetString +
 				"\n  type=" + type +
+				"\n  connectionId=" + connectionId +
 				"\n}";
 	}
 

--- a/manager/tm-common/src/main/java/com/tapdata/tm/shareCdcTableMapping/ShareCdcTableMappingDto.java
+++ b/manager/tm-common/src/main/java/com/tapdata/tm/shareCdcTableMapping/ShareCdcTableMappingDto.java
@@ -1,0 +1,39 @@
+package com.tapdata.tm.shareCdcTableMapping;
+
+import com.tapdata.tm.commons.base.dto.BaseDto;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.apache.commons.lang3.StringUtils;
+
+
+/**
+ * shareCdcTableMapping
+ */
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+@Data
+public class ShareCdcTableMappingDto extends BaseDto {
+
+	public static final String VERSION_V1 = "v1";
+	public static final String VERSION_V2 = "v2";
+
+	private String sign;
+	private String version = VERSION_V1;
+	private String tableName;
+	private String externalStorageTableName;
+	private String shareCdcTaskId;
+	private String connectionId;
+
+	public String genSign() {
+		if (StringUtils.isBlank(shareCdcTaskId))
+			throw new IllegalArgumentException("Share cdc task id cannot be blank");
+		if (StringUtils.isBlank(connectionId)) throw new IllegalArgumentException("Connection id cannot be blank");
+		if (StringUtils.isBlank(tableName)) throw new IllegalArgumentException("Table name cannot be blank");
+		return String.join("_", shareCdcTaskId, connectionId, tableName);
+	}
+
+	public static String genSign(String taskId, String connId, String tableName) {
+		return String.join("_", taskId, connId, tableName);
+	}
+}

--- a/manager/tm/src/main/java/com/tapdata/tm/init/patches/daas/v3_3_5_Share_Cdc_Table_Mapping_Init.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/init/patches/daas/v3_3_5_Share_Cdc_Table_Mapping_Init.java
@@ -1,0 +1,159 @@
+package com.tapdata.tm.init.patches.daas;
+
+import com.tapdata.tm.commons.dag.DAG;
+import com.tapdata.tm.commons.dag.Node;
+import com.tapdata.tm.commons.dag.logCollector.LogCollecotrConnConfig;
+import com.tapdata.tm.commons.dag.logCollector.LogCollectorNode;
+import com.tapdata.tm.commons.task.dto.TaskDto;
+import com.tapdata.tm.ds.entity.DataSourceEntity;
+import com.tapdata.tm.ds.repository.DataSourceRepository;
+import com.tapdata.tm.init.PatchType;
+import com.tapdata.tm.init.PatchVersion;
+import com.tapdata.tm.init.patches.AbsPatch;
+import com.tapdata.tm.init.patches.PatchAnnotation;
+import com.tapdata.tm.sdk.util.AppType;
+import com.tapdata.tm.shareCdcTableMapping.entity.ShareCdcTableMappingEntity;
+import com.tapdata.tm.shareCdcTableMapping.repository.ShareCdcTableMappingRepository;
+import com.tapdata.tm.shareCdcTableMapping.service.ShareCdcTableMappingService;
+import com.tapdata.tm.task.entity.TaskEntity;
+import com.tapdata.tm.task.repository.TaskRepository;
+import com.tapdata.tm.utils.SpringContextHelper;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.MapUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.bson.Document;
+import org.springframework.data.mongodb.core.BulkOperations;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.index.CompoundIndexDefinition;
+import org.springframework.data.mongodb.core.index.Index;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.data.util.Pair;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author samuel
+ * @Description
+ * @create 2023-07-06 17:33
+ **/
+@PatchAnnotation(appType = AppType.DAAS, version = "3.3-5")
+public class v3_3_5_Share_Cdc_Table_Mapping_Init extends AbsPatch {
+	private static final Logger logger = LogManager.getLogger(v3_3_5_Share_Cdc_Table_Mapping_Init.class);
+	public static final String TAG = v3_3_5_Share_Cdc_Table_Mapping_Init.class.getSimpleName();
+
+	public v3_3_5_Share_Cdc_Table_Mapping_Init(PatchType type, PatchVersion version) {
+		super(type, version);
+	}
+
+	@Override
+	public void run() {
+		ShareCdcTableMappingRepository shareCdcTableMappingRepository = SpringContextHelper.getBean(ShareCdcTableMappingRepository.class);
+		MongoTemplate mongoTemplate = shareCdcTableMappingRepository.getMongoOperations();
+
+		DataSourceRepository dataSourceRepository = SpringContextHelper.getBean(DataSourceRepository.class);
+
+		// Create Index
+		Index signIndex = new CompoundIndexDefinition(new Document("sign", 1)).unique().background();
+		logger.info("[{}] Create share cdc table mapping sign index: {}", TAG, signIndex);
+		mongoTemplate.indexOps(ShareCdcTableMappingEntity.class).ensureIndex(signIndex);
+		Index index = new CompoundIndexDefinition(new Document("connectionId", 1).append("tableName", 1).append("shareCdcTaskId", 1)).background();
+		logger.info("[{}] Create share cdc table mapping index: {}", TAG, index);
+		mongoTemplate.indexOps(ShareCdcTableMappingEntity.class).ensureIndex(index);
+
+		TaskRepository taskRepository = SpringContextHelper.getBean(TaskRepository.class);
+		Query taskQuery = new Query(Criteria.where("syncType").is(TaskDto.SYNC_TYPE_LOG_COLLECTOR).and("is_deleted").is(false));
+		taskQuery.fields().include("_id", "name", "dag");
+		List<TaskEntity> logCollectorTasks = taskRepository.findAll(taskQuery);
+		logger.info("[{}] Create share cdc table mapping for log collector tasks: {}", TAG, logCollectorTasks.size());
+		if (CollectionUtils.isNotEmpty(logCollectorTasks)) {
+			long startMS = System.currentTimeMillis();
+			int taskCounter = 0;
+			for (TaskEntity logCollectorTask : logCollectorTasks) {
+				DAG dag = logCollectorTask.getDag();
+				String taskId = logCollectorTask.getId().toHexString();
+				String taskName = logCollectorTask.getName();
+				if (null == dag) {
+					continue;
+				}
+				List<Node> nodes = dag.getNodes();
+				if (CollectionUtils.isEmpty(nodes)) {
+					continue;
+				}
+				Node foundNode = nodes.stream().filter(n -> n instanceof LogCollectorNode).findFirst().orElse(null);
+				if (null == foundNode) {
+					continue;
+				}
+				LogCollectorNode logCollectorNode = (LogCollectorNode) foundNode;
+				List<String> tableNames = logCollectorNode.getTableNames();
+				Map<String, LogCollecotrConnConfig> logCollectorConnConfigs = logCollectorNode.getLogCollectorConnConfigs();
+				Map<String, List<String>> connTableNames = new HashMap<>();
+				if (null != logCollectorConnConfigs) {
+					for (Map.Entry<String, LogCollecotrConnConfig> entry : logCollectorConnConfigs.entrySet()) {
+						String connectionId = entry.getKey();
+						LogCollecotrConnConfig logCollecotrConnConfig = entry.getValue();
+						List<String> connConfigTableNames = logCollecotrConnConfig.getTableNames();
+						connTableNames.put(connectionId, connConfigTableNames);
+					}
+				} else if (CollectionUtils.isNotEmpty(tableNames)) {
+					connTableNames.put(logCollectorNode.getConnectionIds().get(0), tableNames);
+				}
+				bulkUpsertShareCdcTableMapping(connTableNames, taskId, taskName, shareCdcTableMappingRepository, dataSourceRepository);
+				taskCounter++;
+				if (taskCounter % 10 == 0) {
+					logger.info("[{}] Create share cdc table mapping for log collector tasks: {}/{}", TAG, taskCounter, logCollectorTasks.size());
+				}
+			}
+			long costMS = System.currentTimeMillis() - startMS;
+			logger.info("[{}] Create share cdc table mapping finish, cost: {} ms", TAG, costMS);
+		}
+	}
+
+	private void bulkUpsertShareCdcTableMapping(Map<String, List<String>> connTableNames, String taskId, String taskName,
+												ShareCdcTableMappingRepository shareCdcTableMappingRepository,
+												DataSourceRepository dataSourceRepository) {
+		if (MapUtils.isEmpty(connTableNames)) {
+			return;
+		}
+		MongoTemplate mongoTemplate = shareCdcTableMappingRepository.getMongoOperations();
+		BulkOperations bulkOperations = mongoTemplate.bulkOps(BulkOperations.BulkMode.UNORDERED, ShareCdcTableMappingEntity.class);
+		List<Pair<Query, Update>> queryUpdateList = new ArrayList<>();
+		for (Map.Entry<String, List<String>> entry : connTableNames.entrySet()) {
+			String connId = entry.getKey();
+			List<String> tableNames = entry.getValue();
+			if (logger.isDebugEnabled()) {
+				logger.debug("[{}] Create share cdc table mapping for log collector task: {}({}), connection id: {}, table names: {}", TAG, taskName, taskId, connId, tableNames);
+			}
+			String connNamespaceStr = dataSourceRepository.findById(connId)
+					.map(DataSourceEntity::getNamespace)
+					.map(ns -> String.join(".", ns)).orElse(null);
+			for (String tableName : tableNames) {
+				ShareCdcTableMappingEntity shareCdcTableMappingEntity = new ShareCdcTableMappingEntity();
+				shareCdcTableMappingEntity.setExternalStorageTableName(ShareCdcTableMappingService.SHARE_CDC_KEY_PREFIX + taskName + "_" + String.join(".", connNamespaceStr, tableName));
+				shareCdcTableMappingEntity.setVersion("v1");
+				shareCdcTableMappingEntity.setShareCdcTaskId(taskId);
+				shareCdcTableMappingEntity.setTableName(tableName);
+				shareCdcTableMappingEntity.setConnectionId(connId);
+				shareCdcTableMappingEntity.setSign(shareCdcTableMappingEntity.genSign());
+				Query query = new Query(Criteria.where("sign").is(shareCdcTableMappingEntity.getSign()));
+				Update update = shareCdcTableMappingRepository.buildUpdateSet(shareCdcTableMappingEntity);
+				queryUpdateList.add(Pair.of(query, update));
+				if (queryUpdateList.size() >= 1000) {
+					bulkOperations.upsert(queryUpdateList);
+					bulkOperations.execute();
+					queryUpdateList.clear();
+					bulkOperations = mongoTemplate.bulkOps(BulkOperations.BulkMode.UNORDERED, ShareCdcTableMappingEntity.class);
+				}
+			}
+		}
+		if (CollectionUtils.isNotEmpty(queryUpdateList)) {
+			bulkOperations.upsert(queryUpdateList);
+			bulkOperations.execute();
+		}
+	}
+}

--- a/manager/tm/src/main/java/com/tapdata/tm/shareCdcTableMapping/controller/ShareCdcTableMappingController.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/shareCdcTableMapping/controller/ShareCdcTableMappingController.java
@@ -1,0 +1,239 @@
+package com.tapdata.tm.shareCdcTableMapping.controller;
+
+import com.tapdata.tm.base.controller.BaseController;
+import com.tapdata.tm.base.dto.*;
+import com.tapdata.tm.shareCdcTableMapping.ShareCdcTableMappingDto;
+import com.tapdata.tm.shareCdcTableMapping.service.ShareCdcTableMappingService;
+import com.tapdata.tm.utils.MongoUtils;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+
+/**
+ * @Date: 2023/10/16
+ * @Description:
+ */
+@Tag(name = "ShareCdcTableMapping", description = "shareCdcTableMapping相关接口")
+@RestController
+@RequestMapping("/api/ShareCdcTableMapping")
+public class ShareCdcTableMappingController extends BaseController {
+
+    @Autowired
+    private ShareCdcTableMappingService shareCdcTableMappingService;
+
+    /**
+     * Create a new instance of the model and persist it into the data source
+     * @param shareCdcTableMapping
+     * @return
+     */
+    @Operation(summary = "Create a new instance of the model and persist it into the data source")
+    @PostMapping
+    public ResponseMessage<ShareCdcTableMappingDto> save(@RequestBody ShareCdcTableMappingDto shareCdcTableMapping) {
+        shareCdcTableMapping.setId(null);
+        return success(shareCdcTableMappingService.save(shareCdcTableMapping, getLoginUser()));
+    }
+
+    /**
+     *  Patch an existing model instance or insert a new one into the data source
+     * @param shareCdcTableMapping
+     * @return
+     */
+    @Operation(summary = "Patch an existing model instance or insert a new one into the data source")
+    @PatchMapping()
+    public ResponseMessage<ShareCdcTableMappingDto> update(@RequestBody ShareCdcTableMappingDto shareCdcTableMapping) {
+        return success(shareCdcTableMappingService.save(shareCdcTableMapping, getLoginUser()));
+    }
+
+
+    /**
+     * Find all instances of the model matched by filter from the data source
+     * @param filterJson
+     * @return
+     */
+    @Operation(summary = "Find all instances of the model matched by filter from the data source")
+    @GetMapping
+    public ResponseMessage<Page<ShareCdcTableMappingDto>> find(
+            @Parameter(in = ParameterIn.QUERY,
+                    description = "Filter defining fields, where, sort, skip, and limit - must be a JSON-encoded string (`{\"where\":{\"something\":\"value\"},\"fields\":{\"something\":true|false},\"sort\": [\"name desc\"],\"page\":1,\"size\":20}`)."
+            )
+            @RequestParam(value = "filter", required = false) String filterJson) {
+        Filter filter = parseFilter(filterJson);
+        if (filter == null) {
+            filter = new Filter();
+        }
+        return success(shareCdcTableMappingService.find(filter, getLoginUser()));
+    }
+
+    /**
+     *  Replace an existing model instance or insert a new one into the data source
+     * @param shareCdcTableMapping
+     * @return
+     */
+    @Operation(summary = "Replace an existing model instance or insert a new one into the data source")
+    @PutMapping
+    public ResponseMessage<ShareCdcTableMappingDto> put(@RequestBody ShareCdcTableMappingDto shareCdcTableMapping) {
+        return success(shareCdcTableMappingService.replaceOrInsert(shareCdcTableMapping, getLoginUser()));
+    }
+
+
+    /**
+     * Check whether a model instance exists in the data source
+     * @return
+     */
+    @Operation(summary = "Check whether a model instance exists in the data source")
+    @RequestMapping(value = "{id}", method = RequestMethod.HEAD)
+    public ResponseMessage<HashMap<String, Boolean>> checkById(@PathVariable("id") String id) {
+        long count = shareCdcTableMappingService.count(Where.where("_id", MongoUtils.toObjectId(id)), getLoginUser());
+        HashMap<String, Boolean> existsValue = new HashMap<>();
+        existsValue.put("exists", count > 0);
+        return success(existsValue);
+    }
+
+    /**
+     *  Patch attributes for a model instance and persist it into the data source
+     * @param shareCdcTableMapping
+     * @return
+     */
+    @Operation(summary = "Patch attributes for a model instance and persist it into the data source")
+    @PatchMapping("{id}")
+    public ResponseMessage<ShareCdcTableMappingDto> updateById(@PathVariable("id") String id, @RequestBody ShareCdcTableMappingDto shareCdcTableMapping) {
+        shareCdcTableMapping.setId(MongoUtils.toObjectId(id));
+        return success(shareCdcTableMappingService.save(shareCdcTableMapping, getLoginUser()));
+    }
+
+
+    /**
+     * Find a model instance by {{id}} from the data source
+     * @param fieldsJson
+     * @return
+     */
+    @Operation(summary = "Find a model instance by {{id}} from the data source")
+    @GetMapping("{id}")
+    public ResponseMessage<ShareCdcTableMappingDto> findById(@PathVariable("id") String id,
+            @RequestParam(value = "fields", required = false) String fieldsJson) {
+        Field fields = parseField(fieldsJson);
+        return success(shareCdcTableMappingService.findById(MongoUtils.toObjectId(id),  fields, getLoginUser()));
+    }
+
+    /**
+     *  Replace attributes for a model instance and persist it into the data source.
+     * @param shareCdcTableMapping
+     * @return
+     */
+    @Operation(summary = "Replace attributes for a model instance and persist it into the data source.")
+    @PutMapping("{id}")
+    public ResponseMessage<ShareCdcTableMappingDto> replceById(@PathVariable("id") String id, @RequestBody ShareCdcTableMappingDto shareCdcTableMapping) {
+        return success(shareCdcTableMappingService.replaceById(MongoUtils.toObjectId(id), shareCdcTableMapping, getLoginUser()));
+    }
+
+    /**
+     *  Replace attributes for a model instance and persist it into the data source.
+     * @param shareCdcTableMapping
+     * @return
+     */
+    @Operation(summary = "Replace attributes for a model instance and persist it into the data source.")
+    @PostMapping("{id}/replace")
+    public ResponseMessage<ShareCdcTableMappingDto> replaceById2(@PathVariable("id") String id, @RequestBody ShareCdcTableMappingDto shareCdcTableMapping) {
+        return success(shareCdcTableMappingService.replaceById(MongoUtils.toObjectId(id), shareCdcTableMapping, getLoginUser()));
+    }
+
+
+
+    /**
+     * Delete a model instance by {{id}} from the data source
+     * @param id
+     * @return
+     */
+    @Operation(summary = "Delete a model instance by {{id}} from the data source")
+    @DeleteMapping("{id}")
+    public ResponseMessage<Void> delete(@PathVariable("id") String id) {
+        shareCdcTableMappingService.deleteById(MongoUtils.toObjectId(id), getLoginUser());
+        return success();
+    }
+
+    /**
+     *  Check whether a model instance exists in the data source
+     * @param id
+     * @return
+     */
+    @Operation(summary = "Check whether a model instance exists in the data source")
+    @GetMapping("{id}/exists")
+    public ResponseMessage<HashMap<String, Boolean>> checkById1(@PathVariable("id") String id) {
+        long count = shareCdcTableMappingService.count(Where.where("_id", MongoUtils.toObjectId(id)), getLoginUser());
+        HashMap<String, Boolean> existsValue = new HashMap<>();
+        existsValue.put("exists", count > 0);
+        return success(existsValue);
+    }
+
+    /**
+     *  Count instances of the model matched by where from the data source
+     * @param whereJson
+     * @return
+     */
+    @Operation(summary = "Count instances of the model matched by where from the data source")
+    @GetMapping("count")
+    public ResponseMessage<HashMap<String, Long>> count(@RequestParam("where") String whereJson) {
+        Where where = parseWhere(whereJson);
+        if (where == null) {
+            where = new Where();
+        }
+        long count = shareCdcTableMappingService.count(where, getLoginUser());
+        HashMap<String, Long> countValue = new HashMap<>();
+        countValue.put("count", count);
+        return success(countValue);
+    }
+
+    /**
+     *  Find first instance of the model matched by filter from the data source.
+     * @param filterJson
+     * @return
+     */
+    @Operation(summary = "Find first instance of the model matched by filter from the data source.")
+    @GetMapping("findOne")
+    public ResponseMessage<ShareCdcTableMappingDto> findOne(
+            @Parameter(in = ParameterIn.QUERY,
+                    description = "Filter defining fields, where, sort, skip, and limit - must be a JSON-encoded string (`{\"where\":{\"something\":\"value\"},\"field\":{\"something\":true|false},\"sort\": [\"name desc\"],\"page\":1,\"size\":20}`)."
+            )
+            @RequestParam(value = "filter", required = false) String filterJson) {
+        Filter filter = parseFilter(filterJson);
+        if (filter == null) {
+            filter = new Filter();
+        }
+        return success(shareCdcTableMappingService.findOne(filter, getLoginUser()));
+    }
+
+    /**
+     *  Update instances of the model matched by {{where}} from the data source.
+     * @param whereJson
+     * @return
+     */
+    @Operation(summary = "Update instances of the model matched by {{where}} from the data source")
+    @PostMapping("update")
+    public ResponseMessage<Map<String, Long>> updateByWhere(@RequestParam("where") String whereJson, @RequestBody ShareCdcTableMappingDto shareCdcTableMapping) {
+        Where where = parseWhere(whereJson);
+        long count = shareCdcTableMappingService.updateByWhere(where, shareCdcTableMapping, getLoginUser());
+        HashMap<String, Long> countValue = new HashMap<>();
+        countValue.put("count", count);
+        return success(countValue);
+    }
+
+    /**
+     *  Update an existing model instance or insert a new one into the data source based on the where criteria.
+     * @param whereJson
+     * @return
+     */
+    @Operation(summary = "Update an existing model instance or insert a new one into the data source based on the where criteria.")
+    @PostMapping("upsertWithWhere")
+    public ResponseMessage<ShareCdcTableMappingDto> upsertByWhere(@RequestParam("where") String whereJson, @RequestBody ShareCdcTableMappingDto shareCdcTableMapping) {
+        Where where = parseWhere(whereJson);
+        return success(shareCdcTableMappingService.upsertByWhere(where, shareCdcTableMapping, getLoginUser()));
+    }
+
+}

--- a/manager/tm/src/main/java/com/tapdata/tm/shareCdcTableMapping/entity/ShareCdcTableMappingEntity.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/shareCdcTableMapping/entity/ShareCdcTableMappingEntity.java
@@ -1,0 +1,31 @@
+package com.tapdata.tm.shareCdcTableMapping.entity;
+
+import com.tapdata.tm.base.entity.BaseEntity;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+
+/**
+ * shareCdcTableMapping
+ */
+@EqualsAndHashCode(callSuper = true)
+@Data
+@Document("ShareCdcTableMapping")
+public class ShareCdcTableMappingEntity extends BaseEntity {
+	private String sign;
+	private String version;
+	private String tableName;
+	private String externalStorageTableName;
+	private String shareCdcTaskId;
+	private String connectionId;
+
+	public String genSign() {
+		if (StringUtils.isBlank(shareCdcTaskId))
+			throw new IllegalArgumentException("Share cdc task id cannot be blank");
+		if (StringUtils.isBlank(connectionId)) throw new IllegalArgumentException("Connection id cannot be blank");
+		if (StringUtils.isBlank(tableName)) throw new IllegalArgumentException("Table name cannot be blank");
+		return String.join("_", shareCdcTaskId, connectionId, tableName);
+	}
+}

--- a/manager/tm/src/main/java/com/tapdata/tm/shareCdcTableMapping/repository/ShareCdcTableMappingRepository.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/shareCdcTableMapping/repository/ShareCdcTableMappingRepository.java
@@ -1,0 +1,24 @@
+package com.tapdata.tm.shareCdcTableMapping.repository;
+
+import com.tapdata.tm.base.reporitory.BaseRepository;
+import com.tapdata.tm.shareCdcTableMapping.entity.ShareCdcTableMappingEntity;
+import org.bson.types.ObjectId;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.stereotype.Repository;
+
+/**
+ * @Author:
+ * @Date: 2023/10/16
+ * @Description:
+ */
+@Repository
+public class ShareCdcTableMappingRepository extends BaseRepository<ShareCdcTableMappingEntity, ObjectId> {
+    public ShareCdcTableMappingRepository(MongoTemplate mongoOperations) {
+        super(ShareCdcTableMappingEntity.class, mongoOperations);
+    }
+
+    @Override
+    protected void init() {
+        super.init();
+    }
+}

--- a/manager/tm/src/main/java/com/tapdata/tm/shareCdcTableMapping/service/ShareCdcTableMappingService.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/shareCdcTableMapping/service/ShareCdcTableMappingService.java
@@ -1,0 +1,149 @@
+package com.tapdata.tm.shareCdcTableMapping.service;
+
+import com.tapdata.tm.base.service.BaseService;
+import com.tapdata.tm.commons.dag.DAG;
+import com.tapdata.tm.commons.dag.Node;
+import com.tapdata.tm.commons.dag.logCollector.LogCollecotrConnConfig;
+import com.tapdata.tm.commons.dag.logCollector.LogCollectorNode;
+import com.tapdata.tm.commons.schema.DataSourceConnectionDto;
+import com.tapdata.tm.commons.task.dto.TaskDto;
+import com.tapdata.tm.config.security.UserDetail;
+import com.tapdata.tm.ds.service.impl.DataSourceService;
+import com.tapdata.tm.shareCdcTableMapping.ShareCdcTableMappingDto;
+import com.tapdata.tm.shareCdcTableMapping.entity.ShareCdcTableMappingEntity;
+import com.tapdata.tm.shareCdcTableMapping.repository.ShareCdcTableMappingRepository;
+import com.tapdata.tm.task.service.TaskService;
+import lombok.NonNull;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.MapUtils;
+import org.bson.types.ObjectId;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.mongodb.core.BulkOperations;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+
+/**
+ * @Author:
+ * @Date: 2023/10/16
+ * @Description:
+ */
+@Service
+@Slf4j
+@Setter(onMethod_ = {@Autowired})
+public class ShareCdcTableMappingService extends BaseService<ShareCdcTableMappingDto, ShareCdcTableMappingEntity, ObjectId, ShareCdcTableMappingRepository> {
+
+	public final static String SHARE_CDC_KEY_PREFIX = "ExternalStorage_SHARE_CDC_";
+
+	private TaskService taskService;
+	private DataSourceService dataSourceService;
+
+	public ShareCdcTableMappingService(@NonNull ShareCdcTableMappingRepository repository) {
+		super(repository, ShareCdcTableMappingDto.class, ShareCdcTableMappingEntity.class);
+	}
+
+	protected void beforeSave(ShareCdcTableMappingDto shareCdcTableMapping, UserDetail user) {
+
+	}
+
+	public void genShareCdcTableMappingsByLogCollectorTask(TaskDto logCollectorTask, boolean newTask) {
+		if (null == logCollectorTask) return;
+		DAG dag = logCollectorTask.getDag();
+		if (null == dag) return;
+		TaskDto existsLogCollectorTask = null;
+		if (!newTask) {
+			existsLogCollectorTask = taskService.findByTaskId(logCollectorTask.getId(), "dag");
+		}
+		Map<String, List<String>> connId2TableNames = getConnId2TableNames(logCollectorTask);
+		if (MapUtils.isEmpty(connId2TableNames)) return;
+		Map<String, List<String>> existsConnId2TableNames = getConnId2TableNames(existsLogCollectorTask);
+		List<ShareCdcTableMappingEntity> wait2SaveShareCdcTableMappingEntities = new ArrayList<>();
+		BulkOperations bulkOperations = repository.bulkOperations(BulkOperations.BulkMode.UNORDERED);
+		for (Map.Entry<String, List<String>> entry : connId2TableNames.entrySet()) {
+			String connId = entry.getKey();
+			List<String> tableNames = entry.getValue();
+			List<String> existsTableNames = existsConnId2TableNames.get(connId);
+			List<String> addedTableNames = new ArrayList<>(tableNames);
+			if (CollectionUtils.isNotEmpty(existsTableNames)) {
+				addedTableNames.removeAll(existsTableNames);
+			}
+			if (CollectionUtils.isEmpty(addedTableNames)) {
+				continue;
+			}
+			String connNamespaceStr = Optional.ofNullable(dataSourceService.findById(new ObjectId(connId)))
+					.map(DataSourceConnectionDto::getNamespace)
+					.map(ns -> String.join(".", ns)).orElse(null);
+			for (String addedTableName : addedTableNames) {
+				ShareCdcTableMappingEntity shareCdcTableMappingEntity = new ShareCdcTableMappingEntity();
+				shareCdcTableMappingEntity.setConnectionId(connId);
+				shareCdcTableMappingEntity.setTableName(addedTableName);
+				shareCdcTableMappingEntity.setShareCdcTaskId(logCollectorTask.getId().toHexString());
+				shareCdcTableMappingEntity.setSign(shareCdcTableMappingEntity.genSign());
+				Query query = Query.query(Criteria.where("sign").is(shareCdcTableMappingEntity.getSign()));
+				Optional<ShareCdcTableMappingEntity> existsTableMapping = repository.findOne(query);
+				if (existsTableMapping.isPresent()) {
+					continue;
+				}
+				shareCdcTableMappingEntity.setVersion(ShareCdcTableMappingDto.VERSION_V2);
+				shareCdcTableMappingEntity.setExternalStorageTableName(genExternalStorageTableName(logCollectorTask.getId().toHexString(), connId, connNamespaceStr, addedTableName));
+				wait2SaveShareCdcTableMappingEntities.add(shareCdcTableMappingEntity);
+			}
+			if (wait2SaveShareCdcTableMappingEntities.size() >= 1000) {
+				bulkUpsert(wait2SaveShareCdcTableMappingEntities, bulkOperations);
+				bulkOperations = repository.bulkOperations(BulkOperations.BulkMode.UNORDERED);
+				wait2SaveShareCdcTableMappingEntities.clear();
+			}
+		}
+		if (CollectionUtils.isNotEmpty(wait2SaveShareCdcTableMappingEntities)) {
+			bulkUpsert(wait2SaveShareCdcTableMappingEntities, bulkOperations);
+		}
+	}
+
+	private static String genExternalStorageTableName(String taskId, String connId, String connNamespaceStr, String tableName) {
+		String name = SHARE_CDC_KEY_PREFIX;
+		if (null != connNamespaceStr) {
+			name += String.join("_", taskId, connId, String.join(".", connNamespaceStr, tableName)).hashCode();
+		} else {
+			name += String.join("_", taskId, connId, tableName).hashCode();
+		}
+		return name;
+	}
+
+	private void bulkUpsert(List<ShareCdcTableMappingEntity> wait2SaveShareCdcTableMappingEntities, BulkOperations bulkOperations) {
+		for (ShareCdcTableMappingEntity wait2SaveShareCdcTableMappingEntity : wait2SaveShareCdcTableMappingEntities) {
+			Query query = Query.query(Criteria.where("sign").is(wait2SaveShareCdcTableMappingEntity.getSign()));
+			Update update = repository.buildUpdateSet(wait2SaveShareCdcTableMappingEntity);
+			bulkOperations.upsert(query, update);
+		}
+		bulkOperations.execute();
+	}
+
+	public Map<String, List<String>> getConnId2TableNames(TaskDto taskDto) {
+		Map<String, List<String>> connId2TableNames = new HashMap<>();
+		if (null == taskDto) return connId2TableNames;
+		DAG dag = taskDto.getDag();
+		if (null == dag) return connId2TableNames;
+		Node foundNode = dag.getNodes().stream().filter(n -> n instanceof LogCollectorNode).findFirst().orElse(null);
+		if (null == foundNode) return connId2TableNames;
+		LogCollectorNode logCollectorNode = (LogCollectorNode) foundNode;
+		Map<String, LogCollecotrConnConfig> logCollectorConnConfigs = logCollectorNode.getLogCollectorConnConfigs();
+		if (MapUtils.isNotEmpty(logCollectorConnConfigs)) {
+			for (Map.Entry<String, LogCollecotrConnConfig> entry : logCollectorConnConfigs.entrySet()) {
+				String connId = entry.getKey();
+				LogCollecotrConnConfig logCollecotrConnConfig = entry.getValue();
+				List<String> tableNames = logCollecotrConnConfig.getTableNames();
+				connId2TableNames.put(connId, tableNames);
+			}
+		} else {
+			List<String> tableNames = logCollectorNode.getTableNames();
+			String connId = logCollectorNode.getConnectionIds().get(0);
+			connId2TableNames.put(connId, tableNames);
+		}
+		return connId2TableNames;
+	}
+}

--- a/manager/tm/src/main/java/com/tapdata/tm/task/bean/ShareCdcTableInfo.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/task/bean/ShareCdcTableInfo.java
@@ -21,4 +21,6 @@ public class ShareCdcTableInfo {
     private Long allCount;
     /** 进入挖掘日志条数*/
     private Long todayCount;
+    /** 实际的外存表名 */
+    private String externalStorageTableName;
 }

--- a/manager/tm/src/main/java/com/tapdata/tm/task/service/LogCollectorService.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/task/service/LogCollectorService.java
@@ -38,6 +38,8 @@ import com.tapdata.tm.externalStorage.vo.ExternalStorageVo;
 import com.tapdata.tm.message.constant.Level;
 import com.tapdata.tm.metadatainstance.service.MetadataInstancesService;
 import com.tapdata.tm.monitoringlogs.service.MonitoringLogsService;
+import com.tapdata.tm.shareCdcTableMapping.ShareCdcTableMappingDto;
+import com.tapdata.tm.shareCdcTableMapping.service.ShareCdcTableMappingService;
 import com.tapdata.tm.shareCdcTableMetrics.ShareCdcTableMetricsDto;
 import com.tapdata.tm.shareCdcTableMetrics.service.ShareCdcTableMetricsService;
 import com.tapdata.tm.task.bean.*;
@@ -61,7 +63,6 @@ import org.bson.types.ObjectId;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.aggregation.Aggregation;
 import org.springframework.data.mongodb.core.aggregation.MatchOperation;
@@ -99,6 +100,7 @@ public class LogCollectorService {
     private ShareCdcTableMetricsService shareCdcTableMetricsService;
     private UserService userService;
     private TaskSaveService taskSaveService;
+    private ShareCdcTableMappingService shareCdcTableMappingService;
 
     private final List<String> syncTimePoints = Lists.newArrayList("current", "localTZ", "connTZ");;
 
@@ -1058,6 +1060,7 @@ public class LogCollectorService {
             taskSaveService.supplementAlarm(taskDto, user);
             taskDto = taskService.create(taskDto, user);
             taskDto = taskService.confirmById(taskDto, user, true);
+			shareCdcTableMappingService.genShareCdcTableMappingsByLogCollectorTask(taskDto, true);
 
             //保存新增挖掘任务id到子任务中
             for (String id : ids) {
@@ -1129,6 +1132,7 @@ public class LogCollectorService {
         if (logCollectorNode.getLogCollectorConnConfigs() == null || logCollectorNode.getLogCollectorConnConfigs().size() != 0) {
             logCollectorNode.setTableNames(new ArrayList<>(finalTableNames));
         }
+		shareCdcTableMappingService.genShareCdcTableMappingsByLogCollectorTask(oldLogCollectorTask, false);
         taskService.updateById(oldLogCollectorTask, user);
         updateLogCollectorMap(oldTaskDto.getId(), newLogCollectorMap, user);
 
@@ -1207,6 +1211,7 @@ public class LogCollectorService {
 					exclusionTables.removeIf(collect::contains);
 				}
 				logCollectorNode.setTableNames(collect);
+                shareCdcTableMappingService.genShareCdcTableMappingsByLogCollectorTask(oldLogCollectorTask, false);
         taskService.updateById(oldLogCollectorTask, user);
         updateLogCollectorMap(oldTaskDto.getId(), newLogCollectorMap, user);
 
@@ -1655,6 +1660,9 @@ public class LogCollectorService {
 					shareCdcTableInfo.setJoinTime(metricsDto.getStartCdcTime());
 					shareCdcTableInfo.setTodayCount(metricsDto.getCount());
 					shareCdcTableInfo.setAllCount(metricsDto.getAllCount());
+                    ShareCdcTableMappingDto shareCdcTableMappingDto = shareCdcTableMappingService.findOne(Query.query(Criteria.where("sign")
+                            .is(ShareCdcTableMappingDto.genSign(taskId, shareCdcTableInfo.getConnectionId(), shareCdcTableInfo.getName()))));
+					shareCdcTableInfo.setExternalStorageTableName(shareCdcTableMappingDto.getExternalStorageTableName());
 				}
 		}
 


### PR DESCRIPTION
1. [HA] 数据源名字过长, 导致共享挖掘任务报错]
2. 共享挖掘增加内存监控 