### PR TITLE
fix: TAP-6818 TapData has been upgraded from a low version (3.10.0) t…

### DIFF
--- a/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/node/hazelcast/data/pdk/HazelcastTargetPdkBaseNode.java
+++ b/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/node/hazelcast/data/pdk/HazelcastTargetPdkBaseNode.java
@@ -246,19 +246,19 @@ public abstract class HazelcastTargetPdkBaseNode extends HazelcastPdkBaseNode {
 	@Override
 	protected void readBatchOffset(SyncProgress syncProgress) {
 		try {
-			callSuperReadBatchOffset(syncProgress);
+			super.readBatchOffset(syncProgress);
 		} catch (CoreException e) {
-			if (null != e.getMessage() && e.getMessage().contains("ClassNotFoundException")) {
-				obsLogger.warn("Decode batch offset failed, as class not found, will ignore, message: {}", e.getMessage());
-				syncProgress.setBatchOffsetObj(new HashMap<>());
-			} else {
-				throw new TapCodeException(e.getMessage(), e);
-			}
+			errorHandle(syncProgress, e);
 		}
 	}
 
-	protected void callSuperReadBatchOffset(SyncProgress syncProgress) {
-		super.readBatchOffset(syncProgress);
+	protected void errorHandle(SyncProgress syncProgress, CoreException e) {
+		if (null != e.getMessage() && e.getMessage().contains("ClassNotFoundException")) {
+			obsLogger.warn("Decode batch offset failed, as class not found, will ignore, message: {}", e.getMessage());
+			syncProgress.setBatchOffsetObj(new HashMap<>());
+		} else {
+			throw new TapCodeException(e.getMessage(), e);
+		}
 	}
 
 	protected void initCodecsFilterManager() {

--- a/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/node/hazelcast/data/pdk/HazelcastTargetPdkBaseNode.java
+++ b/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/node/hazelcast/data/pdk/HazelcastTargetPdkBaseNode.java
@@ -37,6 +37,7 @@ import io.tapdata.aspect.supervisor.DataNodeThreadGroupAspect;
 import io.tapdata.aspect.taskmilestones.*;
 import io.tapdata.aspect.utils.AspectUtils;
 import io.tapdata.entity.codec.filter.TapCodecsFilterManager;
+import io.tapdata.entity.error.CoreException;
 import io.tapdata.entity.event.TapBaseEvent;
 import io.tapdata.entity.event.TapEvent;
 import io.tapdata.entity.event.ddl.TapDDLEvent;
@@ -240,6 +241,24 @@ public abstract class HazelcastTargetPdkBaseNode extends HazelcastPdkBaseNode {
 				syncProgressMap.put(entry.getKey(), entry.getValue());
 			}
 		}
+	}
+
+	@Override
+	protected void readBatchOffset(SyncProgress syncProgress) {
+		try {
+			callSuperReadBatchOffset(syncProgress);
+		} catch (CoreException e) {
+			if (null != e.getMessage() && e.getMessage().contains("ClassNotFoundException")) {
+				obsLogger.warn("Decode batch offset failed, as class not found, will ignore, message: {}", e.getMessage());
+				syncProgress.setBatchOffsetObj(new HashMap<>());
+			} else {
+				throw new TapCodeException(e.getMessage(), e);
+			}
+		}
+	}
+
+	protected void callSuperReadBatchOffset(SyncProgress syncProgress) {
+		super.readBatchOffset(syncProgress);
 	}
 
 	protected void initCodecsFilterManager() {


### PR DESCRIPTION
…o a high version (3.27.0), and many tasks have encountered errors where classes cannot be found java.lang.ClassNotFoundException: io.tapdata.dummy.po.DummyOffset