### PR TITLE
Chore(ci): update file server domain

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Patch Maven Dependens
         run: |
           echo "${{ secrets.RSYNC_PASSWORD }}" > /tmp/rsync.passwd && chmod 600 /tmp/rsync.passwd
-          rsync --delete --password-file=/tmp/rsync.passwd -avz rsync://root@fileserver.tapdata.io:873/data/enterprise-temp/tapdata/ /root/.m2/
+          rsync --delete --password-file=/tmp/rsync.passwd -avz rsync://root@fileserver.tapdata.net:873/data/enterprise-temp/tapdata/ /root/.m2/
       - name: Checkout Tapdata Repo
         run: |
           rm -rf tapdata
@@ -93,7 +93,7 @@ jobs:
           mkdir -p version/${{ needs.Set-Branch.outputs.TAG_NAME }}/
           echo "- tapdata: ${{ needs.Set-Branch.outputs.TAPDATA_BRANCH }} $tapdata_version" > version/${{ needs.Set-Branch.outputs.TAG_NAME }}/tapdata.version
           echo "Gotapd8!" > /tmp/rsync.passwd && chmod 600 /tmp/rsync.passwd
-          rsync -r --password-file=/tmp/rsync.passwd version/* rsync://root@fileserver.tapdata.io:873/data/version/
+          rsync -r --password-file=/tmp/rsync.passwd version/* rsync://root@fileserver.tapdata.net:873/data/version/
       - name: compile opensource tapdata
         run: |
           cd tapdata
@@ -109,7 +109,7 @@ jobs:
           mkdir -p $temp_dir
           cp -r output/* $temp_dir/
           echo "${{ secrets.RSYNC_PASSWORD }}" > /tmp/rsync.passwd && chmod 600 /tmp/rsync.passwd
-          rsync -r --password-file=/tmp/rsync.passwd temp/ rsync://root@fileserver.tapdata.io:873/data/temp/
+          rsync -r --password-file=/tmp/rsync.passwd temp/ rsync://root@fileserver.tapdata.net:873/data/temp/
 
   Build-Connectors:
     runs-on: office-scan
@@ -132,7 +132,7 @@ jobs:
       - name: Patch Maven Dependens
         run: |
           echo "${{ secrets.RSYNC_PASSWORD }}" > /tmp/rsync.passwd && chmod 600 /tmp/rsync.passwd
-          rsync --delete --password-file=/tmp/rsync.passwd -avz rsync://root@fileserver.tapdata.io:873/data/enterprise-temp/tapdata/ /root/.m2/
+          rsync --delete --password-file=/tmp/rsync.passwd -avz rsync://root@fileserver.tapdata.net:873/data/enterprise-temp/tapdata/ /root/.m2/
       - name: Checkout Connectors Code
         run: |
           rm -rf tapdata-connectors
@@ -144,7 +144,7 @@ jobs:
           mkdir -p version/${{ needs.Set-Branch.outputs.TAG_NAME }}/
           echo "- tapdata-connectors: ${{ inputs.connectors_branch }} $tapdata_connectors_version" > version/${{ needs.Set-Branch.outputs.TAG_NAME }}/tapdata-connectors.version
           echo "Gotapd8!" > /tmp/rsync.passwd && chmod 600 /tmp/rsync.passwd
-          rsync -r --password-file=/tmp/rsync.passwd version/* rsync://root@fileserver.tapdata.io:873/data/version/
+          rsync -r --password-file=/tmp/rsync.passwd version/* rsync://root@fileserver.tapdata.net:873/data/version/
       - name: compile tapdata connectors
         run: |
           cd tapdata
@@ -160,7 +160,7 @@ jobs:
           mkdir -p $temp_dir
           cp -r output/* $temp_dir/
           echo "${{ secrets.RSYNC_PASSWORD }}" > /tmp/rsync.passwd && chmod 600 /tmp/rsync.passwd
-          rsync -r --password-file=/tmp/rsync.passwd temp/ rsync://root@fileserver.tapdata.io:873/data/temp/
+          rsync -r --password-file=/tmp/rsync.passwd temp/ rsync://root@fileserver.tapdata.net:873/data/temp/
 
   Build-Frontend:
     runs-on: office-scan
@@ -198,7 +198,7 @@ jobs:
           mkdir -p version/${{ needs.Set-Branch.outputs.TAG_NAME }}/
           echo "- tapdata-enterprise-web: ${{ inputs.frontend_branch }} $tapdata_enterprise_web_version" > version/${{ needs.Set-Branch.outputs.TAG_NAME }}/tapdata-enterprise-web.version
           echo "Gotapd8!" > /tmp/rsync.passwd && chmod 600 /tmp/rsync.passwd
-          rsync -r --password-file=/tmp/rsync.passwd version/* rsync://root@fileserver.tapdata.io:873/data/version/
+          rsync -r --password-file=/tmp/rsync.passwd version/* rsync://root@fileserver.tapdata.net:873/data/version/
       - name: Build Frontend
         run: |
           cd tapdata && bash build/build.sh -c frontend -t ${{ needs.Set-Branch.outputs.TAG_NAME }}
@@ -214,7 +214,7 @@ jobs:
           mkdir -p $temp_dir
           cp -r output/* $temp_dir/
           echo "${{ secrets.RSYNC_PASSWORD }}" > /tmp/rsync.passwd && chmod 600 /tmp/rsync.passwd
-          rsync -r --password-file=/tmp/rsync.passwd temp/ rsync://root@fileserver.tapdata.io:873/data/temp/
+          rsync -r --password-file=/tmp/rsync.passwd temp/ rsync://root@fileserver.tapdata.net:873/data/temp/
 
   Build-Image:
     runs-on: office-scan
@@ -244,7 +244,7 @@ jobs:
           cd tapdata
           echo "${{ secrets.RSYNC_PASSWORD }}" > /tmp/rsync.passwd && chmod 600 /tmp/rsync.passwd
           mkdir -p output
-          rsync -r --links --progress --password-file=/tmp/rsync.passwd rsync://root@fileserver.tapdata.io:873/data/temp/${{ needs.Set-Branch.outputs.TAG_NAME }}/ output/
+          rsync -r --links --progress --password-file=/tmp/rsync.passwd rsync://root@fileserver.tapdata.net:873/data/temp/${{ needs.Set-Branch.outputs.TAG_NAME }}/ output/
           echo '${{ secrets.HARBOR_PASS }}' | docker login harbor.internal.tapdata.io --username=${{ secrets.HARBOR_USER }} --password-stdin
           bash build/build.sh -o docker -t ${{ needs.Set-Branch.outputs.TAG_NAME }}
       - name: Print Image Info
@@ -260,7 +260,7 @@ jobs:
       - name: Add Commit ID and Version Map
         run: |
           echo "${{ secrets.RSYNC_PASSWORD }}" > /tmp/rsync.passwd && chmod 600 /tmp/rsync.passwd
-          rsync -r --progress --password-file=/tmp/rsync.passwd rsync://root@fileserver.tapdata.io:873/data/version/${{ needs.Set-Branch.outputs.TAG_NAME }}/ ./
+          rsync -r --progress --password-file=/tmp/rsync.passwd rsync://root@fileserver.tapdata.net:873/data/version/${{ needs.Set-Branch.outputs.TAG_NAME }}/ ./
           echo "## ${{ needs.Set-Branch.outputs.TAG_NAME }}" >> tapdata-application/README.md
           cat tapdata.version >> tapdata-application/README.md
           cat tapdata-enterprise-web.version >> tapdata-application/README.md
@@ -301,12 +301,12 @@ jobs:
           cd tapdata
           echo "${{ secrets.RSYNC_PASSWORD }}" > /tmp/rsync.passwd && chmod 600 /tmp/rsync.passwd
           mkdir -p output
-          rsync -r --links --progress --password-file=/tmp/rsync.passwd rsync://root@fileserver.tapdata.io:873/data/temp/${{ needs.Set-Branch.outputs.TAG_NAME }}/ output/
+          rsync -r --links --progress --password-file=/tmp/rsync.passwd rsync://root@fileserver.tapdata.net:873/data/temp/${{ needs.Set-Branch.outputs.TAG_NAME }}/ output/
           bash build/build.sh -o tar -t ${{ needs.Set-Branch.outputs.TAG_NAME }} -m x86_64
-          rsync -r --progress --password-file=/tmp/rsync.passwd output/tapdata-x86_64-${{ needs.Set-Branch.outputs.TAG_NAME }}.tar.gz rsync://root@fileserver.tapdata.io:873/data/enterprise-artifact/gz/
+          rsync -r --progress --password-file=/tmp/rsync.passwd output/tapdata-x86_64-${{ needs.Set-Branch.outputs.TAG_NAME }}.tar.gz rsync://root@fileserver.tapdata.net:873/data/enterprise-artifact/gz/
           rm -rf output/tapdata-x86_64-${{ needs.Set-Branch.outputs.TAG_NAME }}.tar.gz
           bash build/build.sh -o tar -t ${{ needs.Set-Branch.outputs.TAG_NAME }} -m arm64
-          rsync -r --progress --password-file=/tmp/rsync.passwd output/tapdata-arm64-${{ needs.Set-Branch.outputs.TAG_NAME }}.tar.gz rsync://root@fileserver.tapdata.io:873/data/enterprise-artifact/gz/
+          rsync -r --progress --password-file=/tmp/rsync.passwd output/tapdata-arm64-${{ needs.Set-Branch.outputs.TAG_NAME }}.tar.gz rsync://root@fileserver.tapdata.net:873/data/enterprise-artifact/gz/
 
   Clean-Build-Temp:
     runs-on: office-scan
@@ -321,4 +321,4 @@ jobs:
         run: |
           mkdir -p temp/${{ needs.Set-Branch.outputs.TAG_NAME }}/
           echo "${{ secrets.RSYNC_PASSWORD }}" > /tmp/rsync.passwd && chmod 600 /tmp/rsync.passwd
-          rsync -r --delete --password-file=/tmp/rsync.passwd temp/${{ needs.Set-Branch.outputs.TAG_NAME }}/ rsync://root@fileserver.tapdata.io:873/data/temp/${{ needs.Set-Branch.outputs.TAG_NAME }}/
+          rsync -r --delete --password-file=/tmp/rsync.passwd temp/${{ needs.Set-Branch.outputs.TAG_NAME }}/ rsync://root@fileserver.tapdata.net:873/data/temp/${{ needs.Set-Branch.outputs.TAG_NAME }}/

--- a/.github/workflows/mr-ci.yaml
+++ b/.github/workflows/mr-ci.yaml
@@ -143,7 +143,7 @@ jobs:
       - name: Patch Maven Dependens
         run: |
           echo "Gotapd8!" > /tmp/rsync.passwd && chmod 600 /tmp/rsync.passwd
-          rsync --delete --password-file=/tmp/rsync.passwd -avz rsync://root@fileserver.tapdata.io:873/data/enterprise-temp/tapdata/ /root/.m2/
+          rsync --delete --password-file=/tmp/rsync.passwd -avz rsync://root@fileserver.tapdata.net:873/data/enterprise-temp/tapdata/ /root/.m2/
       - name: Build Tapdata - And Analyze
         env:
           GITHUB_TOKEN: ${{ secrets.TAPDATA_ENT_CICD_TOKEN }}


### PR DESCRIPTION
Change CI rsync endpoints in the build and merge-request workflows from fileserver.tapdata.io to fileserver.tapdata.net for Maven cache patching, version metadata synchronization, temporary build artifact transfer, and enterprise package publishing.

This keeps CI workflows aligned with the new file server domain and prevents jobs from continuing to depend on the old fileserver.tapdata.io endpoint after the domain migration.