### PR TITLE
fix: TAP-8268 Fix the exception of the import verification task if th…

### DIFF
--- a/manager/tm/src/main/java/com/tapdata/tm/task/service/TaskServiceImpl.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/task/service/TaskServiceImpl.java
@@ -1899,40 +1899,27 @@ public class TaskServiceImpl extends TaskService{
     }
 
     public Node getSourceNode(TaskDto taskDto) {
-        DAG dag = taskDto.getDag();
-        if (dag == null) {
-            return null;
-        }
-
-        List<Edge> edges = dag.getEdges();
-        if (CollectionUtils.isNotEmpty(edges)) {
-            Edge edge = edges.get(0);
-            String source = edge.getSource();
-            List<Node> nodeList = taskDto.getDag().getNodes();
-            if (CollectionUtils.isNotEmpty(nodeList)) {
-                List<Node> sourceList = nodeList.stream().filter(Node -> null != Node && null != Node.getId() && source.equals(Node.getId())).collect(Collectors.toList());
-                if (CollectionUtils.isNotEmpty(sourceList) && null != sourceList.get(0)) {
-                    return sourceList.get(0);
+        return Optional.ofNullable(taskDto.getDag())
+            .map(DAG::getSourceNode)
+            .map(nodes -> {
+                if (nodes.isEmpty()) {
+                    return null;
                 }
-            }
-        }
-        return null;
+                return nodes.getFirst();
+            })
+            .orElse(null);
     }
 
     public Node getTargetNode(TaskDto taskDto) {
-        List<Edge> edges = taskDto.getDag().getEdges();
-        if (CollectionUtils.isNotEmpty(edges)) {
-            Edge edge = edges.get(0);
-            String target = edge.getTarget();
-            List<Node> nodeList = taskDto.getDag().getNodes();
-            if (CollectionUtils.isNotEmpty(nodeList)) {
-                List<Node> sourceList = nodeList.stream().filter(Node -> null != Node && null != Node.getId() && target.equals(Node.getId())).collect(Collectors.toList());
-                if (CollectionUtils.isNotEmpty(sourceList) && null != sourceList.get(0)) {
-                    return sourceList.get(0);
+        return Optional.ofNullable(taskDto.getDag())
+            .map(DAG::getTargetNode)
+            .map(nodes -> {
+                if (nodes.isEmpty()) {
+                    return null;
                 }
-            }
-        }
-        return null;
+                return nodes.getFirst();
+            })
+            .orElse(null);
     }
 
     public static String printInfos(DAG dag) {

--- a/manager/tm/src/test/java/com/tapdata/tm/task/service/TaskServiceImplTest.java
+++ b/manager/tm/src/test/java/com/tapdata/tm/task/service/TaskServiceImplTest.java
@@ -1796,22 +1796,18 @@ class TaskServiceImplTest {
         }
         @Test
         @DisplayName("test getSourceNode method normal")
-        void test2(){
-            DAG dag = mock(DAG.class);
-            LinkedList<Edge> edges = new LinkedList();
-            Edge edge = mock(Edge.class);
-            edges.add(edge);
-            when(edge.getSource()).thenReturn("111");
-            when(dag.getEdges()).thenReturn(edges);
-            List<Node> nodeList = new ArrayList<>();
+        void test2() {
+            // mock data
             Node node = mock(Node.class);
-            nodeList.add(node);
-            when(node.getId()).thenReturn("111");
-            when(dag.getNodes()).thenReturn(nodeList);
-            when(taskDto.getDag()).thenReturn(dag);
+            DAG dag = mock(DAG.class);
+
+            // mock method
+            doReturn(Arrays.asList(node)).when(dag).getSourceNode();
             doCallRealMethod().when(taskService).getSourceNode(taskDto);
+
+            // call method
             Node actual = taskService.getSourceNode(taskDto);
-            assertEquals(nodeList.get(0),actual);
+            assertEquals(node, actual);
         }
         @Test
         @DisplayName("test getSourceNode method when edges is empty")
@@ -1835,21 +1831,17 @@ class TaskServiceImplTest {
         @Test
         @DisplayName("test getTargetNode method normal")
         void test1(){
-            DAG dag = mock(DAG.class);
-            LinkedList<Edge> edges = new LinkedList();
-            Edge edge = mock(Edge.class);
-            edges.add(edge);
-            when(edge.getTarget()).thenReturn("111");
-            when(dag.getEdges()).thenReturn(edges);
-            List<Node> nodeList = new ArrayList<>();
+            // mock data
             Node node = mock(Node.class);
-            nodeList.add(node);
-            when(node.getId()).thenReturn("111");
-            when(dag.getNodes()).thenReturn(nodeList);
-            when(taskDto.getDag()).thenReturn(dag);
+            DAG dag = mock(DAG.class);
+
+            // mock method
+            doReturn(Arrays.asList(node)).when(dag).getTargetNode();
             doCallRealMethod().when(taskService).getTargetNode(taskDto);
+
+            // call method
             Node actual = taskService.getTargetNode(taskDto);
-            assertEquals(nodeList.get(0),actual);
+            assertEquals(node, actual);
         }
         @Test
         @DisplayName("test getTargetNode method when edges is empty")


### PR DESCRIPTION
…e synchronization task contains non-data nodes

the error: System error: class com.tapdata.tm.commons.dag.processs. MigrateTypeFilterProcessor Node cannot be cast to class com.tapdata.tm.commons.dag.nodes.DataParentNode