### PR TITLE
fix(iengine): T-2.6: mdb to mdb, preimage + batch update, performance test

### DIFF
--- a/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/node/hazelcast/data/pdk/concurrent/PartitionConcurrentProcessor.java
+++ b/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/node/hazelcast/data/pdk/concurrent/PartitionConcurrentProcessor.java
@@ -279,8 +279,7 @@ public class PartitionConcurrentProcessor {
 			if (toSingleMode(tapEvent, partitionValue, singleMode)) {
 				partition = 0;
 			} else {
-				final List<Object> partitionOriginalValues = keySelector.convert2OriginValue(partitionValue);
-				final PartitionResult<TapdataEvent> partitionResult = partitioner.partition(partitionSize, tapdataEvent, partitionOriginalValues);
+				final PartitionResult<TapdataEvent> partitionResult = partitioner.partition(partitionSize, tapdataEvent, partitionValue);
 				partition = partitionResult.getPartition() < 0 ? DEFAULT_PARTITION : partitionResult.getPartition();
 			}
 

--- a/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/node/hazelcast/data/pdk/concurrent/selector/TapEventPartitionKeySelector.java
+++ b/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/node/hazelcast/data/pdk/concurrent/selector/TapEventPartitionKeySelector.java
@@ -35,6 +35,9 @@ public class TapEventPartitionKeySelector implements PartitionKeySelector<TapEve
 			getPartitionValue(partitionValue, keys, row);
 		}
 
+		if (null != partitionValue && !CollectionUtils.isEmpty(partitionValue)) {
+			partitionValue = convert2OriginValue(partitionValue);
+		}
 		return partitionValue;
 	}
 

--- a/iengine/iengine-app/src/test/java/io/tapdata/flow/engine/V2/node/hazelcast/data/pdk/concurrent/selector/TapEventPartitionKeySelectorTest.java
+++ b/iengine/iengine-app/src/test/java/io/tapdata/flow/engine/V2/node/hazelcast/data/pdk/concurrent/selector/TapEventPartitionKeySelectorTest.java
@@ -1,0 +1,61 @@
+package io.tapdata.flow.engine.V2.node.hazelcast.data.pdk.concurrent.selector;
+
+import io.tapdata.entity.event.dml.TapUpdateRecordEvent;
+import io.tapdata.entity.schema.type.TapString;
+import io.tapdata.entity.schema.value.TapStringValue;
+import io.tapdata.entity.schema.value.TapValue;
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * @author samuel
+ * @Description
+ * @create 2024-04-28 18:32
+ **/
+@DisplayName("Class TapEventPartitionKeySelector Test")
+class TapEventPartitionKeySelectorTest {
+	@Nested
+	@DisplayName("Method select Test")
+	class selectTest {
+		@Test
+		@DisplayName("test main process")
+		void testMainProcess() {
+			TapEventPartitionKeySelector keySelector = new TapEventPartitionKeySelector(tapEvent -> {
+				List<String> list = new ArrayList<>();
+				list.add("_id");
+				return list;
+			});
+
+			ObjectId oid = new ObjectId();
+			TapValue<String, TapString> _idTapStringValue = new TapStringValue(oid.toHexString())
+					.originValue(oid)
+					.tapType(new TapString());
+
+			Map<String, Object> before = new HashMap<>();
+			before.put("_id", _idTapStringValue);
+			before.put("name", "test");
+
+			Map<String, Object> after = new HashMap<>();
+			after.put("_id", _idTapStringValue);
+			after.put("name", "test1");
+
+			TapUpdateRecordEvent tapEvent = TapUpdateRecordEvent.create().init()
+					.before(before)
+					.after(after);
+
+			List<Object> result = keySelector.select(tapEvent, after);
+
+			assertEquals(1, result.size());
+			assertEquals(oid.toHexString(), result.get(0));
+		}
+	}
+}


### PR DESCRIPTION
Conditions must be met to trigger:
1. Turn on the incremental concurrent writing switch;
2. Update conditions are complex types, such as dates or ObjectIds;
3. All increments are update events, and the source end must provide 'before'.

At this point, the QPS of incremental writing will drop sharply to around 40

Closes TAP-2444