### PR TITLE
fix: Fixed HazelcastSourcePdkBaseNodeTest.DoAsyncTableCountMethodTest…

### DIFF
--- a/iengine/iengine-app/src/test/java/io/tapdata/flow/engine/V2/node/hazelcast/data/pdk/HazelcastSourcePdkBaseNodeTest.java
+++ b/iengine/iengine-app/src/test/java/io/tapdata/flow/engine/V2/node/hazelcast/data/pdk/HazelcastSourcePdkBaseNodeTest.java
@@ -21,16 +21,11 @@ import io.tapdata.pdk.core.async.ThreadPoolExecutorEx;
 import io.tapdata.schema.TapTableMap;
 import lombok.SneakyThrows;
 import org.bson.types.ObjectId;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import java.lang.reflect.Method;
-import java.util.LinkedHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -228,8 +223,10 @@ class HazelcastSourcePdkBaseNodeTest extends BaseHazelcastNodeTest {
 
 			// test thread exception if not running
 			assertDoesNotThrow(() -> {
+                // the isRunning method Return true on the first call and false on the second call
+                // Ensure that the exception 'isRunning' returns false, please!
+                when(mockInstance.isRunning()).thenReturn(true, false);
 				try (AutoCloseable autoCloseable = mockInstance.doAsyncTableCount(mockBatchCountFunction.get(), testTableName)) {
-					when(mockInstance.isRunning()).thenReturn(false);
 				}
 			});
 		}


### PR DESCRIPTION
….testThrowException test case error.

Unexpected exception thrown: org.mockito.exceptions.misusing.WrongTypeOfReturnValue: Boolean cannot be returned by getDataProcessorContext() getDataProcessorContext() should return DataProcessorContext