### PR TITLE
fix:Target model compare. target node does not load the model to get …

### DIFF
--- a/manager/tm/src/main/java/com/tapdata/tm/metadatainstance/service/MetadataInstancesCompareServiceImpl.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/metadatainstance/service/MetadataInstancesCompareServiceImpl.java
@@ -680,10 +680,12 @@ public class MetadataInstancesCompareServiceImpl extends MetadataInstancesCompar
     /**
      * Creates an empty comparison result when no target metadata instances are found
      */
-    private MetadataInstancesCompareResult createEmptyComparisonResult(Long targetSchemaLoadTime) {
+    protected MetadataInstancesCompareResult createEmptyComparisonResult(Long targetSchemaLoadTime) {
         MetadataInstancesCompareResult result = new MetadataInstancesCompareResult();
         result.setDifferentFieldNumberMap(null);
-        result.setTargetSchemaLoadTime(DateUtil.date(targetSchemaLoadTime));
+        if(null != targetSchemaLoadTime){
+            result.setTargetSchemaLoadTime(DateUtil.date(targetSchemaLoadTime));
+        }
         return result;
     }
 

--- a/manager/tm/src/test/java/com/tapdata/tm/metadatainstance/service/MetadataInstancesCompareServiceImplTest.java
+++ b/manager/tm/src/test/java/com/tapdata/tm/metadatainstance/service/MetadataInstancesCompareServiceImplTest.java
@@ -1109,6 +1109,29 @@ class MetadataInstancesCompareServiceImplTest {
             assertTrue(result.isEmpty());
         }
     }
+    @Nested
+    @DisplayName("CreateEmptyComparisonResult Tests")
+    class CreateEmptyComparisonResultTest{
+        @Test
+        @DisplayName("Should create empty comparison result with target schema load time")
+        void testCreateEmptyComparisonResult_WithTargetSchemaLoadTime() {
+            // Given
+            Long targetSchemaLoadTime = System.currentTimeMillis();
+            MetadataInstancesCompareResult result = service.createEmptyComparisonResult(targetSchemaLoadTime);
+            assertNotNull(result);
+            assertEquals(targetSchemaLoadTime, result.getTargetSchemaLoadTime().getTime());
+        }
+
+        @Test
+        @DisplayName("Should create empty comparison result with null target schema load time")
+        void testCreateEmptyComparisonResult_WithNullTargetSchemaLoadTime() {
+            // Given
+            MetadataInstancesCompareResult result = service.createEmptyComparisonResult(null);
+            assertNotNull(result);
+            assertNull(result.getTargetSchemaLoadTime());
+        }
+
+    }
 
     // Helper method to create mock MetadataInstancesDto
     private MetadataInstancesDto createMockMetadataInstancesDto(String tableName, String qualifiedName) {


### PR DESCRIPTION
…targetSchemaLoadTime is empty