### PR TITLE
LDP创建任务时TM端对源是否支持增量的判断逻辑有问题

### DIFF
--- a/manager/tm/src/main/java/com/tapdata/tm/task/service/impl/LdpServiceImpl.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/task/service/impl/LdpServiceImpl.java
@@ -249,23 +249,7 @@ public class LdpServiceImpl implements LdpService {
 
         boolean streamRead = true;
         boolean batchRead = true;
-        /*ResponseBody responseBody = connection.getResponse_body();
-        if (responseBody != null) {
-            List<ValidateDetail> validateDetails = responseBody.getValidateDetails();
-            Map<String, ValidateDetail> map = new HashMap<>();
-            if (org.apache.commons.collections.CollectionUtils.isNotEmpty(validateDetails)) {
-                // list to map
-                map = validateDetails.stream().collect(Collectors.toMap(ValidateDetail::getShowMsg, Function.identity()));
-            }
-            if (!map.containsKey(TestItem.ITEM_READ_LOG) || !"passed".equals(map.get(TestItem.ITEM_READ_LOG).getStatus())) {
-                streamRead = false;
-            }
 
-            if (!map.containsKey(TestItem.ITEM_READ) || !"passed".equals(map.get(TestItem.ITEM_READ).getStatus())) {
-                batchRead = false;
-            }
-
-        }*/
         Set<String> capabilityIds = capabilities.stream().map(Capability::getId).collect(Collectors.toSet());
         if (!capabilityIds.contains(CapabilityEnum.STREAM_READ_FUNCTION.name().toLowerCase())) {
             streamRead = false;

--- a/manager/tm/src/main/java/com/tapdata/tm/task/service/impl/LdpServiceImpl.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/task/service/impl/LdpServiceImpl.java
@@ -249,7 +249,7 @@ public class LdpServiceImpl implements LdpService {
 
         boolean streamRead = true;
         boolean batchRead = true;
-        ResponseBody responseBody = connection.getResponse_body();
+        /*ResponseBody responseBody = connection.getResponse_body();
         if (responseBody != null) {
             List<ValidateDetail> validateDetails = responseBody.getValidateDetails();
             Map<String, ValidateDetail> map = new HashMap<>();
@@ -265,7 +265,7 @@ public class LdpServiceImpl implements LdpService {
                 batchRead = false;
             }
 
-        }
+        }*/
         Set<String> capabilityIds = capabilities.stream().map(Capability::getId).collect(Collectors.toSet());
         if (!capabilityIds.contains(CapabilityEnum.STREAM_READ_FUNCTION.name().toLowerCase())) {
             streamRead = false;


### PR DESCRIPTION
LDP 创建任务这里TM端有点问题，判断任务类型的时候判断了连接有没有测试Read log，这样连接没有这个测试项目，就算有stream_read_function增量能力也会提示不支持，比如dummy，其他saas数据源也有过这个问题