### PR TITLE
fix(iengine): TAP-5369 TapTable.getNameFieldMap() item order should b…

### DIFF
--- a/iengine/iengine-app/src/main/java/io/tapdata/common/DAGDataEngineServiceImpl.java
+++ b/iengine/iengine-app/src/main/java/io/tapdata/common/DAGDataEngineServiceImpl.java
@@ -29,6 +29,7 @@ import io.tapdata.observable.logging.ObsLogger;
 import io.tapdata.observable.logging.ObsLoggerFactory;
 import io.tapdata.pdk.core.utils.CommonUtils;
 import io.tapdata.schema.TapTableMap;
+import io.tapdata.schema.TapTableUtil;
 import io.tapdata.websocket.handler.DeduceSchemaHandler;
 import org.apache.commons.collections.CollectionUtils;
 import org.springframework.data.mongodb.core.query.Query;
@@ -225,7 +226,9 @@ public class DAGDataEngineServiceImpl extends DAGDataServiceImpl {
 
     protected TapTable convertTapTable(MetadataInstancesDto item){
         FilterMetadataInstanceUtil.filterMetadataInstancesFields(item);
-        return PdkSchemaConvert.toPdk(item);
+        TapTable tapTable = PdkSchemaConvert.toPdk(item);
+        TapTableUtil.sortFieldMap(tapTable);
+        return tapTable;
     }
 
     @Override

--- a/iengine/iengine-common/src/main/java/io/tapdata/schema/TapTableMap.java
+++ b/iengine/iengine-common/src/main/java/io/tapdata/schema/TapTableMap.java
@@ -424,27 +424,7 @@ public class TapTableMap<K extends String, V extends TapTable> extends HashMap<K
 			throw new RuntimeException("Table name \"" + k + "\" not exists, qualified name: " + qualifiedName);
 		}
 
-		LinkedHashMap<String, TapField> nameFieldMap = tapTable.getNameFieldMap();
-		if (MapUtils.isNotEmpty(nameFieldMap)) {
-			LinkedHashMap<String, TapField> sortedFieldMap = new LinkedHashMap<>();
-			nameFieldMap.entrySet().stream().sorted((o1, o2) -> {
-				Integer o1Pos = o1.getValue().getPos();
-				Integer o2Pos = o2.getValue().getPos();
-				if (o1Pos == null && o2Pos == null) {
-					return 0;
-				}
-
-				if (o1Pos == null) {
-					return -1;
-				}
-
-				if (o2Pos == null) {
-					return 1;
-				}
-				return o1Pos.compareTo(o2Pos);
-			}).forEach(entry -> sortedFieldMap.put(entry.getKey(), entry.getValue()));
-			tapTable.setNameFieldMap(sortedFieldMap);
-		}
+		TapTableUtil.sortFieldMap(tapTable);
 		return (V) tapTable;
 	}
 

--- a/iengine/iengine-common/src/main/java/io/tapdata/schema/TapTableUtil.java
+++ b/iengine/iengine-common/src/main/java/io/tapdata/schema/TapTableUtil.java
@@ -7,12 +7,15 @@ import com.tapdata.tm.commons.dag.Node;
 import com.tapdata.tm.commons.schema.Schema;
 import com.tapdata.tm.commons.schema.bean.SourceTypeEnum;
 import com.tapdata.tm.commons.util.PdkSchemaConvert;
+import io.tapdata.entity.schema.TapField;
 import io.tapdata.entity.schema.TapTable;
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.MapUtils;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.data.mongodb.core.query.Query;
 
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -106,6 +109,30 @@ public class TapTableUtil {
 			return schemaList.stream().map(PdkSchemaConvert::toPdk).collect(Collectors.toList());
 		} else {
 			return Collections.emptyList();
+		}
+	}
+
+	public static void sortFieldMap(TapTable tapTable) {
+		LinkedHashMap<String, TapField> nameFieldMap = tapTable.getNameFieldMap();
+		if (MapUtils.isNotEmpty(nameFieldMap)) {
+			LinkedHashMap<String, TapField> sortedFieldMap = new LinkedHashMap<>();
+			nameFieldMap.entrySet().stream().sorted((o1, o2) -> {
+				Integer o1Pos = o1.getValue().getPos();
+				Integer o2Pos = o2.getValue().getPos();
+				if (o1Pos == null && o2Pos == null) {
+					return 0;
+				}
+
+				if (o1Pos == null) {
+					return -1;
+				}
+
+				if (o2Pos == null) {
+					return 1;
+				}
+				return o1Pos.compareTo(o2Pos);
+			}).forEach(entry -> sortedFieldMap.put(entry.getKey(), entry.getValue()));
+			tapTable.setNameFieldMap(sortedFieldMap);
 		}
 	}
 }

--- a/iengine/iengine-common/src/test/java/io/tapdata/schema/TapTableUtilTest.java
+++ b/iengine/iengine-common/src/test/java/io/tapdata/schema/TapTableUtilTest.java
@@ -1,0 +1,58 @@
+package io.tapdata.schema;
+
+import io.tapdata.entity.schema.TapField;
+import io.tapdata.entity.schema.TapTable;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * @author samuel
+ * @Description
+ * @create 2024-12-18 17:48
+ **/
+@DisplayName("Class io.tapdata.schema.TapTableUtil Test")
+class TapTableUtilTest {
+	@Nested
+	@DisplayName("Method sortFieldMap test")
+	class sortFieldMapTest {
+		@Test
+		@DisplayName("test main process")
+		void test1() {
+			LinkedHashMap<String, TapField> fieldMap = new LinkedHashMap<>();
+			fieldMap.put("f5", new TapField().name("f5").pos(null));
+			fieldMap.put("f4", new TapField().name("f4").pos(null));
+			fieldMap.put("f2", new TapField().name("f2").pos(2));
+			fieldMap.put("f1", new TapField().name("f1").pos(1));
+			fieldMap.put("f3", new TapField().name("f3").pos(3));
+			fieldMap.put("f6", new TapField().name("f6").pos(null));
+			TapTable tapTable = new TapTable("test");
+			tapTable.setNameFieldMap(fieldMap);
+			TapTableUtil.sortFieldMap(tapTable);
+			LinkedHashMap<String, TapField> nameFieldMap = tapTable.getNameFieldMap();
+			assertNotSame(fieldMap, nameFieldMap);
+			Iterator<TapField> iterator = nameFieldMap.values().iterator();
+			assertEquals("f5", iterator.next().getName());
+			assertEquals("f4", iterator.next().getName());
+			assertEquals("f6", iterator.next().getName());
+			assertEquals("f1", iterator.next().getName());
+			assertEquals("f2", iterator.next().getName());
+			assertEquals("f3", iterator.next().getName());
+		}
+
+		@Test
+		@DisplayName("test empty name field map")
+		void test2() {
+			TapTable tapTable = new TapTable("test");
+			assertDoesNotThrow(() -> TapTableUtil.sortFieldMap(tapTable));
+			assertNull(tapTable.getNameFieldMap());
+			tapTable.setNameFieldMap(new LinkedHashMap<>());
+			assertDoesNotThrow(() -> TapTableUtil.sortFieldMap(tapTable));
+		}
+	}
+}


### PR DESCRIPTION
…e same with datasource load schema, but it's not same now

Closes TAP-5369