### PR TITLE
Fix(tm): TAP-11888 handle task HA rescheduling

### DIFF
--- a/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/monitor/impl/TaskPingTimeMonitor.java
+++ b/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/monitor/impl/TaskPingTimeMonitor.java
@@ -1,14 +1,17 @@
 package io.tapdata.flow.engine.V2.monitor.impl;
 
 import com.mongodb.client.result.UpdateResult;
+import com.tapdata.constant.BeanUtil;
 import com.tapdata.constant.ConnectorConstant;
 import com.tapdata.constant.ExecutorUtil;
 import com.tapdata.mongo.HttpClientMongoOperator;
 import com.tapdata.tm.commons.task.dto.TaskDto;
+import io.tapdata.common.SettingService;
 import io.tapdata.flow.engine.V2.task.TerminalMode;
 import io.tapdata.flow.engine.V2.util.ConsumerImpl;
 import io.tapdata.flow.engine.V2.util.SupplierImpl;
 import io.tapdata.pdk.core.utils.CommonUtils;
+import io.tapdata.utils.AppType;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
@@ -33,15 +36,15 @@ import static org.springframework.data.mongodb.core.query.Criteria.where;
  **/
 public class TaskPingTimeMonitor extends TaskMonitor<Object> {
 	private final static long PING_INTERVAL_MS = 5000L;
+	private static final long DEFAULT_TASK_HEART_TIMEOUT_MS = 60000L;
 	public static final String TAG = TaskPingTimeMonitor.class.getSimpleName();
 
 	private Logger logger = LogManager.getLogger(TaskPingTimeMonitor.class);
-	private ScheduledExecutorService executorService;
-	private HttpClientMongoOperator clientMongoOperator;
-	private Supplier<Boolean> stopTask;
-    private long failedStartTime = 0;
-
-	private Consumer<TerminalMode> taskMonitor;
+	private final ScheduledExecutorService executorService;
+	private final HttpClientMongoOperator clientMongoOperator;
+	private final Supplier<Boolean> stopTask;
+	private final Consumer<TerminalMode> taskMonitor;
+    private long latestSuccessPingTime = 0;
 
 	public TaskPingTimeMonitor(TaskDto taskDto, HttpClientMongoOperator clientMongoOperator, SupplierImpl<Boolean> stopTask, ConsumerImpl<TerminalMode> terminalMode) {
 		super(taskDto);
@@ -53,7 +56,7 @@ public class TaskPingTimeMonitor extends TaskMonitor<Object> {
 
 	@Override
 	public void start() {
-        failedStartTime = 0;
+		latestSuccessPingTime = System.currentTimeMillis();
 		// Always ping every PING_INTERVAL_MS (5s). TM treats pingTime older than
 		// JOB_HEART_TIMEOUT (≥25s) as a dead task; gating ping by heartExpire/2
 		// previously made the ping interval equal the timeout, leaving zero buffer
@@ -62,11 +65,12 @@ public class TaskPingTimeMonitor extends TaskMonitor<Object> {
 				() -> {
 					Thread.currentThread().setName("Task-PingTime-" + taskDto.getId().toHexString());
 
+					long now = System.currentTimeMillis();
 					Query query = new Query(where("_id").is(taskDto.getId())
 							.and("status").nin(TaskDto.STATUS_ERROR, TaskDto.STATUS_SCHEDULE_FAILED)
 							.and("agentId").is(taskDto.getAgentId())
 					);
-					Update update = new Update().set("pingTime", System.currentTimeMillis());
+					Update update = new Update().set("pingTime", now);
 					try {
 						taskPingTimeUseHttp(query, update);
 					} catch (Exception e) {
@@ -84,38 +88,54 @@ public class TaskPingTimeMonitor extends TaskMonitor<Object> {
 	}
 
 	public void taskPingTimeUseHttp(Query query, Update update) {
+		boolean isCloud = AppType.currentType().isCloud();
 		try {
 			UpdateResult updateResult = clientMongoOperator.update(query, update, ConnectorConstant.TASK_COLLECTION);
-			if (updateResult.getModifiedCount() == 0) {
-				// Self-stop on ownership loss for ALL profiles (cloud + DAAS). Previously cloud
-				// silently continued, which is the root cause of the dual-engine running window
-				// observed in HA drill tests.
-				logger.warn("TaskHA event=ping_rejected reason=update_modifiedCount_zero, will stop task");
-				taskMonitor.accept(TerminalMode.INTERNAL_STOP);
-				stopTask.get();
-				ExecutorUtil.shutdown(executorService, 1L, TimeUnit.SECONDS);
-			} else {
-                failedStartTime = 0L;
-            }
+			if (updateResult.getModifiedCount() != 0) {
+				latestSuccessPingTime = System.currentTimeMillis();
+				return;
+			}
+			if (isCloud) {
+				logger.warn("TaskHA event=ping_rejected reason=update_modifiedCount_zero, cloud task will keep running");
+				return;
+			}
+			logger.warn("TaskHA event=ping_rejected reason=update_modifiedCount_zero, will stop task");
 		} catch (Exception e) {
-            if (failedStartTime == 0) {
-                failedStartTime = System.currentTimeMillis();
-            }
-            if (System.currentTimeMillis() - failedStartTime > onHeartExpire()) {
-                logger.warn("TaskHA event=ping_failed_giveup elapsedMs={}, will stop task: {}",
-                        System.currentTimeMillis() - failedStartTime, e.getMessage(), e);
-                taskMonitor.accept(TerminalMode.INTERNAL_STOP);
-                stopTask.get();
-                ExecutorUtil.shutdown(executorService, 1L, TimeUnit.SECONDS);
-            } else {
-                logger.warn("TaskHA event=ping_failed_retry elapsedMs={} giveupAfterMs={}",
-                        System.currentTimeMillis() - failedStartTime, onHeartExpire());
-            }
+			if (isCloud) {
+				logger.warn("TaskHA event=ping_failed_cloud_keep_running error={}", e.getMessage(), e);
+				return;
+			}
+			long now = System.currentTimeMillis();
+			long elapsedSinceLastSuccess = now - latestSuccessPingTime;
+            long taskHeartTimeout = getTaskHeartTimeout();
+			if (elapsedSinceLastSuccess <= taskHeartTimeout) {
+				logger.warn("TaskHA event=ping_failed_retry elapsedSinceLastSuccessMs={} giveupAfterMs={}",
+						elapsedSinceLastSuccess, taskHeartTimeout);
+				return;
+			}
+			logger.warn("TaskHA event=ping_failed_giveup elapsedSinceLastSuccessMs={}, will stop task: {}",
+					elapsedSinceLastSuccess, e.getMessage(), e);
 		}
+
+		internalStop();
+    }
+
+	private void internalStop() {
+		taskMonitor.accept(TerminalMode.INTERNAL_STOP);
+		stopTask.get();
+		ExecutorUtil.shutdown(executorService, 1L, TimeUnit.SECONDS);
 	}
 
-	protected long onHeartExpire() {
-		return TimeUnit.SECONDS.toMillis(15L);
+	private long getTaskHeartTimeout() {
+		try {
+			SettingService settingService = BeanUtil.getBean(SettingService.class);
+			if (settingService != null) {
+				return settingService.getLong("jobHeartTimeout", DEFAULT_TASK_HEART_TIMEOUT_MS);
+			}
+		} catch (Exception e) {
+			logger.warn("Get task heart timeout from setting failed, use default {}ms", DEFAULT_TASK_HEART_TIMEOUT_MS, e);
+		}
+		return DEFAULT_TASK_HEART_TIMEOUT_MS;
 	}
 
 	@Override

--- a/iengine/iengine-app/src/test/java/io/tapdata/flow/engine/V2/monitor/impl/TaskPingTimeMonitorTest.java
+++ b/iengine/iengine-app/src/test/java/io/tapdata/flow/engine/V2/monitor/impl/TaskPingTimeMonitorTest.java
@@ -57,7 +57,13 @@ class TaskPingTimeMonitorTest {
 			when(updateResult.getModifiedCount()).thenReturn(1L);
 			when(clientMongoOperator.update(any(), any(), any())).thenReturn(updateResult);
 
-			taskPingTimeMonitor.taskPingTimeUseHttp(query, update);
+			try (MockedStatic<AppType> ignoreAppType = mockStatic(AppType.class)) {
+				AppType appType = mock(AppType.class);
+				when(appType.isCloud()).thenReturn(false);
+				ignoreAppType.when(AppType::currentType).thenReturn(appType);
+
+				taskPingTimeMonitor.taskPingTimeUseHttp(query, update);
+			}
 		}
 
 		@Test
@@ -69,7 +75,13 @@ class TaskPingTimeMonitorTest {
 			when(updateResult.getModifiedCount()).thenReturn(0L);
 			when(clientMongoOperator.update(any(), any(), any())).thenReturn(updateResult);
 
-			taskPingTimeMonitor.taskPingTimeUseHttp(query, update);
+			try (MockedStatic<AppType> ignoreAppType = mockStatic(AppType.class)) {
+				AppType appType = mock(AppType.class);
+				when(appType.isCloud()).thenReturn(false);
+				ignoreAppType.when(AppType::currentType).thenReturn(appType);
+
+				taskPingTimeMonitor.taskPingTimeUseHttp(query, update);
+			}
 
 			verify(taskMonitor, times(1)).accept(TerminalMode.INTERNAL_STOP);
 			verify(stopTask, times(1)).get();
@@ -91,6 +103,9 @@ class TaskPingTimeMonitorTest {
 
 				taskPingTimeMonitor.taskPingTimeUseHttp(query, update);
 			}
+
+			verify(taskMonitor, never()).accept(any());
+			verify(stopTask, never()).get();
 		}
 
 		@Test
@@ -100,11 +115,38 @@ class TaskPingTimeMonitorTest {
 
 			// Ignore log printing for successful use cases
 			UnitTestUtils.injectField(TaskPingTimeMonitor.class, taskPingTimeMonitor, "logger", mock(Logger.class));
-			when(taskPingTimeMonitor.onHeartExpire()).thenReturn(-1L);
-			taskPingTimeMonitor.taskPingTimeUseHttp(query, update);
+			UnitTestUtils.injectField(TaskPingTimeMonitor.class, taskPingTimeMonitor, "taskHeartTimeout", 1000L);
+			UnitTestUtils.injectField(TaskPingTimeMonitor.class, taskPingTimeMonitor, "latestSuccessPingTime", System.currentTimeMillis() - 2000L);
+			try (MockedStatic<AppType> ignoreAppType = mockStatic(AppType.class)) {
+				AppType appType = mock(AppType.class);
+				when(appType.isCloud()).thenReturn(false);
+				ignoreAppType.when(AppType::currentType).thenReturn(appType);
+
+				taskPingTimeMonitor.taskPingTimeUseHttp(query, update);
+			}
 
 			verify(taskMonitor, times(1)).accept(TerminalMode.INTERNAL_STOP);
 			verify(stopTask, times(1)).get();
+		}
+
+		@Test
+		void whenUpdateExceptionButLatestSuccessPingTimeNotTimeout() {
+			Query query = mock(Query.class);
+			Update update = mock(Update.class);
+
+			UnitTestUtils.injectField(TaskPingTimeMonitor.class, taskPingTimeMonitor, "logger", mock(Logger.class));
+			UnitTestUtils.injectField(TaskPingTimeMonitor.class, taskPingTimeMonitor, "taskHeartTimeout", 60000L);
+			UnitTestUtils.injectField(TaskPingTimeMonitor.class, taskPingTimeMonitor, "latestSuccessPingTime", System.currentTimeMillis());
+			try (MockedStatic<AppType> ignoreAppType = mockStatic(AppType.class)) {
+				AppType appType = mock(AppType.class);
+				when(appType.isCloud()).thenReturn(false);
+				ignoreAppType.when(AppType::currentType).thenReturn(appType);
+
+				taskPingTimeMonitor.taskPingTimeUseHttp(query, update);
+			}
+
+			verify(taskMonitor, never()).accept(any());
+			verify(stopTask, never()).get();
 		}
 
 		@Test
@@ -112,6 +154,9 @@ class TaskPingTimeMonitorTest {
 			Query query = mock(Query.class);
 			Update update = mock(Update.class);
 
+			UnitTestUtils.injectField(TaskPingTimeMonitor.class, taskPingTimeMonitor, "logger", mock(Logger.class));
+			UnitTestUtils.injectField(TaskPingTimeMonitor.class, taskPingTimeMonitor, "taskHeartTimeout", 1000L);
+			UnitTestUtils.injectField(TaskPingTimeMonitor.class, taskPingTimeMonitor, "latestSuccessPingTime", System.currentTimeMillis() - 2000L);
 			try (MockedStatic<AppType> ignoreAppType = mockStatic(AppType.class)) {
 				AppType appType = mock(AppType.class);
 				when(appType.isCloud()).thenReturn(true);
@@ -119,6 +164,9 @@ class TaskPingTimeMonitorTest {
 
 				taskPingTimeMonitor.taskPingTimeUseHttp(query, update);
 			}
+
+			verify(taskMonitor, never()).accept(any());
+			verify(stopTask, never()).get();
 		}
 
 	}

--- a/iengine/iengine-app/src/test/java/io/tapdata/flow/engine/V2/monitor/impl/TaskPingTimeMonitorTest.java
+++ b/iengine/iengine-app/src/test/java/io/tapdata/flow/engine/V2/monitor/impl/TaskPingTimeMonitorTest.java
@@ -15,9 +15,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
-import org.springframework.test.util.ReflectionTestUtils;
-
-import java.lang.reflect.Field;
 
 import static org.mockito.Mockito.*;
 
@@ -115,8 +112,7 @@ class TaskPingTimeMonitorTest {
 
 			// Ignore log printing for successful use cases
 			UnitTestUtils.injectField(TaskPingTimeMonitor.class, taskPingTimeMonitor, "logger", mock(Logger.class));
-			UnitTestUtils.injectField(TaskPingTimeMonitor.class, taskPingTimeMonitor, "taskHeartTimeout", 1000L);
-			UnitTestUtils.injectField(TaskPingTimeMonitor.class, taskPingTimeMonitor, "latestSuccessPingTime", System.currentTimeMillis() - 2000L);
+			UnitTestUtils.injectField(TaskPingTimeMonitor.class, taskPingTimeMonitor, "latestSuccessPingTime", System.currentTimeMillis() - 61000L);
 			try (MockedStatic<AppType> ignoreAppType = mockStatic(AppType.class)) {
 				AppType appType = mock(AppType.class);
 				when(appType.isCloud()).thenReturn(false);
@@ -135,7 +131,6 @@ class TaskPingTimeMonitorTest {
 			Update update = mock(Update.class);
 
 			UnitTestUtils.injectField(TaskPingTimeMonitor.class, taskPingTimeMonitor, "logger", mock(Logger.class));
-			UnitTestUtils.injectField(TaskPingTimeMonitor.class, taskPingTimeMonitor, "taskHeartTimeout", 60000L);
 			UnitTestUtils.injectField(TaskPingTimeMonitor.class, taskPingTimeMonitor, "latestSuccessPingTime", System.currentTimeMillis());
 			try (MockedStatic<AppType> ignoreAppType = mockStatic(AppType.class)) {
 				AppType appType = mock(AppType.class);
@@ -155,7 +150,6 @@ class TaskPingTimeMonitorTest {
 			Update update = mock(Update.class);
 
 			UnitTestUtils.injectField(TaskPingTimeMonitor.class, taskPingTimeMonitor, "logger", mock(Logger.class));
-			UnitTestUtils.injectField(TaskPingTimeMonitor.class, taskPingTimeMonitor, "taskHeartTimeout", 1000L);
 			UnitTestUtils.injectField(TaskPingTimeMonitor.class, taskPingTimeMonitor, "latestSuccessPingTime", System.currentTimeMillis() - 2000L);
 			try (MockedStatic<AppType> ignoreAppType = mockStatic(AppType.class)) {
 				AppType appType = mock(AppType.class);

--- a/manager/tm-common/src/test/java/com/tapdata/tm/utils/PdkSourceUtilsTest.java
+++ b/manager/tm-common/src/test/java/com/tapdata/tm/utils/PdkSourceUtilsTest.java
@@ -127,7 +127,7 @@ public class PdkSourceUtilsTest {
             Files.write(file.toPath(), "test".getBytes(StandardCharsets.UTF_8));
             String fileMD5 = PdkSourceUtils.calculateFileMD5(file);
             file.delete();
-            assertEquals("098f6bcd4621d373cade4e832627b4f6", fileMD5);
+            assertEquals("98f6bcd4621d373cade4e832627b4f6", fileMD5);
         }
     }
     @Nested

--- a/manager/tm/src/main/java/com/tapdata/tm/schedule/TaskRestartSchedule.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/schedule/TaskRestartSchedule.java
@@ -316,13 +316,6 @@ public class TaskRestartSchedule {
                 continue;
             }
 
-            // Same liveness guard for WAIT_RUN: if the new owner is alive, the engine is
-            // simply slow to acknowledge — don't roll back to SCHEDULING.
-            if (!isCloud() && isAgentAlive(agentId, user)) {
-                logSkipReschedule("waitRunTask", taskDto, "wait_run_but_worker_alive");
-                continue;
-            }
-
             asyncTaskWarnLog(taskDto, user, "The engine[{0}] takes over the task with a timeout of {1}ms."
                 , agentId, heartExpire
             );

--- a/manager/tm/src/main/java/com/tapdata/tm/task/service/impl/TaskScheduleServiceImpl.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/task/service/impl/TaskScheduleServiceImpl.java
@@ -67,12 +67,6 @@ public class TaskScheduleServiceImpl implements TaskScheduleService {
 
     @Override
     public void scheduling(TaskDto taskDto, UserDetail user,Boolean isReStart) {
-        // Capture the previous owner BEFORE cloudTaskLimitNum mutates taskDto.agentId
-        // so we can fire a best-effort STOP to it after a new owner is chosen (HA failover
-        // path). Reduces the dual-running window when the old engine is alive but TM
-        // already moved the task elsewhere.
-        String oldAgentId = taskDto.getAgentId();
-
         FunctionUtils.ignoreAnyError(() -> {
             CheckTaskMemoryResult checkTaskMemoryResult = taskService.checkTaskMemoryHeap(taskDto, isReStart, user);
             if (null != checkTaskMemoryResult && !checkTaskMemoryResult.getIsSafe()) {
@@ -101,20 +95,6 @@ public class TaskScheduleServiceImpl implements TaskScheduleService {
 
         Date now = new Date();
         monitoringLogsService.agentAssignMonitoringLog(taskDto, calculationEngineVo.getProcessId(), calculationEngineVo.getProcessName(), calculationEngineVo.getAvailable(), calculationEngineVo.isManually(), user, now);
-
-        // Best-effort STOP to the previous owner so it shuts down its local TaskClient
-        // before the new owner finishes booting. Failure here is non-fatal: TaskPingTimeMonitor
-        // on the old engine has its own ownership-loss self-stop as backup.
-        if (StringUtils.isNotBlank(oldAgentId) && !oldAgentId.equals(taskDto.getAgentId())) {
-            try {
-                log.info("TaskHA event=stop_old_agent taskId={} oldAgentId={} newAgentId={}",
-                        taskDto.getId().toHexString(), oldAgentId, taskDto.getAgentId());
-                taskService.sendStoppingMsg(taskDto.getId().toHexString(), oldAgentId, user, false);
-            } catch (Exception e) {
-                log.warn("TaskHA event=stop_old_agent_failed taskId={} oldAgentId={} error={}",
-                        taskDto.getId().toHexString(), oldAgentId, e.getMessage());
-            }
-        }
 
         // Step 1: Write agentId first while still in SCHEDULING state.
         // This is safe because no scheduler dispatches start messages to tasks in SCHEDULING state.

--- a/manager/tm/src/test/java/com/tapdata/tm/schedule/TaskRestartScheduleTest.java
+++ b/manager/tm/src/test/java/com/tapdata/tm/schedule/TaskRestartScheduleTest.java
@@ -87,11 +87,9 @@ public class TaskRestartScheduleTest {
         }
 
         @Test
-        void testWaitRunTaskSkipsWhenAgentAlive() {
-            // Regression for HA drill test: a wait_run task whose current agent is still
-            // alive must NOT roll back to scheduling. Earlier behavior triggered OVERTIME
-            // purely on scheduledTime, which falsely tore down tasks on healthy engines
-            // whenever the engine's task-pingTime update was momentarily delayed.
+        void testWaitRunTaskReschedulesWhenAgentAlive() {
+            // A wait_run task that exceeds the task heartbeat timeout should be rolled back
+            // and rescheduled instead of resending START directly.
             String userId = "test-user-id";
             String agentId = "test-agent-id";
 
@@ -116,6 +114,7 @@ public class TaskRestartScheduleTest {
 
             StateMachineService stateMachineService = mock(StateMachineService.class);
             taskRestartSchedule.setStateMachineService(stateMachineService);
+            when(stateMachineService.executeAboutTask(any(TaskDto.class), eq(DataFlowEvent.OVERTIME), any(UserDetail.class))).thenReturn(StateMachineResult.ok());
 
             TaskScheduleService taskScheduleService = mock(TaskScheduleService.class);
             taskRestartSchedule.setTaskScheduleService(taskScheduleService);
@@ -138,8 +137,9 @@ public class TaskRestartScheduleTest {
 
             taskRestartSchedule.waitRunTask();
 
-            verify(stateMachineService, never()).executeAboutTask(any(TaskDto.class), any(DataFlowEvent.class), any(UserDetail.class));
-            verify(taskScheduleService, never()).scheduling(any(), any(), any());
+            verify(stateMachineService, times(1)).executeAboutTask(taskDto, DataFlowEvent.OVERTIME, userDetail);
+            verify(taskScheduleService, times(1)).scheduling(taskDto, userDetail, true);
+            verify(taskScheduleService, never()).sendStartMsg(anyString(), anyString(), any(UserDetail.class));
         }
 
         @Test

--- a/manager/tm/src/test/java/com/tapdata/tm/schedule/service/impl/TaskScheduleServiceImplTest.java
+++ b/manager/tm/src/test/java/com/tapdata/tm/schedule/service/impl/TaskScheduleServiceImplTest.java
@@ -5,9 +5,12 @@ import com.tapdata.tm.base.exception.BizException;
 import com.tapdata.tm.commons.task.dto.TaskDto;
 import com.tapdata.tm.config.security.SimpleGrantedAuthority;
 import com.tapdata.tm.config.security.UserDetail;
+import com.tapdata.tm.messagequeue.service.MessageQueueService;
+import com.tapdata.tm.monitoringlogs.service.MonitoringLogsService;
 import com.tapdata.tm.statemachine.enums.DataFlowEvent;
 import com.tapdata.tm.statemachine.model.StateMachineResult;
 import com.tapdata.tm.statemachine.service.StateMachineService;
+import com.tapdata.tm.task.service.TaskCollectionObjService;
 import com.tapdata.tm.task.service.TaskService;
 import com.tapdata.tm.task.service.impl.TaskScheduleServiceImpl;
 import com.tapdata.tm.user.service.UserService;
@@ -35,6 +38,63 @@ import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class TaskScheduleServiceImplTest {
+    @Nested
+    class SchedulingTest {
+        final UserDetail user = new UserDetail("6393f084c162f518b18165c3", "customerId", "username", "password", "customerType",
+                "accessCode", false, false, false, false, Arrays.asList(new SimpleGrantedAuthority("role")));
+        final ObjectId taskId = MongoUtils.toObjectId("6324562fc5c0a4052d821d90");
+        TaskScheduleServiceImpl taskScheduleService;
+        TaskService taskService;
+        StateMachineService stateMachineService;
+        MonitoringLogsService monitoringLogsService;
+        TaskCollectionObjService taskCollectionObjService;
+        MessageQueueService messageQueueService;
+        TaskDto taskDto;
+
+        @BeforeEach
+        void beforeEach() {
+            taskScheduleService = spy(new TaskScheduleServiceImpl());
+            taskService = mock(TaskService.class);
+            stateMachineService = mock(StateMachineService.class);
+            monitoringLogsService = mock(MonitoringLogsService.class);
+            taskCollectionObjService = mock(TaskCollectionObjService.class);
+            messageQueueService = mock(MessageQueueService.class);
+
+            taskScheduleService.setTaskService(taskService);
+            taskScheduleService.setStateMachineService(stateMachineService);
+            taskScheduleService.setMonitoringLogsService(monitoringLogsService);
+            taskScheduleService.setTaskCollectionObjService(taskCollectionObjService);
+            taskScheduleService.setMessageQueueService(messageQueueService);
+
+            taskDto = new TaskDto();
+            taskDto.setId(taskId);
+            taskDto.setUserId(user.getUserId());
+            taskDto.setName("test");
+            taskDto.setStatus(TaskDto.STATUS_SCHEDULING);
+            taskDto.setAgentId("old-agent");
+            taskDto.setCanOpenInspect(false);
+        }
+
+        @Test
+        void shouldNotStopOldAgentWhenTaskRescheduled() {
+            CalculationEngineVo calculationEngineVo = new CalculationEngineVo();
+            calculationEngineVo.setProcessId("new-agent");
+            doAnswer(invocation -> {
+                taskDto.setAgentId("new-agent");
+                return calculationEngineVo;
+            }).when(taskScheduleService).cloudTaskLimitNum(taskDto, user, false);
+            when(stateMachineService.executeAboutTask(taskDto, DataFlowEvent.SCHEDULE_SUCCESS, user)).thenReturn(StateMachineResult.ok());
+            when(taskService.findById(taskId, user)).thenReturn(taskDto);
+            doNothing().when(taskScheduleService).sendStartMsg(taskId.toHexString(), "new-agent", user);
+
+            taskScheduleService.scheduling(taskDto, user, true);
+
+            verify(taskService, never()).sendStoppingMsg(taskId.toHexString(), "old-agent", user, false);
+            verify(stateMachineService, times(1)).executeAboutTask(taskDto, DataFlowEvent.SCHEDULE_SUCCESS, user);
+            verify(taskScheduleService, times(1)).sendStartMsg(taskId.toHexString(), "new-agent", user);
+        }
+    }
+
     @Nested
     class testCloudTaskLimitNum {
         final UserDetail user = new UserDetail("6393f084c162f518b18165c3", "customerId", "username", "password", "customerType",


### PR DESCRIPTION
Stop sending TM stop messages to old task owners during rescheduling and let the engine stop itself after heartbeat update failures exceed the task timeout.

Reschedule expired wait_run tasks through the OVERTIME path instead of resending start messages, and align unit tests with the current wait_run and scheduling behavior.

Refs: TAP-11888