### PR TITLE
Fix(task): TAP-11759 clear agent affinity before manual start

### DIFF
--- a/manager/tm-api/src/main/java/com/tapdata/tm/task/service/TaskService.java
+++ b/manager/tm-api/src/main/java/com/tapdata/tm/task/service/TaskService.java
@@ -221,6 +221,10 @@ public abstract class TaskService extends BaseService<TaskDto, TaskEntity, Objec
 
     public abstract boolean findAgent(TaskDto taskDto, UserDetail user);
 
+    public abstract void clearAgentAffinityForManualStart(ObjectId taskId, UserDetail user);
+
+    public abstract void clearAgentAffinityForManualStart(List<ObjectId> taskIds, UserDetail user);
+
     public abstract void start(ObjectId id, UserDetail user);
 
     public abstract void start(ObjectId id, UserDetail user, boolean system);

--- a/manager/tm/src/main/java/com/tapdata/tm/task/controller/CacheTaskController.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/task/controller/CacheTaskController.java
@@ -3,6 +3,7 @@ package com.tapdata.tm.task.controller;
 import com.tapdata.tm.base.controller.BaseController;
 import com.tapdata.tm.base.dto.*;
 import com.tapdata.tm.commons.task.dto.TaskDto;
+import com.tapdata.tm.config.security.UserDetail;
 import com.tapdata.tm.task.param.SaveShareCacheParam;
 import com.tapdata.tm.task.service.TaskService;
 import com.tapdata.tm.task.vo.ShareCacheDetailVo;
@@ -189,7 +190,10 @@ public class CacheTaskController extends BaseController {
     @Operation(summary = "启动同步任务")
     @PutMapping("start/{id}")
     public ResponseMessage<Void> start(@PathVariable("id") String id) {
-        taskService.start(MongoUtils.toObjectId(id), getLoginUser());
+        UserDetail userDetail = getLoginUser();
+        ObjectId objectId = MongoUtils.toObjectId(id);
+        taskService.clearAgentAffinityForManualStart(objectId, userDetail);
+        taskService.start(objectId, userDetail);
         return success();
     }
 
@@ -222,7 +226,9 @@ public class CacheTaskController extends BaseController {
                                                                  HttpServletRequest request,
                                                                  HttpServletResponse response) {
         List<ObjectId> taskObjectIds = taskIds.stream().map(MongoUtils::toObjectId).collect(Collectors.toList());
-        List<MutiResponseMessage> responseMessages = taskService.batchStart(taskObjectIds, getLoginUser(), request, response);
+        UserDetail userDetail = getLoginUser();
+        taskService.clearAgentAffinityForManualStart(taskObjectIds, userDetail);
+        List<MutiResponseMessage> responseMessages = taskService.batchStart(taskObjectIds, userDetail, request, response);
         return success(responseMessages);
     }
 

--- a/manager/tm/src/main/java/com/tapdata/tm/task/controller/TaskController.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/task/controller/TaskController.java
@@ -692,6 +692,7 @@ public class TaskController extends BaseController {
 			UserDetail userDetail = getLoginUser();
 			ObjectId objectId = MongoUtils.toObjectId(id);
 			dataPermissionCheckOfId(request, userDetail, objectId, DataPermissionActionEnums.Start, () -> {
+				taskService.clearAgentAffinityForManualStart(objectId, userDetail);
 				taskService.start(objectId, userDetail);
 				return null;
 			});
@@ -913,7 +914,10 @@ public class TaskController extends BaseController {
 			List<ObjectId> taskObjectIds = taskIds.stream().map(MongoUtils::toObjectId).collect(Collectors.toList());
             syncType = resolveSyncType(syncType, taskObjectIds);
 			List<MutiResponseMessage> responseMessages = dataPermissionCheckOfMenu(userDetail, syncType, DataPermissionActionEnums.Start,
-				() -> taskService.batchStart(taskObjectIds, userDetail, request, response)
+				() -> {
+					taskService.clearAgentAffinityForManualStart(taskObjectIds, userDetail);
+					return taskService.batchStart(taskObjectIds, userDetail, request, response);
+				}
 			);
 			return success(responseMessages);
 		}

--- a/manager/tm/src/main/java/com/tapdata/tm/task/service/TaskServiceImpl.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/task/service/TaskServiceImpl.java
@@ -4431,6 +4431,26 @@ public class TaskServiceImpl extends TaskService{
         return noAgent;
     }
 
+    @Override
+    public void clearAgentAffinityForManualStart(ObjectId taskId, UserDetail user) {
+        if (Objects.isNull(taskId)) {
+            return;
+        }
+        clearAgentAffinityForManualStart(Collections.singletonList(taskId), user);
+    }
+
+    @Override
+    public void clearAgentAffinityForManualStart(List<ObjectId> taskIds, UserDetail user) {
+        if (CollectionUtils.isEmpty(taskIds)) {
+            return;
+        }
+        Query query = Query.query(Criteria.where("_id").in(taskIds)
+                .and(STATUS).in(TaskOpStatusEnum.to_start_status.v())
+                .and(AGENT_ID).exists(true).ne(null)
+                .and("accessNodeType").ne(AccessNodeTypeEnum.MANUALLY_SPECIFIED_BY_THE_USER.name()));
+        Update update = new Update().unset(AGENT_ID).set("last_updated", new Date());
+        update(query, update, user);
+    }
 
     private String judgePostgreClearSlot(TaskDto taskDto, String opType) {
         Node node = getSourceNode(taskDto);

--- a/manager/tm/src/main/java/com/tapdata/tm/task/service/TaskServiceImpl.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/task/service/TaskServiceImpl.java
@@ -4448,7 +4448,9 @@ public class TaskServiceImpl extends TaskService{
                 .and(STATUS).in(TaskOpStatusEnum.to_start_status.v())
                 .and(AGENT_ID).exists(true).ne(null)
                 .and("accessNodeType").ne(AccessNodeTypeEnum.MANUALLY_SPECIFIED_BY_THE_USER.name()));
-        Update update = new Update().unset(AGENT_ID).set("last_updated", new Date());
+        Update update = new Update().unset(AGENT_ID)
+                .set("lastUpdBy", user.getUserId())
+                .set("last_updated", new Date());
         update(query, update, user);
     }
 

--- a/manager/tm/src/test/java/com/tapdata/tm/task/service/TaskServiceImplTest.java
+++ b/manager/tm/src/test/java/com/tapdata/tm/task/service/TaskServiceImplTest.java
@@ -86,6 +86,7 @@ import com.tapdata.tm.statemachine.model.StateMachineResult;
 import com.tapdata.tm.statemachine.service.StateMachineService;
 import com.tapdata.tm.task.bean.*;
 import com.tapdata.tm.task.constant.TableStatusEnum;
+import com.tapdata.tm.task.constant.TaskOpStatusEnum;
 import com.tapdata.tm.task.dto.CheckEchoOneNodeParam;
 import com.tapdata.tm.task.entity.TaskEntity;
 import com.tapdata.tm.task.entity.TaskRecord;
@@ -3398,6 +3399,57 @@ class TaskServiceImplTest {
             doCallRealMethod().when(taskService).findAgent(taskDto,user);
             taskService.findAgent(taskDto, user);
             assertEquals("work_1",taskDto.getAgentId());
+        }
+    }
+    @Nested
+    class ClearAgentAffinityForManualStartTest {
+        @Test
+        @DisplayName("test clearAgentAffinityForManualStart builds manual start affinity cleanup query")
+        void testClearAgentAffinityForManualStart() {
+            ObjectId taskId = new ObjectId();
+            doCallRealMethod().when(taskService).clearAgentAffinityForManualStart(any(ObjectId.class), any(UserDetail.class));
+            doCallRealMethod().when(taskService).clearAgentAffinityForManualStart(anyList(), any(UserDetail.class));
+
+            taskService.clearAgentAffinityForManualStart(taskId, user);
+
+            org.mockito.ArgumentCaptor<Query> queryCaptor = org.mockito.ArgumentCaptor.forClass(Query.class);
+            org.mockito.ArgumentCaptor<Update> updateCaptor = org.mockito.ArgumentCaptor.forClass(Update.class);
+            verify(taskService).update(queryCaptor.capture(), updateCaptor.capture(), eq(user));
+
+            Document query = queryCaptor.getValue().getQueryObject();
+            assertEquals(Collections.singletonList(taskId), ((Document) query.get("_id")).get("$in"));
+            assertEquals(TaskOpStatusEnum.to_start_status.v(), ((Document) query.get("status")).get("$in"));
+
+            Document agentIdCriteria = (Document) query.get(AGENT_ID);
+            assertEquals(Boolean.TRUE, agentIdCriteria.get("$exists"));
+            assertTrue(agentIdCriteria.containsKey("$ne"));
+
+            Document accessNodeTypeCriteria = (Document) query.get("accessNodeType");
+            assertEquals(AccessNodeTypeEnum.MANUALLY_SPECIFIED_BY_THE_USER.name(), accessNodeTypeCriteria.get("$ne"));
+
+            Document update = updateCaptor.getValue().getUpdateObject();
+            assertTrue(update.get("$unset", Document.class).containsKey(AGENT_ID));
+            assertTrue(update.get("$set", Document.class).containsKey("last_updated"));
+        }
+
+        @Test
+        @DisplayName("test clearAgentAffinityForManualStart ignores null task id")
+        void testClearAgentAffinityForManualStartWithNullId() {
+            doCallRealMethod().when(taskService).clearAgentAffinityForManualStart(any(ObjectId.class), any(UserDetail.class));
+
+            taskService.clearAgentAffinityForManualStart((ObjectId) null, user);
+
+            verify(taskService, never()).update(any(Query.class), any(Update.class), any(UserDetail.class));
+        }
+
+        @Test
+        @DisplayName("test clearAgentAffinityForManualStart ignores empty task ids")
+        void testClearAgentAffinityForManualStartWithEmptyIds() {
+            doCallRealMethod().when(taskService).clearAgentAffinityForManualStart(anyList(), any(UserDetail.class));
+
+            taskService.clearAgentAffinityForManualStart(Collections.emptyList(), user);
+
+            verify(taskService, never()).update(any(Query.class), any(Update.class), any(UserDetail.class));
         }
     }
     @Nested

--- a/manager/tm/src/test/java/com/tapdata/tm/task/service/TaskServiceImplTest.java
+++ b/manager/tm/src/test/java/com/tapdata/tm/task/service/TaskServiceImplTest.java
@@ -3407,6 +3407,7 @@ class TaskServiceImplTest {
         @DisplayName("test clearAgentAffinityForManualStart builds manual start affinity cleanup query")
         void testClearAgentAffinityForManualStart() {
             ObjectId taskId = new ObjectId();
+            when(user.getUserId()).thenReturn("userId");
             doCallRealMethod().when(taskService).clearAgentAffinityForManualStart(any(ObjectId.class), any(UserDetail.class));
             doCallRealMethod().when(taskService).clearAgentAffinityForManualStart(anyList(), any(UserDetail.class));
 
@@ -3430,6 +3431,7 @@ class TaskServiceImplTest {
             Document update = updateCaptor.getValue().getUpdateObject();
             assertTrue(update.get("$unset", Document.class).containsKey(AGENT_ID));
             assertTrue(update.get("$set", Document.class).containsKey("last_updated"));
+            assertEquals("userId", update.get("$set", Document.class).get("lastUpdBy"));
         }
 
         @Test


### PR DESCRIPTION
Clear persisted task agent affinity before user-triggered task starts so stopped tasks can use the normal scheduling path again. Apply the cleanup to single and batch manual start endpoints, including cache task starts, while preserving explicitly assigned engine tasks.

Add service-level tests for the manual-start affinity cleanup query and no-op cases.

Refs: TAP-11759