### PR TITLE
Fix(proxy): TAP-10588 allow internal proxy forwarding

### DIFF
--- a/manager/tm/src/main/java/com/tapdata/tm/proxy/controller/ProxyController.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/proxy/controller/ProxyController.java
@@ -404,6 +404,7 @@ public class ProxyController extends BaseController {
 
 	@Operation(summary = "External callback url")
 	@PostMapping("internal")
+	@IgnoreLogin
 	public void proxyCallNew(HttpServletRequest request,
 							 HttpServletResponse response,
 							 @RequestParam(name = "key", required = true) String key,


### PR DESCRIPTION
Allow /api/proxy/internal to bypass login interception so TM-to-TM NodeConnection ping and forwarded proxy calls can reach the internal key validation path.

This keeps ProxyConstants.INTERNAL_KEY validation in place while preventing unauthenticated internal requests from being rejected before the proxy handler runs.

Refs: TAP-10588