### PR TITLE
fix:TAP-11626 When there are multiple pieces of data in the master-sl…

### DIFF
--- a/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/node/hazelcast/processor/HazelcastMergeNode.java
+++ b/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/node/hazelcast/processor/HazelcastMergeNode.java
@@ -1866,11 +1866,14 @@ public class HazelcastMergeNode extends HazelcastProcessorBaseNode implements Me
 								lookupData = mockLookupMap(childMergeProperty);
 								mockData = true;
 							} else {
-								String firstKey = keySet.iterator().next();
-								lookupData = (Map<String, Object>) findData.get(firstKey);
+								String lastKey = null;
+								for (String key : keySet) {
+									lastKey = key;
+								}
+								lookupData = (Map<String, Object>) findData.get(lastKey);
 							}
 							if (keySet.size() > 1) {
-								nodeLogger.warn("Update write merge lookup, find more than one row, lookup table: {}, join key value: {}, will use first row: {}", tableName, joinValueKey, lookupData);
+								nodeLogger.warn("Update write merge lookup, find more than one row, lookup table: {}, join key value: {}, will use last row: {}", tableName, joinValueKey, lookupData);
 							}
 						}
 						mergeLookupResult.setSharedJoinKeys(shareJoinKeys);


### PR DESCRIPTION
…ave merge cache, the first entry is taken by default, while actually the last one is the latest.