### PR TITLE
TAP-5052:fix(iengine):When a table is followed by an empty table, the…

### DIFF
--- a/iengine/iengine-app/src/test/java/io/tapdata/flow/engine/V2/node/hazelcast/data/pdk/concurrent/PartitionConcurrentProcessorTest.java
+++ b/iengine/iengine-app/src/test/java/io/tapdata/flow/engine/V2/node/hazelcast/data/pdk/concurrent/PartitionConcurrentProcessorTest.java
@@ -639,6 +639,7 @@ class PartitionConcurrentProcessorTest {
         PartitionConcurrentProcessor processor = mock(PartitionConcurrentProcessor.class);
         when(processor.isRunning()).thenReturn(true);
         doCallRealMethod().when(processor).process(anyList(), anyBoolean());
+        doCallRealMethod().when(processor).getOffsetEvent(any(),anyList());
         doAnswer(invocationOnMock -> {
             offsetEvent.set(invocationOnMock.getArgument(0));
             return null;

--- a/iengine/iengine-app/src/test/java/io/tapdata/flow/engine/V2/node/hazelcast/data/pdk/concurrent/PartitionConcurrentProcessorTest.java
+++ b/iengine/iengine-app/src/test/java/io/tapdata/flow/engine/V2/node/hazelcast/data/pdk/concurrent/PartitionConcurrentProcessorTest.java
@@ -105,7 +105,9 @@ class PartitionConcurrentProcessorTest {
         list.add(generateDDLEvent(new TapField("ddl3", "string"))); // need after ddl1,ddl2,1,2,3,4,5,6
         list.add(generateInsertEvent("i", 7, null));
         list.add(new TapdataCompleteSnapshotEvent());
-        list.add(new TapdataCompleteTableSnapshotEvent());
+        TapdataCompleteTableSnapshotEvent tapdataCompleteTableSnapshotEvent = new TapdataCompleteTableSnapshotEvent();
+        tapdataCompleteTableSnapshotEvent.setBatchOffset("OVER");
+        list.add(tapdataCompleteTableSnapshotEvent);
         list.add(new TapdataStartingCdcEvent());
         list.add(TapdataStartedCdcEvent.create());
         list.add(generateInsertEvent("u", 8, null));


### PR DESCRIPTION
… offset of the previous table is overwritten