### PR TITLE
feat: supports a new scheduling strategy framework.

### DIFF
--- a/manager/tm/src/main/java/com/tapdata/tm/worker/schedule/CloudWorkerScheduler.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/worker/schedule/CloudWorkerScheduler.java
@@ -1,0 +1,35 @@
+package com.tapdata.tm.worker.schedule;
+
+import com.tapdata.tm.Settings.service.SettingsService;
+import com.tapdata.tm.commons.base.dto.SchedulableDto;
+import com.tapdata.tm.config.security.UserDetail;
+import com.tapdata.tm.scheduleTasks.service.ScheduleTasksService;
+import com.tapdata.tm.task.service.TaskService;
+import com.tapdata.tm.worker.dto.WorkSchedule;
+import com.tapdata.tm.worker.service.WorkerService;
+import com.tapdata.tm.worker.vo.CalculationEngineVo;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.data.mongodb.core.MongoTemplate;
+
+import java.util.ArrayList;
+
+/**
+ * Worker scheduler DTS impl
+ */
+public class CloudWorkerScheduler extends WorkerScheduler {
+    public CloudWorkerScheduler(ScheduleTasksService scheduleTasksService,
+                                TaskService taskService,
+                                WorkerService workerService,
+                                SettingsService settingsService,
+                                MongoTemplate mongoTemplate) {
+        super(scheduleTasksService, taskService, workerService, settingsService, mongoTemplate);
+    }
+
+    @Override
+    protected @NotNull CalculationEngineVo chooseOptimalWorker(SchedulableDto entity, UserDetail userDetail,
+                                                               Long findTime, boolean isCloud,
+                                                               ArrayList<WorkSchedule> threadLog) {
+        // TODO impl choose optimal worker for cloud
+        return super.chooseOptimalWorker(entity, userDetail, findTime, isCloud, threadLog);
+    }
+}

--- a/manager/tm/src/main/java/com/tapdata/tm/worker/schedule/DefaultWorkerScheduler.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/worker/schedule/DefaultWorkerScheduler.java
@@ -1,0 +1,28 @@
+package com.tapdata.tm.worker.schedule;
+
+import com.tapdata.tm.Settings.service.SettingsService;
+import com.tapdata.tm.commons.base.dto.SchedulableDto;
+import com.tapdata.tm.config.security.UserDetail;
+import com.tapdata.tm.scheduleTasks.service.ScheduleTasksService;
+import com.tapdata.tm.task.service.TaskService;
+import com.tapdata.tm.worker.dto.WorkSchedule;
+import com.tapdata.tm.worker.service.WorkerService;
+import com.tapdata.tm.worker.vo.CalculationEngineVo;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.data.mongodb.core.MongoTemplate;
+
+import java.util.ArrayList;
+
+/**
+ * Worker scheduler default impl
+ */
+public class DefaultWorkerScheduler extends WorkerScheduler {
+    public DefaultWorkerScheduler(ScheduleTasksService scheduleTasksService, TaskService taskService, WorkerService workerService, SettingsService settingsService, MongoTemplate mongoTemplate) {
+        super(scheduleTasksService, taskService, workerService, settingsService, mongoTemplate);
+    }
+
+    @Override
+    protected @NotNull CalculationEngineVo chooseOptimalWorker(SchedulableDto entity, UserDetail userDetail, Long findTime, boolean isCloud, ArrayList<WorkSchedule> threadLog) {
+        return super.chooseOptimalWorker(entity, userDetail, findTime, isCloud, threadLog);
+    }
+}

--- a/manager/tm/src/main/java/com/tapdata/tm/worker/schedule/SchedulerStrategy.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/worker/schedule/SchedulerStrategy.java
@@ -1,0 +1,6 @@
+package com.tapdata.tm.worker.schedule;
+
+public enum SchedulerStrategy {
+    CLOUD,
+    DEFAULT;
+}

--- a/manager/tm/src/main/java/com/tapdata/tm/worker/schedule/WorkerScheduler.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/worker/schedule/WorkerScheduler.java
@@ -1,0 +1,261 @@
+package com.tapdata.tm.worker.schedule;
+
+import com.tapdata.manager.common.utils.StringUtils;
+import com.tapdata.tm.Settings.constant.CategoryEnum;
+import com.tapdata.tm.Settings.constant.KeyEnum;
+import com.tapdata.tm.Settings.service.SettingsService;
+import com.tapdata.tm.base.exception.BizException;
+import com.tapdata.tm.commons.base.dto.SchedulableDto;
+import com.tapdata.tm.config.security.UserDetail;
+import com.tapdata.tm.scheduleTasks.dto.ScheduleTasksDto;
+import com.tapdata.tm.scheduleTasks.service.ScheduleTasksService;
+import com.tapdata.tm.task.service.TaskService;
+import com.tapdata.tm.utils.FunctionUtils;
+import com.tapdata.tm.worker.dto.WorkSchedule;
+import com.tapdata.tm.worker.dto.WorkerDto;
+import com.tapdata.tm.worker.entity.WorkerExpire;
+import com.tapdata.tm.worker.service.WorkerService;
+import com.tapdata.tm.worker.vo.CalculationEngineVo;
+import org.apache.commons.collections4.CollectionUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+public abstract class WorkerScheduler {
+    protected MongoTemplate mongoTemplate;
+
+    protected ScheduleTasksService scheduleTasksService;
+
+    protected TaskService taskService;
+
+    protected WorkerService workerService;
+
+    protected SettingsService settingsService;
+
+
+    public WorkerScheduler(ScheduleTasksService scheduleTasksService, TaskService taskService,
+                           WorkerService workerService, SettingsService settingsService,
+                           MongoTemplate mongoTemplate) {
+        this.scheduleTasksService = scheduleTasksService;
+        this.taskService = taskService;
+        this.workerService = workerService;
+        this.settingsService = settingsService;
+        this.mongoTemplate = mongoTemplate;
+    }
+
+    /**
+     * 1. returns an available worker.
+     * 2. persist the selected worker to db.
+     * @param entity
+     * @param userDetail
+     * @param type
+     * @param name
+     * @return
+     */
+    public CalculationEngineVo schedule(SchedulableDto entity, UserDetail userDetail, String type, String name) {
+        CalculationEngineVo calculationEngineVo = selectAvailableWorker(entity, userDetail);
+        saveWorker(userDetail, type, name, calculationEngineVo);
+        return calculationEngineVo;
+    }
+
+    /**
+     * returns an available worker.
+     * @param entity
+     * @param userDetail
+     * @return
+     */
+    public CalculationEngineVo schedule(SchedulableDto entity, UserDetail userDetail) {
+        return selectAvailableWorker(entity, userDetail);
+    }
+
+    private CalculationEngineVo selectAvailableWorker(SchedulableDto entity, UserDetail userDetail) {
+        ArrayList<WorkSchedule> threadLog = new ArrayList<>();
+        Object jobHeartTimeout = settingsService.getByCategoryAndKey(CategoryEnum.WORKER, KeyEnum.WORKER_HEART_TIMEOUT).getValue();
+        boolean isCloud = settingsService.isCloud();
+        if ((userDetail.getUserId() == null || userDetail.getUserId().equals("")) && isCloud) {
+            throw new BizException("NotFoundUserId");
+        }
+        Long findTime = System.currentTimeMillis() - Long.parseLong((String) jobHeartTimeout) * 1000L;
+
+        // 53迭代Task上增加了指定Flow Engine的功能 --start
+        CalculationEngineVo calculationEngine = manuallyAssignAgent(entity, userDetail, findTime, threadLog);
+        if (calculationEngine != null) return calculationEngine;
+        // 53迭代Task上增加了指定Flow Engine的功能 --end
+        return chooseOptimalWorker(entity, userDetail, findTime, isCloud, threadLog);
+    }
+
+    protected @NotNull CalculationEngineVo chooseOptimalWorker(SchedulableDto entity, UserDetail userDetail, Long findTime, boolean isCloud, ArrayList<WorkSchedule> threadLog) {
+        CalculationEngineVo calculationEngineVo = new CalculationEngineVo();
+        AtomicReference<String> scheduleAgentId = new AtomicReference<>("");
+        String filter;
+        int availableNum;
+        Criteria where = Criteria.where("worker_type").is("connector")
+                .and("ping_time").gte(findTime)
+                .and("isDeleted").ne(true)
+                .and("stopping").ne(true);
+        if (isCloud) {
+            // query user have share worker
+            WorkerExpire workerExpire = mongoTemplate.findOne(Query.query(Criteria.where("userId").is(userDetail.getUserId())), WorkerExpire.class);
+            if (Objects.nonNull(workerExpire) && workerExpire.getExpireTime().after(new Date())) {
+                where.and("user_id").in(userDetail.getUserId(), workerExpire.getShareTmUserId());
+            } else {
+                where.and("user_id").is(userDetail.getUserId());
+            }
+        }
+
+        if (isCloud && entity.getAgentTags() != null && entity.getAgentTags().size() > 0) {
+            List<String> agentTags = new ArrayList<>();
+            for (int i = 0; i < entity.getAgentTags().size(); i++) {
+                String s = entity.getAgentTags().get(i);
+                if (!s.equals("unidirectional")) {
+                    agentTags.add(s);
+                }
+            }
+            if (CollectionUtils.isNotEmpty(agentTags)) {
+                where.and("agentTags").all(agentTags);
+            } else {
+                where.and("agentTags").ne("disabledScheduleTask");
+            }
+        } else {
+            where.and("agentTags").ne("disabledScheduleTask");
+        }
+
+        Query query = Query.query(where);
+        List<WorkerDto> workers = workerService.findAll(query);
+        if (CollectionUtils.isEmpty(workers)) {
+            throw new BizException("Task.AgentNotFound");
+        }
+        availableNum = workers.size();
+
+        AtomicInteger scheduleWeight = new AtomicInteger();
+        AtomicInteger scheduleRunNum = new AtomicInteger();
+        AtomicInteger scheduleTaskLimit = new AtomicInteger();
+        AtomicInteger totalTaskLimit = new AtomicInteger();
+
+        for (int i = 0; i < workers.size(); i++) {
+            WorkerDto worker = workers.get(i);
+            FunctionUtils.isTureOrFalse(worker.getUserId().equals(userDetail.getUserId())).trueOrFalseHandle(() -> worker.setWeight(99), () -> worker.setWeight(1));
+
+            String processId = worker.getProcessId();
+            int runningNum = taskService.runningTaskNum(processId, userDetail);
+            int taskLimit = workerService.getLimitTaskNum(worker, userDetail);
+            Integer weight = worker.getWeight();
+            totalTaskLimit.addAndGet(taskLimit);
+            if (isCloud && runningNum > taskLimit) {
+                continue;
+            }
+
+            WorkSchedule workSchedule = new WorkSchedule();
+            workSchedule.setProcessId(processId);
+            workSchedule.setWeight(weight);
+            workSchedule.setTaskRunNum(runningNum);
+            workSchedule.setTaskLimit(taskLimit);
+            threadLog.add(workSchedule);
+
+            if (i == 0 || workSchedule.getProcessId() == null) {
+                scheduleAgentId.set(processId);
+                scheduleWeight.set(weight);
+                scheduleRunNum.set(runningNum);
+                scheduleTaskLimit.set(taskLimit);
+            } else if (worker.getWeight() > scheduleWeight.get()) {
+                scheduleAgentId.set(processId);
+                scheduleWeight.set(weight);
+                scheduleRunNum.set(runningNum);
+                scheduleTaskLimit.set(taskLimit);
+            } else if (worker.getWeight().equals(scheduleWeight.get()) && (taskLimit - runningNum) > (scheduleTaskLimit.get() - scheduleRunNum.get())) {
+                scheduleAgentId.set(processId);
+                scheduleWeight.set(weight);
+                scheduleRunNum.set(runningNum);
+                scheduleTaskLimit.set(taskLimit);
+            }
+        }
+        int totalRunningNum = taskService.runningTaskNum(userDetail);
+        filter = where.toString();
+        String processId = scheduleAgentId.get();
+
+        entity.setAgentId(processId);
+        entity.setScheduleTime(System.currentTimeMillis());
+
+        calculationEngineVo.setProcessId(processId);
+        calculationEngineVo.setFilter(filter);
+        calculationEngineVo.setThreadLog(threadLog);
+        calculationEngineVo.setAvailable(availableNum);
+        calculationEngineVo.setManually(false);
+        int totalTask = totalTaskLimit.get() < 0 ? Integer.MAX_VALUE : totalTaskLimit.get();
+        calculationEngineVo.setTaskLimit(totalTask);
+        calculationEngineVo.setRunningNum(totalRunningNum);
+        calculationEngineVo.setTotalLimit(totalTask);
+        return calculationEngineVo;
+    }
+
+    private @Nullable CalculationEngineVo manuallyAssignAgent(SchedulableDto entity, UserDetail userDetail,
+                                                              Long findTime, ArrayList<WorkSchedule> threadLog) {
+        CalculationEngineVo calculationEngineVo = new CalculationEngineVo();
+        String agentId = entity.getAgentId();
+        if (StringUtils.isNotBlank(agentId)) {
+            Criteria where = Criteria.where("worker_type").is("connector")
+                    .and("ping_time").gte(findTime)
+                    .and("isDeleted").ne(true)
+                    .and("stopping").ne(true)
+                    .and("process_id").is(agentId);
+            WorkerDto worker = workerService.findOne(Query.query(where));
+
+            int runningNum = taskService.runningTaskNum(agentId, userDetail);
+            if (Objects.nonNull(worker)) {
+                int availableNum = 1;
+                int taskLimit = workerService.getLimitTaskNum(worker, userDetail);
+
+                calculationEngineVo.setProcessId(agentId);
+                calculationEngineVo.setManually(true);
+
+                calculationEngineVo.setFilter(where.toString());
+
+                WorkSchedule workSchedule = new WorkSchedule();
+                workSchedule.setProcessId(worker.getProcessId());
+                workSchedule.setWeight(worker.getWeight());
+                workSchedule.setTaskRunNum(runningNum);
+                workSchedule.setTaskLimit(taskLimit);
+                threadLog.add(workSchedule);
+                calculationEngineVo.setThreadLog(threadLog);
+
+                entity.setAgentId(calculationEngineVo.getProcessId());
+                entity.setScheduleTime(System.currentTimeMillis());
+
+                calculationEngineVo.setAvailable(availableNum);
+                calculationEngineVo.setTaskLimit(taskLimit);
+                calculationEngineVo.setRunningNum(runningNum);
+                calculationEngineVo.setTotalLimit(taskLimit);
+                return calculationEngineVo;
+            }
+        }
+        return null;
+    }
+
+    private void saveWorker(UserDetail userDetail, String type, String name, CalculationEngineVo calculationEngineVo) {
+        String processId = calculationEngineVo.getProcessId();
+        String filter = calculationEngineVo.getFilter();
+
+        ScheduleTasksDto scheduleTasksDto = new ScheduleTasksDto();
+        scheduleTasksDto.setTask_name("TM_SCHEDULE");
+        scheduleTasksDto.setType(type);
+        scheduleTasksDto.setPeriod(0L);
+        scheduleTasksDto.setStatus("done");
+        scheduleTasksDto.setTask_name(name);
+        scheduleTasksDto.setTask_profile("DEFAULT");
+        scheduleTasksDto.setAgent_id(processId);
+        scheduleTasksDto.setLast_updated(new Date());
+        scheduleTasksDto.setPing_time(System.currentTimeMillis());
+        scheduleTasksDto.setFilter(filter);
+        scheduleTasksDto.setThread(calculationEngineVo.getThreadLog());
+        scheduleTasksService.save(scheduleTasksDto, userDetail);
+    }
+}

--- a/manager/tm/src/main/java/com/tapdata/tm/worker/schedule/WorkerSchedulerFactory.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/worker/schedule/WorkerSchedulerFactory.java
@@ -1,0 +1,23 @@
+package com.tapdata.tm.worker.schedule;
+
+import com.tapdata.tm.Settings.service.SettingsService;
+import com.tapdata.tm.scheduleTasks.service.ScheduleTasksService;
+import com.tapdata.tm.task.service.TaskService;
+import com.tapdata.tm.worker.service.WorkerService;
+import org.springframework.data.mongodb.core.MongoTemplate;
+
+public class WorkerSchedulerFactory {
+    public static WorkerScheduler createScheduler(ScheduleTasksService scheduleTasksService, TaskService taskService,
+                                                  WorkerService workerService, SettingsService settingsService,
+                                                  MongoTemplate mongoTemplate, SchedulerStrategy strategy) {
+        // Select different scheduling implementations based on the strategy.
+        switch (strategy) {
+            case DEFAULT:
+                return new DefaultWorkerScheduler(scheduleTasksService, taskService, workerService, settingsService, mongoTemplate);
+            case CLOUD:
+                return new CloudWorkerScheduler(scheduleTasksService, taskService, workerService, settingsService, mongoTemplate);
+            default:
+                throw new IllegalArgumentException("Unknown scheduling strategy: " + strategy);
+        }
+    }
+}

--- a/manager/tm/src/main/java/com/tapdata/tm/worker/service/WorkerServiceImpl.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/worker/service/WorkerServiceImpl.java
@@ -16,7 +16,6 @@ import com.tapdata.tm.Settings.service.SettingsService;
 import com.tapdata.tm.base.dto.Filter;
 import com.tapdata.tm.base.dto.Page;
 import com.tapdata.tm.base.exception.BizException;
-import com.tapdata.tm.base.service.BaseService;
 import com.tapdata.tm.cluster.dto.ClusterStateDto;
 import com.tapdata.tm.cluster.dto.SystemInfo;
 import com.tapdata.tm.cluster.dto.UpdataStatusRequest;
@@ -45,6 +44,9 @@ import com.tapdata.tm.worker.dto.*;
 import com.tapdata.tm.worker.entity.Worker;
 import com.tapdata.tm.worker.entity.WorkerExpire;
 import com.tapdata.tm.worker.repository.WorkerRepository;
+import com.tapdata.tm.worker.schedule.SchedulerStrategy;
+import com.tapdata.tm.worker.schedule.WorkerScheduler;
+import com.tapdata.tm.worker.schedule.WorkerSchedulerFactory;
 import com.tapdata.tm.worker.vo.ApiWorkerStatusVo;
 import com.tapdata.tm.worker.vo.CalculationEngineVo;
 import io.firedome.MultiTaggedCounter;
@@ -57,6 +59,7 @@ import org.bson.types.ObjectId;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
@@ -64,6 +67,7 @@ import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.stereotype.Service;
 
+import javax.annotation.PostConstruct;
 import java.math.BigInteger;
 import java.text.SimpleDateFormat;
 import java.util.*;
@@ -78,7 +82,7 @@ import java.util.stream.Collectors;
  */
 @Service
 @Slf4j
-public class WorkerServiceImpl extends WorkerService{
+public class WorkerServiceImpl extends WorkerService {
 
     @Autowired
     private DataFlowService dataFlowService;
@@ -101,9 +105,19 @@ public class WorkerServiceImpl extends WorkerService{
 
     private final MultiTaggedCounter workerPing;
 
+    private WorkerScheduler workerScheduler;
+
+    @Value("${cluster.manager.scheduler.strategy}")
+    private SchedulerStrategy schedulerStrategy;
+
     public WorkerServiceImpl(@NonNull WorkerRepository repository) {
         super(repository);
         workerPing = new MultiTaggedCounter("worker_ping", Metrics.globalRegistry, "worker_type", "version");
+    }
+
+    @PostConstruct
+    public void init() {
+        this.workerScheduler = WorkerSchedulerFactory.createScheduler(scheduleTasksService, taskService, this, settingsService, mongoTemplate, schedulerStrategy);
     }
 
     @Override
@@ -276,10 +290,10 @@ public class WorkerServiceImpl extends WorkerService{
             Criteria criteria = Criteria.where("agentId").is(worker.getProcessId())
                     .and("is_deleted").ne(true)
                     .and("user_id").is(userDetail.getUserId())
-                    .and("status").nin(TaskDto.STATUS_DELETE_FAILED,TaskDto.STATUS_DELETING)
+                    .and("status").nin(TaskDto.STATUS_DELETE_FAILED, TaskDto.STATUS_DELETING)
                     .orOperator(Criteria.where("status").in(TaskDto.STATUS_RUNNING, TaskDto.STATUS_SCHEDULING, TaskDto.STATUS_WAIT_RUN),
-                     Criteria.where("crontabExpressionFlag").is(true),
-                     Criteria.where("planStartDateFlag").is(true));
+                            Criteria.where("crontabExpressionFlag").is(true),
+                            Criteria.where("planStartDateFlag").is(true));
             Query query = Query.query(criteria);
             query.fields().include("id", "name", "syncType");
             //List<DataFlowDto> dataFlows = dataFlowService.findAll(query);
@@ -316,188 +330,13 @@ public class WorkerServiceImpl extends WorkerService{
      * <p>
      * 支持DRS场景（地域/可用区、有无互联网访问、单向/双向过滤）、DFS场景（托管实例、本地自建实例）
      * 支持资源池同地域多个实例的负载调度
-     *
      */
     public CalculationEngineVo scheduleTaskToEngine(SchedulableDto entity, UserDetail userDetail, String type, String name) throws BizException {
-
-        CalculationEngineVo calculationEngineVo = calculationEngine(entity, userDetail, type);
-        String processId = calculationEngineVo.getProcessId();
-        String filter = calculationEngineVo.getFilter();
-
-        ScheduleTasksDto scheduleTasksDto = new ScheduleTasksDto();
-        scheduleTasksDto.setTask_name("TM_SCHEDULE");
-        scheduleTasksDto.setType(type);
-        scheduleTasksDto.setPeriod(0L);
-        scheduleTasksDto.setStatus("done");
-        scheduleTasksDto.setTask_name(name);
-        scheduleTasksDto.setTask_profile("DEFAULT");
-        scheduleTasksDto.setAgent_id(processId);
-        scheduleTasksDto.setLast_updated(new Date());
-        scheduleTasksDto.setPing_time(System.currentTimeMillis());
-        scheduleTasksDto.setFilter(filter);
-        scheduleTasksDto.setThread(calculationEngineVo.getThreadLog());
-        scheduleTasksService.save(scheduleTasksDto, userDetail);
-
-        return calculationEngineVo;
+        return workerScheduler.schedule(entity, userDetail, type, name);
     }
 
     public CalculationEngineVo calculationEngine(SchedulableDto entity, UserDetail userDetail, String type) {
-        CalculationEngineVo calculationEngineVo = new CalculationEngineVo();
-        String filter;
-        int availableNum;
-        int taskLimit = 0;
-        int runningNum = 0;
-
-        ArrayList<WorkSchedule> threadLog = new ArrayList<>();
-
-        AtomicReference<String> scheduleAgentId = new AtomicReference<>("");
-
-        Object jobHeartTimeout = settingsService.getByCategoryAndKey(CategoryEnum.WORKER, KeyEnum.WORKER_HEART_TIMEOUT).getValue();
-        boolean isCloud = settingsService.isCloud();
-        if ((userDetail.getUserId() == null || userDetail.getUserId().equals("")) && isCloud) {
-            throw new BizException("NotFoundUserId");
-        }
-        Long findTime = System.currentTimeMillis() - Long.parseLong((String) jobHeartTimeout) * 1000L;
-
-        // 53迭代Task上增加了指定Flow Engine的功能 --start
-        String agentId = entity.getAgentId();
-        if (StringUtils.isNotBlank(agentId)) {
-            Criteria where = Criteria.where("worker_type").is("connector")
-                    .and("ping_time").gte(findTime)
-                    .and("isDeleted").ne(true)
-                    .and("stopping").ne(true)
-                    .and("process_id").is(agentId);
-            WorkerDto worker = findOne(Query.query(where));
-
-            runningNum = taskService.runningTaskNum(agentId, userDetail);
-            if (Objects.nonNull(worker)) {
-                availableNum = 1;
-                taskLimit = getLimitTaskNum(worker, userDetail);
-
-                calculationEngineVo.setProcessId(agentId);
-                scheduleAgentId.set(agentId);
-                calculationEngineVo.setManually(true);
-
-                calculationEngineVo.setFilter(where.toString());
-
-                WorkSchedule workSchedule = new WorkSchedule();
-                workSchedule.setProcessId(worker.getProcessId());
-                workSchedule.setWeight(worker.getWeight());
-                workSchedule.setTaskRunNum(runningNum);
-                workSchedule.setTaskLimit(taskLimit);
-                threadLog.add(workSchedule);
-                calculationEngineVo.setThreadLog(threadLog);
-
-                entity.setAgentId(calculationEngineVo.getProcessId());
-                entity.setScheduleTime(System.currentTimeMillis());
-
-                calculationEngineVo.setAvailable(availableNum);
-                calculationEngineVo.setTaskLimit(taskLimit);
-                calculationEngineVo.setRunningNum(runningNum);
-                calculationEngineVo.setTotalLimit(taskLimit);
-                return calculationEngineVo;
-            }
-        }
-        // 53迭代Task上增加了指定Flow Engine的功能 --end
-
-        Criteria where = Criteria.where("worker_type").is("connector")
-                .and("ping_time").gte(findTime)
-                .and("isDeleted").ne(true)
-                .and("stopping").ne(true);
-        if (isCloud) {
-            // query user have share worker
-            WorkerExpire workerExpire = mongoTemplate.findOne(Query.query(Criteria.where("userId").is(userDetail.getUserId())), WorkerExpire.class);
-            if (Objects.nonNull(workerExpire) && workerExpire.getExpireTime().after(new Date())) {
-                where.and("user_id").in(userDetail.getUserId(), workerExpire.getShareTmUserId());
-            } else {
-                where.and("user_id").is(userDetail.getUserId());
-            }
-        }
-
-        if (isCloud && entity.getAgentTags() != null && entity.getAgentTags().size() > 0) {
-            List<String> agentTags = new ArrayList<>();
-            for (int i = 0; i < entity.getAgentTags().size(); i++) {
-                String s = entity.getAgentTags().get(i);
-                if (!s.equals("unidirectional")) {
-                    agentTags.add(s);
-                }
-            }
-            if (CollectionUtils.isNotEmpty(agentTags)) {
-                where.and("agentTags").all(agentTags);
-            } else {
-                where.and("agentTags").ne("disabledScheduleTask");
-            }
-        } else {
-            where.and("agentTags").ne("disabledScheduleTask");
-        }
-
-        Query query = Query.query(where);
-        List<WorkerDto> workers = findAll(query);
-        if (CollectionUtils.isEmpty(workers)) {
-            throw new BizException("Task.AgentNotFound");
-        }
-        availableNum = workers.size();
-
-        AtomicInteger scheduleWeight = new AtomicInteger();
-        AtomicInteger scheduleRunNum = new AtomicInteger();
-        AtomicInteger scheduleTaskLimit = new AtomicInteger();
-        AtomicInteger totalTaskLimit = new AtomicInteger();
-
-        for (int i = 0; i < workers.size(); i++) {
-            WorkerDto worker = workers.get(i);
-            FunctionUtils.isTureOrFalse(worker.getUserId().equals(userDetail.getUserId())).trueOrFalseHandle(() -> worker.setWeight(99), () -> worker.setWeight(1));
-
-            String processId = worker.getProcessId();
-            runningNum = taskService.runningTaskNum(processId, userDetail);
-            taskLimit = getLimitTaskNum(worker, userDetail);
-            Integer weight = worker.getWeight();
-            totalTaskLimit.addAndGet(taskLimit);
-            if (isCloud && runningNum > taskLimit) {
-                continue;
-            }
-
-            WorkSchedule workSchedule = new WorkSchedule();
-            workSchedule.setProcessId(processId);
-            workSchedule.setWeight(weight);
-            workSchedule.setTaskRunNum(runningNum);
-            workSchedule.setTaskLimit(taskLimit);
-            threadLog.add(workSchedule);
-
-
-            if (i == 0 || workSchedule.getProcessId() == null) {
-                scheduleAgentId.set(processId);
-                scheduleWeight.set(weight);
-                scheduleRunNum.set(runningNum);
-                scheduleTaskLimit.set(taskLimit);
-            } else if (worker.getWeight() > scheduleWeight.get()) {
-                scheduleAgentId.set(processId);
-                scheduleWeight.set(weight);
-                scheduleRunNum.set(runningNum);
-                scheduleTaskLimit.set(taskLimit);
-            } else if (worker.getWeight().equals(scheduleWeight.get()) &&  (taskLimit - runningNum) > (scheduleTaskLimit.get() - scheduleRunNum.get())) {
-                scheduleAgentId.set(processId);
-                scheduleWeight.set(weight);
-                scheduleRunNum.set(runningNum);
-                scheduleTaskLimit.set(taskLimit);
-            }
-        }
-        int totalRunningNum = taskService.runningTaskNum(userDetail);
-        filter = where.toString();
-        String processId = scheduleAgentId.get();
-
-        entity.setAgentId(processId);
-        entity.setScheduleTime(System.currentTimeMillis());
-
-        calculationEngineVo.setProcessId(processId);
-        calculationEngineVo.setFilter(filter);
-        calculationEngineVo.setThreadLog(threadLog);
-        calculationEngineVo.setAvailable(availableNum);
-        calculationEngineVo.setManually(false);
-        int totalTask = totalTaskLimit.get() < 0 ? Integer.MAX_VALUE : totalTaskLimit.get();
-        calculationEngineVo.setTaskLimit(totalTask);
-        calculationEngineVo.setRunningNum(totalRunningNum);
-        calculationEngineVo.setTotalLimit(totalTask);
-        return calculationEngineVo;
+        return workerScheduler.schedule(entity, userDetail);
     }
 
     public void scheduleTaskToEngine(InspectDto inspectDto, UserDetail userDetail) throws BizException {
@@ -587,7 +426,7 @@ public class WorkerServiceImpl extends WorkerService{
         } else {
             log.error("找不到woerker22222222，userDetail：{}", JSON.toJSONString(userDetail));
         }
-        Page<ApiWorkerStatusVo> page=new Page<ApiWorkerStatusVo>();
+        Page<ApiWorkerStatusVo> page = new Page<ApiWorkerStatusVo>();
         page.setItems(list);
         return page;
 
@@ -599,7 +438,8 @@ public class WorkerServiceImpl extends WorkerService{
 
     /**
      * 客户端上报心跳信息, 这个方法将会根据 process_id 和 worker_type 执行 upsert 操作
-     * @param worker worker
+     *
+     * @param worker    worker
      * @param loginUser loginUser
      * @return WorkerDto
      */
@@ -615,7 +455,7 @@ public class WorkerServiceImpl extends WorkerService{
 //        if(worker.getPingTime()!=null&&worker.getPingTime()==1){
 //            log.info("The engine {} has stopped",worker.getProcessId());
 //        }else{
-            worker.setPingTime(System.currentTimeMillis());
+        worker.setPingTime(System.currentTimeMillis());
 //        }
         Object buildProfile = settingsService.getByCategoryAndKey(CategoryEnum.SYSTEM, KeyEnum.BUILD_PROFILE).getValue();
         boolean isCloud = buildProfile.equals("CLOUD") || buildProfile.equals("DRS") || buildProfile.equals("DFS");
@@ -673,6 +513,7 @@ public class WorkerServiceImpl extends WorkerService{
         TaskDto taskDto = taskService.checkExistById(MongoUtils.toObjectId(taskId), user, "agentId");
         return checkUsedAgent(taskDto.getAgentId(), user);
     }
+
     public String checkUsedAgent(String processId, UserDetail user) {
         Criteria availableAgentCriteria = Criteria.where("worker_type").is("connector")
                 .and("stopping").ne(true);
@@ -832,20 +673,23 @@ public class WorkerServiceImpl extends WorkerService{
         Update expireTime = Update.update("expireTime", date).set("is_deleted", true).set("last_updated", date);
         mongoTemplate.updateFirst(query, expireTime, WorkerExpire.class);
     }
-    public WorkerDto queryWorkerByProcessId(String processId){
+
+    public WorkerDto queryWorkerByProcessId(String processId) {
         if (StringUtils.isBlank(processId)) throw new IllegalArgumentException("process id can not be empty");
         Query query = Query.query(Criteria.where("process_id").is(processId).and("worker_type").is("connector"));
         return findOne(query);
     }
-    public List<Worker> queryAllBindWorker(){
+
+    public List<Worker> queryAllBindWorker() {
         Query query = Query.query(Criteria.where("worker_type").is("connector").and("licenseBind").is(true));
         return repository.findAll(query);
     }
-    public boolean bindByProcessId(WorkerDto workerDto, String processId, UserDetail userDetail){
+
+    public boolean bindByProcessId(WorkerDto workerDto, String processId, UserDetail userDetail) {
         if (StringUtils.isBlank(processId)) throw new IllegalArgumentException("process id can not be empty");
         //if not exist
         WorkerDto res = queryWorkerByProcessId(processId);
-        if (null == res){
+        if (null == res) {
             save(workerDto, userDetail);
         }
         Query query = Query.query(Criteria.where("process_id").is(processId).and("worker_type").is("connector"));
@@ -854,7 +698,8 @@ public class WorkerServiceImpl extends WorkerService{
         if (null == result) return false;
         return result.getModifiedCount() == 1 ? true : false;
     }
-    public boolean unbindByProcessId(String processId){
+
+    public boolean unbindByProcessId(String processId) {
         if (StringUtils.isBlank(processId)) throw new IllegalArgumentException("process id can not be empty");
         Query query = Query.query(Criteria.where("process_id").is(processId).and("worker_type").is("connector"));
         Update update = Update.update("licenseBind", false);
@@ -863,11 +708,11 @@ public class WorkerServiceImpl extends WorkerService{
         return result.getModifiedCount() == 1 ? true : false;
     }
 
-    public Long getAvailableAgentCount(){
+    public Long getAvailableAgentCount() {
         return count(getAvailableAgentQuery());
     }
 
-    public Long getLastCheckAvailableAgentCount(){
+    public Long getLastCheckAvailableAgentCount() {
         int overTime = SettingsEnum.WORKER_HEART_OVERTIME.getIntValue(30) + 120;
         Criteria criteria = Criteria.where("worker_type").is("connector")
                 .and("ping_time").gte(System.currentTimeMillis() - (overTime * 1000L))
@@ -876,27 +721,27 @@ public class WorkerServiceImpl extends WorkerService{
         return count(Query.query(criteria));
     }
 
-    public String getWorkerCurrentTime(UserDetail userDetail){
+    public String getWorkerCurrentTime(UserDetail userDetail) {
         SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
         List<Worker> workerList = findAvailableAgent(userDetail);
-        if(CollectionUtils.isNotEmpty(workerList)){
+        if (CollectionUtils.isNotEmpty(workerList)) {
             Worker worker = workerList.get(0);
-            if( null != worker.getWorkerDate()){
+            if (null != worker.getWorkerDate()) {
                 return simpleDateFormat.format(worker.getWorkerDate());
             }
         }
         return simpleDateFormat.format(new Date());
     }
 
-    public Boolean checkEngineVersion(UserDetail userDetail){
+    public Boolean checkEngineVersion(UserDetail userDetail) {
         boolean isCloud = settingsService.isCloud();
-        if(isCloud){
+        if (isCloud) {
             List<Worker> workers = findAvailableAgent(userDetail);
-            if(CollectionUtils.isEmpty(workers)) return false;
+            if (CollectionUtils.isEmpty(workers)) return false;
             List<Worker> oldWorkers = workers.stream().filter(worker -> StringUtils.isBlank(worker.getVersion())
                     || !EngineVersionUtil.checkEngineTransFormSchema(worker.getVersion())).collect(Collectors.toList());
             return CollectionUtils.isEmpty(oldWorkers);
-        }else{
+        } else {
             return true;
         }
     }

--- a/manager/tm/src/main/resources/application-default.yml
+++ b/manager/tm/src/main/resources/application-default.yml
@@ -133,3 +133,12 @@ report:
     clientId: '796104786.1713955139'
   data:
     oss: ${REPORT_DATA_OSS:false}
+
+cluster:
+  agent:
+    resources:
+      minTaskSlots: 10
+      maxTaskSlots: 10
+  manager:
+    scheduler:
+      strategy: DEFAULT


### PR DESCRIPTION
In practical scenarios, we need to strictly control the number of tasks started on each Agent to avoid overloading a single Pod, which could lead to performance issues. We have abstracted a framework that allows the use of different task scheduling strategies based on configuration in various environments. The local deployment mode is suitable for community use, while the cloud scheduling mode supports elastic task scheduling and over-commitment in a Kubernetes environment. As a result, we have abstracted a new interface design where only the core worker selection algorithm needs to be implemented. This enables influencing the scheduling results according to the new algorithm.