### PR TITLE
Fix(task-schedule): TAP-11911 handle empty agent group scheduling

### DIFF
--- a/manager/tm/src/main/java/com/tapdata/tm/task/service/impl/TaskScheduleServiceImpl.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/task/service/impl/TaskScheduleServiceImpl.java
@@ -194,6 +194,11 @@ public class TaskScheduleServiceImpl implements TaskScheduleService {
             } else if(AccessNodeTypeEnum.isGroupManually(taskDto.getAccessNodeType())
                     && CollectionUtils.isNotEmpty(accessNodeProcessIdList)){
                 List<Worker> availableAgent = workerService.findAvailableAgentByAccessNode(user,accessNodeProcessIdList);
+                if (CollectionUtils.isEmpty(availableAgent)) {
+                    log.warn("No available agent found in specified agent group for task [{}]", taskDto.getName());
+                    taskDto.setAgentId(null);
+                    return noAvailableAgentResult();
+                }
                 List<String> processIds = availableAgent.stream().map(Worker::getProcessId).collect(Collectors.toList());
                 String finalAgentId = null;
                 if(StringUtils.isNotEmpty(taskDto.getPriorityProcessId()) && processIds.contains(taskDto.getPriorityProcessId())){
@@ -233,6 +238,17 @@ public class TaskScheduleServiceImpl implements TaskScheduleService {
                 throw new BizException("Task.ScheduleLimit");
             }
         }
+        return calculationEngineVo;
+    }
+
+    private CalculationEngineVo noAvailableAgentResult() {
+        CalculationEngineVo calculationEngineVo = new CalculationEngineVo();
+        calculationEngineVo.setAvailable(0);
+        calculationEngineVo.setRunningNum(0);
+        calculationEngineVo.setTaskLimit(Integer.MAX_VALUE);
+        calculationEngineVo.setTotalLimit(Integer.MAX_VALUE);
+        calculationEngineVo.setThreadLog(new ArrayList<>());
+        calculationEngineVo.setManually(true);
         return calculationEngineVo;
     }
 

--- a/manager/tm/src/test/java/com/tapdata/tm/schedule/service/impl/TaskScheduleServiceImplTest.java
+++ b/manager/tm/src/test/java/com/tapdata/tm/schedule/service/impl/TaskScheduleServiceImplTest.java
@@ -238,5 +238,20 @@ public class TaskScheduleServiceImplTest {
             });
             taskScheduleService.cloudTaskLimitNum(taskDto, user, false);
         }
+
+        @Test
+        void testTaskIsGroupManually_availableAgent_is_Empty(){
+            taskDto.setAccessNodeType("MANUALLY_SPECIFIED_BY_THE_USER_AGENT_GROUP");
+            taskDto.setAgentId("offline-worker");
+            when(agentGroupService.getProcessNodeListWithGroup(taskDto, user)).thenReturn(Arrays.asList("worker_test1","worker_test2"));
+            when(workerService.findAvailableAgentByAccessNode(any(),anyList())).thenReturn(new ArrayList<>());
+
+            CalculationEngineVo result = taskScheduleService.cloudTaskLimitNum(taskDto, user, false);
+
+            Assertions.assertNull(taskDto.getAgentId());
+            Assertions.assertEquals(0, result.getAvailable());
+            Assertions.assertEquals(Integer.MAX_VALUE, result.getTaskLimit());
+            verify(workerService, never()).scheduleTaskToEngine(taskDto, user, "task", taskDto.getName());
+        }
     }
 }


### PR DESCRIPTION
Guard manual agent group scheduling when the group has configured process IDs but no currently available workers. Return an empty scheduling result and clear the task agent so the retry path can keep the task waiting instead of failing with an index out of bounds error.

Add regression coverage for empty available worker lists in manual agent group scheduling.

Refs: TAP-11911