### PR TITLE
TAP-3639 fix(iengine): The engine encounters an unknown ddl and reports a null…

### DIFF
--- a/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/node/hazelcast/data/pdk/HazelcastSourcePdkBaseNode.java
+++ b/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/node/hazelcast/data/pdk/HazelcastSourcePdkBaseNode.java
@@ -45,6 +45,7 @@ import io.tapdata.entity.event.TapBaseEvent;
 import io.tapdata.entity.event.TapEvent;
 import io.tapdata.entity.event.control.HeartbeatEvent;
 import io.tapdata.entity.event.ddl.TapDDLEvent;
+import io.tapdata.entity.event.ddl.TapDDLUnknownEvent;
 import io.tapdata.entity.event.ddl.table.TapCreateTableEvent;
 import io.tapdata.entity.event.ddl.table.TapDropTableEvent;
 import io.tapdata.entity.event.dml.TapRecordEvent;
@@ -922,13 +923,17 @@ public abstract class HazelcastSourcePdkBaseNode extends HazelcastPdkBaseNode {
 		}
 	}
 
-	private TapdataEvent wrapSingleTapdataEvent(TapEvent tapEvent, SyncStage syncStage, Object offsetObj, boolean isLast) {
+	protected TapdataEvent wrapSingleTapdataEvent(TapEvent tapEvent, SyncStage syncStage, Object offsetObj, boolean isLast) {
 		TapdataEvent tapdataEvent = null;
 		switch (sourceMode) {
 			case NORMAL:
 				tapdataEvent = new TapdataEvent();
 				break;
 			case LOG_COLLECTOR:
+				if (tapEvent instanceof TapDDLUnknownEvent) {
+					obsLogger.warn("DDL unknown event: " + tapEvent);
+					return null;
+				}
 				tapdataEvent = new TapdataShareLogEvent();
 				Connections connections = dataProcessorContext.getConnections();
 				Node<?> node = getNode();

--- a/iengine/iengine-app/src/test/java/io/tapdata/flow/engine/V2/node/hazelcast/data/pdk/HazelcastSourcePdkBaseNodeTest.java
+++ b/iengine/iengine-app/src/test/java/io/tapdata/flow/engine/V2/node/hazelcast/data/pdk/HazelcastSourcePdkBaseNodeTest.java
@@ -1212,5 +1212,29 @@ class HazelcastSourcePdkBaseNodeTest extends BaseHazelcastNodeTest {
 				excepted,tableName,consumer);
 	}
 
+	@Nested
+	@DisplayName("Method wrapSingleTapdataEvent test")
+	class wrapSingleTapdataEventTest {
+		@BeforeEach
+		void setUp() {
+			instance = spy(instance);
+			ReflectionTestUtils.setField(instance, "obsLogger", mockObsLogger);
+		}
+
+		@Test
+		@DisplayName("test source mode=LOG_COLLECTOR, TapEvent is a TapDDLUnknownEvent, expect return null")
+		void test1() {
+			HazelcastSourcePdkBaseNode.SourceMode sourceMode = HazelcastSourcePdkBaseNode.SourceMode.LOG_COLLECTOR;
+			ReflectionTestUtils.setField(instance, "sourceMode", sourceMode);
+			TapDDLUnknownEvent tapDDLUnknownEvent = new TapDDLUnknownEvent();
+			tapDDLUnknownEvent.setReferenceTime(System.currentTimeMillis());
+			tapDDLUnknownEvent.setTime(System.currentTimeMillis());
+			tapDDLUnknownEvent.setOriginDDL("alter table xxx add new_field number(8,0)");
+			TapdataEvent tapdataEvent = instance.wrapSingleTapdataEvent(tapDDLUnknownEvent, SyncStage.CDC, null, true);
+			assertNull(tapdataEvent);
+			verify(mockObsLogger).warn(any());
+		}
+	}
+
 
 }


### PR DESCRIPTION
… pointer exception.

Closes TAP-3639