### PR TITLE
v3.5.11 - fix for css

### DIFF
--- a/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/node/hazelcast/data/pdk/HazelcastTargetPdkBaseNode.java
+++ b/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/node/hazelcast/data/pdk/HazelcastTargetPdkBaseNode.java
@@ -621,7 +621,9 @@ public abstract class HazelcastTargetPdkBaseNode extends HazelcastPdkBaseNode {
 						transactionCommit();
 					}
 				} catch (Exception e) {
-					transactionRollback();
+					if (checkExactlyOnceWriteEnableResult.getEnable() && hasExactlyOnceWriteCache) {
+						transactionRollback();
+					}
 					throw e;
 				}
 				flushOffsetByTapdataEventForNoConcurrent(lastTapdataEvent);


### PR DESCRIPTION
fix(iengine): When there is an exception during the data write, the transactionRollBack method is mistakenly called, resulting in the loss of the original exception