### PR TITLE
fix: TAP-11868 The three-level master-slave merging task did not dele…

### DIFF
--- a/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/node/hazelcast/processor/HazelcastMergeNode.java
+++ b/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/node/hazelcast/processor/HazelcastMergeNode.java
@@ -1833,8 +1833,10 @@ public class HazelcastMergeNode extends HazelcastProcessorBaseNode implements Me
 				ConstructIMap<Document> hazelcastConstruct = getHazelcastConstruct(childMergeProperty.getId());
 				joinValueKeys = getJoinValueKeyByTarget(data, childMergeProperty, mergeTableProperties, hazelcastConstruct);
 				if (joinValueKeys == null) {
-					continue;
-				}
+					if (!Boolean.TRUE.equals(childMergeProperty.getEnableUpdateJoinKeyValue())) {
+						continue;
+					}
+				} else {
 				io.tapdata.pdk.apis.entity.merge.MergeTableProperties copyMergeTableProperty = copyMergeTableProperty(childMergeProperty);
 				Node<?> preNode = getPreNode(childMergeProperty.getId());
 				String tableName = getTableName(preNode);
@@ -1902,8 +1904,10 @@ public class HazelcastMergeNode extends HazelcastProcessorBaseNode implements Me
 					}
 				}
 				continue; // already handled for each joinValueKey
+				}
 			}
-			// if not lookupDataExists, keep previous behavior but without performing find; nothing to add
+			// join key missing on parent for an updateJoinKey-enabled child, or lookupDataExists==false:
+			// emit a mock lookup entry so downstream cleanup of orphaned merged data can run
 			io.tapdata.pdk.apis.entity.merge.MergeTableProperties copyMergeTableProperty = copyMergeTableProperty(childMergeProperty);
 			Node<?> preNode = getPreNode(childMergeProperty.getId());
 			String tableName = getTableName(preNode);


### PR DESCRIPTION
…te the associated data of the third level table after the association key between the second level table and the third level table was unset