### PR TITLE
fix: TAP-4345 call

### DIFF
--- a/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/node/hazelcast/data/pdk/HazelcastSourcePdkBaseNode.java
+++ b/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/node/hazelcast/data/pdk/HazelcastSourcePdkBaseNode.java
@@ -953,6 +953,7 @@ public abstract class HazelcastSourcePdkBaseNode extends HazelcastPdkBaseNode {
 
 			this.sourceRunner = AsyncUtils.createThreadPoolExecutor(String.format("Source-Runner-table-changed-%s[%s]", getNode().getName(), getNode().getId()), 2, connectorOnTaskThreadGroup, TAG);
 			initAndStartSourceRunner();
+			initToTapValueConcurrent();
 		} else {
 			String error = "Connector node is null";
 			errorHandle(new RuntimeException(error), error);

--- a/iengine/iengine-app/src/test/java/io/tapdata/flow/engine/V2/node/hazelcast/data/pdk/HazelcastSourcePdkBaseNodeTest.java
+++ b/iengine/iengine-app/src/test/java/io/tapdata/flow/engine/V2/node/hazelcast/data/pdk/HazelcastSourcePdkBaseNodeTest.java
@@ -1135,6 +1135,7 @@ class HazelcastSourcePdkBaseNodeTest extends BaseHazelcastNodeTest {
 					MockedStatic<PDKIntegration> pdkIntegrationMockedStatic = mockStatic(PDKIntegration.class)
 			) {
 				ThreadPoolExecutorEx sourceRunner = mock(ThreadPoolExecutorEx.class);
+				ReflectionTestUtils.setField(instance, "readBatchSize", 100);
 				ReflectionTestUtils.setField(instance, "sourceRunner", sourceRunner);
 				String associateId = "test_associateId";
 				ReflectionTestUtils.setField(instance, "associateId", associateId);


### PR DESCRIPTION
initToTapValueConcurrent method when dynamic add table restart pdk connector