### PR TITLE
Fix(task): TAP-11386 expose heartbeat task running state in task resp…

### DIFF
--- a/manager/tm-api/src/main/java/com/tapdata/tm/task/service/TaskService.java
+++ b/manager/tm-api/src/main/java/com/tapdata/tm/task/service/TaskService.java
@@ -207,6 +207,14 @@ public abstract class TaskService extends BaseService<TaskDto, TaskEntity, Objec
 
     public abstract List<TaskDto> findAllTasksByIds(List<String> list);
 
+    public abstract Boolean getHeartbeatTaskRunningByTaskId(String taskId);
+
+    public abstract Map<String, Boolean> batchGetHeartbeatTaskRunningByTaskIds(List<String> taskIds);
+
+    public abstract void appendHeartbeatTaskRunning(TaskDto taskDto);
+
+    public abstract void appendHeartbeatTaskRunning(List<TaskDto> taskDtos);
+
     public abstract void renewAgentMeasurement(String taskId);
 
     public abstract UpdateResult renewNotSendMq(TaskDto taskDto, UserDetail user);

--- a/manager/tm-api/src/main/java/com/tapdata/tm/task/vo/TaskDetailVo.java
+++ b/manager/tm-api/src/main/java/com/tapdata/tm/task/vo/TaskDetailVo.java
@@ -58,4 +58,6 @@ public class TaskDetailVo extends BaseVo {
 
     private String type;
 
+    private Boolean heartbeatTaskRunning;
+
 }

--- a/manager/tm-common/src/main/java/com/tapdata/tm/commons/task/dto/TaskDto.java
+++ b/manager/tm-common/src/main/java/com/tapdata/tm/commons/task/dto/TaskDto.java
@@ -177,6 +177,7 @@ public class TaskDto extends ParentTaskDto implements IDataPermissionDto {
     /** 使用的共享挖掘任务停止 */
     private Boolean shareCdcStop;
     private String shareCdcStopMessage;
+    private Boolean heartbeatTaskRunning;
     private Long delayTime;
     /** 任务增量延迟告警的当前最大延迟 */
     private Long taskIncrementDelay;

--- a/manager/tm-common/src/main/java/com/tapdata/tm/commons/util/ConnHeartbeatUtils.java
+++ b/manager/tm-common/src/main/java/com/tapdata/tm/commons/util/ConnHeartbeatUtils.java
@@ -27,6 +27,11 @@ public class ConnHeartbeatUtils {
     public static final String CONNECTION_NAME = "tapdata_heartbeat_dummy_connection";
     public static final String TABLE_NAME = "_tapdata_heartbeat_table";
     public static final String TASK_RELATION_FIELD = "heartbeatTasks";
+    public static final Set<String> TASK_RUNNING_STATUSES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+            TaskDto.STATUS_SCHEDULING,
+            TaskDto.STATUS_WAIT_RUN,
+            TaskDto.STATUS_RUNNING
+    )));
 
     private ConnHeartbeatUtils() {
     }
@@ -164,5 +169,9 @@ public class ConnHeartbeatUtils {
             }});
         }});
         return heartbeatConnection;
+    }
+
+    public static boolean isTaskRunningStatus(String status) {
+        return TASK_RUNNING_STATUSES.contains(status);
     }
 }

--- a/manager/tm/src/main/java/com/tapdata/tm/task/controller/TaskController.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/task/controller/TaskController.java
@@ -214,6 +214,9 @@ public class TaskController extends BaseController {
         Page<TaskDto> result = DataPermissionMenuEnums.checkAndSetFilter(
             userDetail, filter, DataPermissionActionEnums.View, () -> taskService.find(finalFilter, userDetail)
         );
+        if (result != null) {
+            taskService.appendHeartbeatTaskRunning(result.getItems());
+        }
         return success(result);
     }
 
@@ -365,6 +368,7 @@ public class TaskController extends BaseController {
 		) {
 			Field fields = parseField(fieldsJson);
 			UserDetail user = getLoginUser();
+            ObjectId oid = MongoUtils.toObjectId(id);
             Field finalFields;
             if(null == fields){
                 finalFields = new Field();
@@ -373,8 +377,8 @@ public class TaskController extends BaseController {
             }
             finalFields.put("errorEvents.stacks",false);
             finalFields.put("attrs.SNAPSHOT_ORDER_LIST",false);
-			TaskDto taskDto = dataPermissionCheckOfId(request, user, MongoUtils.toObjectId(id), DataPermissionActionEnums.View,
-				() -> taskService.findById(MongoUtils.toObjectId(id), finalFields, user)
+			TaskDto taskDto = dataPermissionCheckOfId(request, user, oid, DataPermissionActionEnums.View,
+				() -> taskService.findById(oid, finalFields, user)
 			);
 			if (taskDto != null) {
 				if (StringUtils.isNotBlank(taskRecordId) && !taskRecordId.equals(taskDto.getTaskRecordId())) {
@@ -401,6 +405,7 @@ public class TaskController extends BaseController {
 					taskDto.setCrontabScheduleMsg(MessageUtil.getMessage(taskDto.getCrontabScheduleMsg()));
 				}
                 taskService.checkSourceTimeDifference(taskDto,user);
+                taskDto.setHeartbeatTaskRunning(taskService.getHeartbeatTaskRunningByTaskId(oid.toHexString()));
 			}
 			return success(taskDto);
 		}
@@ -413,10 +418,15 @@ public class TaskController extends BaseController {
      */
     @Operation(summary = "获取任务详情")
     @GetMapping("findTaskDetailById/{id}")
-    public ResponseMessage<TaskDetailVo> findTaskDetailById(@PathVariable("id") String id,
-                                                            @RequestParam(value = "fields", required = false) String fieldsJson) {
+    public ResponseMessage<TaskDetailVo> findTaskDetailById(
+        @PathVariable("id") String id,
+        @RequestParam(value = "fields", required = false) String fieldsJson
+    ) {
         Field fields = parseField(fieldsJson);
         TaskDetailVo taskDetailVo = taskService.findTaskDetailById(id, fields, getLoginUser());
+        if (taskDetailVo != null) {
+            taskDetailVo.setHeartbeatTaskRunning(taskService.getHeartbeatTaskRunningByTaskId(id));
+        }
         return success(taskDetailVo);
     }
 

--- a/manager/tm/src/main/java/com/tapdata/tm/task/service/TaskServiceImpl.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/task/service/TaskServiceImpl.java
@@ -5563,6 +5563,98 @@ public class TaskServiceImpl extends TaskService{
         return findOne(query);
     }
 
+    @Override
+    public Boolean getHeartbeatTaskRunningByTaskId(String taskId) {
+        if (StringUtils.isBlank(taskId)) {
+            return null;
+        }
+        Map<String, Boolean> result = batchGetHeartbeatTaskRunningByTaskIds(Collections.singletonList(taskId));
+        return result.get(taskId);
+    }
+
+    @Override
+    public Map<String, Boolean> batchGetHeartbeatTaskRunningByTaskIds(List<String> taskIds) {
+        if (CollectionUtils.isEmpty(taskIds)) {
+            return Collections.emptyMap();
+        }
+        LinkedHashSet<String> uniqueTaskIds = taskIds.stream()
+                .filter(StringUtils::isNotBlank)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+        if (CollectionUtils.isEmpty(uniqueTaskIds)) {
+            return Collections.emptyMap();
+        }
+        Map<String, Optional<Boolean>> loadedValues = loadHeartbeatTaskRunning(new ArrayList<>(uniqueTaskIds));
+        Map<String, Boolean> result = new LinkedHashMap<>();
+        uniqueTaskIds.forEach(taskId -> result.put(taskId, loadedValues.getOrDefault(taskId, Optional.empty()).orElse(null)));
+        return result;
+    }
+
+    @Override
+    public void appendHeartbeatTaskRunning(TaskDto taskDto) {
+        if (taskDto == null || taskDto.getId() == null) {
+            return;
+        }
+        taskDto.setHeartbeatTaskRunning(getHeartbeatTaskRunningByTaskId(taskDto.getId().toHexString()));
+    }
+
+    @Override
+    public void appendHeartbeatTaskRunning(List<TaskDto> taskDtos) {
+        if (CollectionUtils.isEmpty(taskDtos)) {
+            return;
+        }
+        List<TaskDto> validTasks = taskDtos.stream()
+                .filter(Objects::nonNull)
+                .filter(taskDto -> taskDto.getId() != null)
+                .collect(Collectors.toList());
+        if (CollectionUtils.isEmpty(validTasks)) {
+            return;
+        }
+        Map<String, Boolean> heartbeatTaskRunningMap = batchGetHeartbeatTaskRunningByTaskIds(validTasks.stream()
+                .map(taskDto -> taskDto.getId().toHexString())
+                .collect(Collectors.toList()));
+        validTasks.forEach(taskDto -> taskDto.setHeartbeatTaskRunning(
+                heartbeatTaskRunningMap.get(taskDto.getId().toHexString())
+        ));
+    }
+
+    private Map<String, Optional<Boolean>> loadHeartbeatTaskRunning(List<String> taskIds) {
+        Map<String, Optional<Boolean>> result = new LinkedHashMap<>();
+        taskIds.forEach(taskId -> result.put(taskId, Optional.empty()));
+
+        Query query = Query.query(Criteria.where(ConnHeartbeatUtils.TASK_RELATION_FIELD).in(taskIds)
+                .and(SYNC_TYPE).is(TaskDto.SYNC_TYPE_CONN_HEARTBEAT)
+                .and(IS_DELETED).is(false));
+        query.fields().include(ConnHeartbeatUtils.TASK_RELATION_FIELD, STATUS);
+
+        List<TaskDto> heartbeatTasks = findAll(query);
+        if (CollectionUtils.isEmpty(heartbeatTasks)) {
+            return result;
+        }
+
+        Set<String> taskIdSet = new HashSet<>(taskIds);
+        for (TaskDto heartbeatTask : heartbeatTasks) {
+            boolean running = isHeartbeatTaskRunning(heartbeatTask.getStatus());
+            if (CollectionUtils.isEmpty(heartbeatTask.getHeartbeatTasks())) {
+                continue;
+            }
+            for (String relatedTaskId : heartbeatTask.getHeartbeatTasks()) {
+                if (!taskIdSet.contains(relatedTaskId)) {
+                    continue;
+                }
+                if (!running) {
+                    result.put(relatedTaskId, Optional.of(false));
+                } else if (!result.getOrDefault(relatedTaskId, Optional.empty()).isPresent()) {
+                    result.put(relatedTaskId, Optional.of(true));
+                }
+            }
+        }
+        return result;
+    }
+
+    private boolean isHeartbeatTaskRunning(String status) {
+        return ConnHeartbeatUtils.isTaskRunningStatus(status);
+    }
+
     public int deleteHeartbeatByConnId(UserDetail user, String connId) {
         int deleteSize = 0;
         List<TaskDto> heartbeatTasks = findHeartbeatByConnectionId(connId, "_id", STATUS, IS_DELETED);

--- a/manager/tm/src/test/java/com/tapdata/tm/task/service/TaskServiceImplTest.java
+++ b/manager/tm/src/test/java/com/tapdata/tm/task/service/TaskServiceImplTest.java
@@ -5920,6 +5920,78 @@ class TaskServiceImplTest {
     }
 
     @Nested
+    class HeartbeatTaskRunningTest {
+        @Test
+        void testGetHeartbeatTaskRunningByTaskIdWhenHeartbeatMissing() {
+            doCallRealMethod().when(taskService).getHeartbeatTaskRunningByTaskId("task-1");
+            doCallRealMethod().when(taskService).batchGetHeartbeatTaskRunningByTaskIds(anyList());
+            when(taskService.findAll(any(Query.class))).thenReturn(Collections.emptyList());
+
+            assertNull(taskService.getHeartbeatTaskRunningByTaskId("task-1"));
+        }
+
+        @Test
+        void testGetHeartbeatTaskRunningByTaskIdWhenHeartbeatRunning() {
+            TaskDto heartbeatTask = new TaskDto();
+            heartbeatTask.setStatus(TaskDto.STATUS_RUNNING);
+            heartbeatTask.setHeartbeatTasks(new HashSet<>(Collections.singletonList("task-1")));
+
+            doCallRealMethod().when(taskService).getHeartbeatTaskRunningByTaskId("task-1");
+            doCallRealMethod().when(taskService).batchGetHeartbeatTaskRunningByTaskIds(anyList());
+            when(taskService.findAll(any(Query.class))).thenReturn(Collections.singletonList(heartbeatTask));
+
+            assertTrue(taskService.getHeartbeatTaskRunningByTaskId("task-1"));
+        }
+
+        @Test
+        void testGetHeartbeatTaskRunningByTaskIdWhenHeartbeatAbnormal() {
+            TaskDto heartbeatTask = new TaskDto();
+            heartbeatTask.setStatus(TaskDto.STATUS_ERROR);
+            heartbeatTask.setHeartbeatTasks(new HashSet<>(Collections.singletonList("task-1")));
+
+            doCallRealMethod().when(taskService).getHeartbeatTaskRunningByTaskId("task-1");
+            doCallRealMethod().when(taskService).batchGetHeartbeatTaskRunningByTaskIds(anyList());
+            when(taskService.findAll(any(Query.class))).thenReturn(Collections.singletonList(heartbeatTask));
+
+            assertFalse(taskService.getHeartbeatTaskRunningByTaskId("task-1"));
+        }
+
+        @Test
+        void testAppendHeartbeatTaskRunning() {
+            TaskDto taskDto = new TaskDto();
+            ObjectId objectId = new ObjectId();
+            taskDto.setId(objectId);
+
+            doCallRealMethod().when(taskService).appendHeartbeatTaskRunning(taskDto);
+            when(taskService.getHeartbeatTaskRunningByTaskId(objectId.toHexString())).thenReturn(Boolean.TRUE);
+
+            taskService.appendHeartbeatTaskRunning(taskDto);
+
+            assertEquals(Boolean.TRUE, taskDto.getHeartbeatTaskRunning());
+        }
+
+        @Test
+        void testAppendHeartbeatTaskRunningList() {
+            TaskDto task1 = new TaskDto();
+            task1.setId(new ObjectId());
+            TaskDto task2 = new TaskDto();
+            task2.setId(new ObjectId());
+
+            doCallRealMethod().when(taskService).appendHeartbeatTaskRunning(anyList());
+            when(taskService.batchGetHeartbeatTaskRunningByTaskIds(anyList())).thenReturn(new HashMap<String, Boolean>() {{
+                put(task1.getId().toHexString(), Boolean.TRUE);
+                put(task2.getId().toHexString(), null);
+            }});
+
+            taskService.appendHeartbeatTaskRunning(Arrays.asList(task1, task2));
+
+            assertEquals(Boolean.TRUE, task1.getHeartbeatTaskRunning());
+            assertNull(task2.getHeartbeatTaskRunning());
+        }
+
+    }
+
+    @Nested
     class CheckSourceTimeDifferenceTest{
 
         @Test


### PR DESCRIPTION
…onses

Add service helpers to evaluate whether a related heartbeat task is currently in a healthy scheduling or running state and expose that result through the existing task DTOs.

Route heartbeat status rule evaluation through ConnHeartbeatUtils, return the status by default in task list and task detail controller responses, and include focused service tests for the heartbeat status mapping logic.

Refs: TAP-11386