### PR TITLE
fix(TM): #149040   After the user specified the engine to start, the current maximum number of startup tasks was not set, resulting in task startup failure 

### DIFF
--- a/manager/tm/src/main/java/com/tapdata/tm/worker/service/WorkerService.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/worker/service/WorkerService.java
@@ -395,6 +395,7 @@ public class WorkerService extends BaseService<WorkerDto, Worker, ObjectId, Work
                 calculationEngineVo.setAvailable(availableNum);
                 calculationEngineVo.setTaskLimit(taskLimit);
                 calculationEngineVo.setRunningNum(runningNum);
+                calculationEngineVo.setTotalLimit(taskLimit);
                 return calculationEngineVo;
             }
         }


### PR DESCRIPTION
…urrent maximum number of startup tasks was not set, resulting in task startup failure.