### PR TITLE
TAP-3922 fix(iengine): Master-slave merge node, if the update join key is turn…

### DIFF
--- a/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/node/hazelcast/processor/HazelcastMergeNode.java
+++ b/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/node/hazelcast/processor/HazelcastMergeNode.java
@@ -1000,10 +1000,14 @@ public class HazelcastMergeNode extends HazelcastProcessorBaseNode implements Me
 		SyncStage syncStage = tapdataEvent.getSyncStage();
 		if (isInvalidOperation(tapdataEvent)) return false;
 		String op = getOp(tapdataEvent);
-		if (op.equals(OperationType.DELETE.getOp()) || op.equals(OperationType.UPDATE.getOp())) {
+		if (op.equals(OperationType.DELETE.getOp())) {
 			return false;
 		}
 		String preNodeId = getPreNodeId(tapdataEvent);
+		EnableUpdateJoinKey enableUpdateJoinKey = enableUpdateJoinKeyMap.get(preNodeId);
+		if (op.equals(OperationType.UPDATE.getOp()) && Boolean.FALSE.equals(enableUpdateJoinKey.isEnableChildren())) {
+			return false;
+		}
 		boolean existsInLookupMap = this.lookupMap.containsKey(preNodeId);
 		if (existsInLookupMap && SyncStage.INITIAL_SYNC.equals(syncStage)
 				&& (isMainTableFirstMode() || (isSubTableFirstMode() && !isFirstMergeLevel(preNodeId)))) {
@@ -1966,7 +1970,6 @@ public class HazelcastMergeNode extends HazelcastProcessorBaseNode implements Me
 			}
 			List<JoinKeyReference> childJoinKeyReferences = joinKeyReference.getChildJoinKeyReferences();
 			if (CollectionUtils.isNotEmpty(childJoinKeyReferences)) {
-				List<Map<String, String>> joinKeys = mergeTableProperties.getJoinKeys();
 				Map<String, Object> beforeJoinKey = buildParentBeforeJoinKeyValueMap(mergeTableProperties, before);
 				if (MapUtils.isNotEmpty(parentBeforeJoinKey)) {
 					beforeJoinKey.putAll(parentBeforeJoinKey);


### PR DESCRIPTION
…ed on, the update event needs to be look up in the sub-table

Closes TAP-3922