### PR TITLE
Fix optimize ci

### DIFF
--- a/.github/workflows/mr-ci.yaml
+++ b/.github/workflows/mr-ci.yaml
@@ -161,6 +161,8 @@ jobs:
 
   MRCI:
     runs-on: aws-ubuntu-20
+    concurrency:
+      group: staging_environment
     timeout-minutes: 60
     needs:
       - Build-And-Deploy

--- a/.github/workflows/mr-ci.yaml
+++ b/.github/workflows/mr-ci.yaml
@@ -68,7 +68,7 @@ jobs:
           echo "::set-output name=TAG_NAME::${TAG_NAME}"
 
   Scan-Tapdata:
-    runs-on: aws-ubuntu-20
+    runs-on: aws-scan
     needs: Get-Stable-Branch
     timeout-minutes: 30
     steps:

--- a/.github/workflows/mr-ci.yaml
+++ b/.github/workflows/mr-ci.yaml
@@ -1,5 +1,8 @@
 name: Merge Request CI
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 on:
   push:
     branches: [ "main", "develop", "release-v*.*" ]

--- a/.github/workflows/mr-ci.yaml
+++ b/.github/workflows/mr-ci.yaml
@@ -4,8 +4,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
 
 on:
-  push:
-    branches: [ "main", "develop", "release-v*.*" ]
   pull_request:
     branches: [ "main", "develop", "release-v*.*" ]
 


### PR DESCRIPTION
1. 增加并发控制，同分支下重复触发，老的流程将被Cancel
2. 将Scan-Tapdata的Runner单独分类，方便拓展，保持MRCI所属的Runner始终为1个（TestSigma无法并发）