### PR TITLE
Fix(engine): TAP-12016 prevent stale task reports after rebalance

### DIFF
--- a/.github/workflows/mr-ci.yaml
+++ b/.github/workflows/mr-ci.yaml
@@ -126,7 +126,7 @@ jobs:
     needs:
       - Get-Stable-Branch
       - Push-Code-To-Gitee
-    timeout-minutes: 60
+    timeout-minutes: 120
     steps:
       - name: Clean Directory
         run: |

--- a/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/monitor/impl/TaskPingTimeMonitor.java
+++ b/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/monitor/impl/TaskPingTimeMonitor.java
@@ -70,6 +70,9 @@ public class TaskPingTimeMonitor extends TaskMonitor<Object> {
 							.and("status").nin(TaskDto.STATUS_ERROR, TaskDto.STATUS_SCHEDULE_FAILED)
 							.and("agentId").is(taskDto.getAgentId())
 					);
+					if (Objects.nonNull(taskDto.getTaskRecordId())) {
+						query.addCriteria(where("taskRecordId").is(taskDto.getTaskRecordId()));
+					}
 					Update update = new Update().set("pingTime", now);
 					try {
 						taskPingTimeUseHttp(query, update);

--- a/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/schedule/TapdataTaskScheduler.java
+++ b/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/schedule/TapdataTaskScheduler.java
@@ -57,6 +57,8 @@ import org.springframework.stereotype.Component;
 
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.*;
@@ -145,29 +147,12 @@ public class TapdataTaskScheduler implements MemoryFetcher {
 			 * 2、上报任务已停止/错误的状态信息
 			 */
 			try {
-				for (Map.Entry<String, TaskClient<TaskDto>> entry : taskClientMap.entrySet()) {
-					TaskClient<TaskDto> subTaskDtoTaskClient = entry.getValue();
-					final TaskDto taskDto = subTaskDtoTaskClient.getTask();
-					String taskId = taskDto.getId().toHexString();
-					Criteria rescheduleCriteria = where("_id").is(taskId).andOperator(where("agentId").ne(instanceNo), where("agentId").ne(null));
-
-					Query query = new Query(rescheduleCriteria);
-					query.fields().include("id").include("status");
-					final List<TaskDto> subTaskDtos = clientMongoOperator.find(query, ConnectorConstant.TASK_COLLECTION, TaskDto.class);
-					if (CollectionUtils.isNotEmpty(subTaskDtos)) {
-						internalStopTaskClientMap.put(taskId, subTaskDtoTaskClient);
-						removeTask(taskId);
-					} else {
-						TmStatusService.setAllowReport(taskId);
-					}
-				}
+				scanAndInternalStopRescheduledTasks();
 			} catch (Exception e) {
 				logger.error("Scan reschedule task failed {}", e.getMessage(), e);
 			}
 		});
-		if (AppType.currentType().isCloud()) {
-			taskScheduler.scheduleAtFixedRate(this::internalStopTask, Duration.ofSeconds(10));
-		}
+		taskScheduler.scheduleAtFixedRate(this::internalStopTask, Duration.ofSeconds(10));
 		taskOperationThreadPool.submit(() -> {
 			Thread.currentThread().setName("Task-Operation-Consumer");
 			while (true) {
@@ -540,7 +525,7 @@ public class TapdataTaskScheduler implements MemoryFetcher {
 			logger.info("The [task {}, id {}, status {}] is being executed, ignore the scheduling", taskDto.getName(), taskId, status);
 			Optional.ofNullable(ObsLoggerFactory.getInstance().getObsLogger(taskId))
 				.ifPresent(log -> log.info("This task is already running"));
-			clientMongoOperator.updateById(new Update(), ConnectorConstant.TASK_COLLECTION + "/running", taskId, TaskOpRespDto.class);
+			clientMongoOperator.updateById(new Update(), taskStatusResource(taskDto, "running"), taskId, TaskOpRespDto.class);
 			return;
 		}
 
@@ -551,7 +536,7 @@ public class TapdataTaskScheduler implements MemoryFetcher {
 
 			// Claim the task first so TM immediately moves wait_run→running; if this fails the
 			// task is still in scheduling/wait_run and we abort rather than start a phantom job.
-			TaskOpRespDto taskOpRespDto = clientMongoOperator.updateById(new Update(), ConnectorConstant.TASK_COLLECTION + "/running", taskId, TaskOpRespDto.class);
+			TaskOpRespDto taskOpRespDto = clientMongoOperator.updateById(new Update(), taskStatusResource(taskDto, "running"), taskId, TaskOpRespDto.class);
 			if (null == taskOpRespDto || !taskOpRespDto.getSuccessIds().contains(taskId)) {
 				// 防止任务异常状态下再次启动任务
 				throw new RuntimeException("Update task status to 'running' failed");
@@ -574,7 +559,7 @@ public class TapdataTaskScheduler implements MemoryFetcher {
 				} else {
 					logger.error("Start task {} failed {}", taskDto.getName(), e.getMessage(), e);
 				}
-				CompletableFuture.runAsync(() -> clientMongoOperator.updateById(new Update(), ConnectorConstant.TASK_COLLECTION + "/runError", taskId, TaskDto.class)).join();
+				CompletableFuture.runAsync(() -> clientMongoOperator.updateById(new Update(), taskStatusResource(taskDto, "runError"), taskId, TaskDto.class)).join();
 			}
 			if (ObsLoggerFactory.getInstance().getObsLogger(taskDto) != null) {
 				ObsLoggerFactory.getInstance().getObsLogger(taskDto).error( "Start task failed: " + e.getMessage(), e);
@@ -602,6 +587,8 @@ public class TapdataTaskScheduler implements MemoryFetcher {
 	public void forceStoppingTask() {
 		Thread.currentThread().setName(String.format(ConnectorConstant.STOP_TASK_THREAD, instanceNo));
 		try {
+			scanAndInternalStopRescheduledTasks();
+
 			for (Map.Entry<String, TaskClient<TaskDto>> entry : taskClientMap.entrySet()) {
 				TaskClient<TaskDto> taskClient = entry.getValue();
 				final TaskDto taskDto = taskClient.getTask();
@@ -616,7 +603,7 @@ public class TapdataTaskScheduler implements MemoryFetcher {
 			List<TaskDto> timeoutStoppingTasks = findStoppingTasks();
 			for (TaskDto timeoutStoppingTask : timeoutStoppingTasks) {
 				final String taskId = timeoutStoppingTask.getId().toHexString();
-				clientMongoOperator.updateById(new Update(), ConnectorConstant.TASK_COLLECTION + "/stopped", taskId, TaskDto.class);
+				clientMongoOperator.updateById(new Update(), taskStatusResource("stopped"), taskId, TaskDto.class);
 			}
 		} catch (Exception e) {
 			logger.error("Scan force stopping data flow failed {}", e.getMessage(), e);
@@ -694,8 +681,38 @@ public class TapdataTaskScheduler implements MemoryFetcher {
 
 
 
+	private void scanAndInternalStopRescheduledTasks() {
+		for (Map.Entry<String, TaskClient<TaskDto>> entry : taskClientMap.entrySet()) {
+			TaskClient<TaskDto> taskClient = entry.getValue();
+			if (taskClient == null || taskClient.getTask() == null || taskClient.getTask().getId() == null) {
+				continue;
+			}
+			String taskId = taskClient.getTask().getId().toHexString();
+			if (isTaskRescheduledToAnotherAgent(taskId)) {
+				TaskClient<TaskDto> removed = taskClientMap.remove(taskId);
+				if (removed == null) {
+					removed = taskClient;
+				}
+				internalStopTaskClientMap.put(taskId, removed);
+				TmStatusService.removeTask(taskId);
+				logger.info("TaskHA event=internal_stop_rescheduled_task taskId={} taskName={} localAgentId={}",
+						taskId, removed.getTask().getName(), instanceNo);
+			} else {
+				TmStatusService.setAllowReport(taskId);
+			}
+		}
+	}
+
+	private boolean isTaskRescheduledToAnotherAgent(String taskId) {
+		Criteria rescheduleCriteria = where("_id").is(taskId).andOperator(where("agentId").ne(instanceNo), where("agentId").ne(null));
+		Query query = new Query(rescheduleCriteria);
+		query.fields().include("id").include("status").include("agentId");
+		final List<TaskDto> subTaskDtos = clientMongoOperator.find(query, ConnectorConstant.TASK_COLLECTION, TaskDto.class);
+		return CollectionUtils.isNotEmpty(subTaskDtos);
+	}
+
 	private void internalStopTask() {
-		Thread.currentThread().setName(String.format(ConnectorConstant.CLOUD_INTERNAL_STOP_TASK_THREAD, instanceNo));
+		Thread.currentThread().setName(String.format(ConnectorConstant.INTERNAL_STOP_TASK_THREAD, instanceNo));
 		try {
 			Iterator<Map.Entry<String, TaskClient<TaskDto>>> iterator = internalStopTaskClientMap.entrySet().iterator();
 			while (iterator.hasNext()) {
@@ -710,6 +727,8 @@ public class TapdataTaskScheduler implements MemoryFetcher {
 					} catch (Exception e) {
 						throw new RuntimeException(String.format("Destroy memory task client cache failed, task: %s[%s]", taskClient.getTask().getName(), taskId), e);
 					}
+					clearTaskRetryCache(taskId);
+					ObsLoggerFactory.getInstance().removeTaskLoggerMarkRemove(taskClient.getTask());
 					iterator.remove();
 				}
 			}
@@ -781,14 +800,13 @@ public class TapdataTaskScheduler implements MemoryFetcher {
 		long jobHeartTimeout = getJobHeartTimeout();
 		long expiredTimeMillis = System.currentTimeMillis() - jobHeartTimeout;
 		Criteria timeoutCriteria = where("status").is(TaskDto.STATUS_STOPPING)
-//      .and("agentId").is(instanceNo)
 				.orOperator(
 						where("pingTime").lt(Double.valueOf(String.valueOf(expiredTimeMillis))),
 						where("pingTime").is(null),
 						where("pingTime").exists(false));
 
 		Query query = new Query(timeoutCriteria);
-		query.fields().include("id").include("status");
+		query.fields().include("id").include("status").include("agentId").include("taskRecordId");
 		return clientMongoOperator.find(query, ConnectorConstant.TASK_COLLECTION, TaskDto.class);
 	}
 
@@ -831,7 +849,7 @@ public class TapdataTaskScheduler implements MemoryFetcher {
 				logger.info("Call {} api to modify task [{}] status", resource, taskName);
 				AtomicBoolean success = new AtomicBoolean(true);
 				CompletableFuture.runAsync(() -> {
-					TaskOpRespDto taskOpRespDto = clientMongoOperator.updateById(new Update(), resource, taskId, TaskOpRespDto.class);
+					TaskOpRespDto taskOpRespDto = clientMongoOperator.updateById(new Update(), taskStatusResource(task, stopTaskResource.getResource()), taskId, TaskOpRespDto.class);
 					if (CollectionUtils.isEmpty(taskOpRespDto.getSuccessIds())) {
 						success.set(false);
 					}
@@ -841,7 +859,7 @@ public class TapdataTaskScheduler implements MemoryFetcher {
 				if (StringUtils.isNotBlank(e.getMessage()) && e.getMessage().contains("Transition.Not.Supported")) {
 					// 违反TM状态机，不再进行修改任务状态的重试
 					logger.warn("Call api to stop task status to {} failed, will set task to error, message: {}", resource, e.getMessage(), e);
-					CompletableFuture.runAsync(() -> clientMongoOperator.updateById(new Update(), ConnectorConstant.TASK_COLLECTION + "/" + StopTaskResource.RUN_ERROR.getResource(), taskId, TaskDto.class)).join();
+					CompletableFuture.runAsync(() -> clientMongoOperator.updateById(new Update(), taskStatusResource(task, StopTaskResource.RUN_ERROR.getResource()), taskId, TaskDto.class)).join();
 					return true;
 				} else {
 					logger.warn("Call stop task api failed, api uri: {}, task: {}[{}]", resource, taskName, taskId, e);
@@ -877,6 +895,29 @@ public class TapdataTaskScheduler implements MemoryFetcher {
 		update.set("agentId", instanceNo);
 	}
 
+	private String taskStatusResource(String statusResource) {
+		return new StringBuilder(ConnectorConstant.TASK_COLLECTION).append("/").append(statusResource).toString();
+	}
+
+	private String taskStatusResource(TaskDto taskDto, String statusResource) {
+		StringBuilder resource = new StringBuilder(taskStatusResource(statusResource));
+		List<String> queryParams = new ArrayList<>();
+		if (StringUtils.isNotBlank(instanceNo)) {
+			queryParams.add("agentId=" + encodeQueryParam(instanceNo));
+		}
+		if (taskDto != null && StringUtils.isNotBlank(taskDto.getTaskRecordId())) {
+			queryParams.add("taskRecordId=" + encodeQueryParam(taskDto.getTaskRecordId()));
+		}
+		if (CollectionUtils.isNotEmpty(queryParams)) {
+			resource.append("?").append(String.join("&", queryParams));
+		}
+		return resource.toString();
+	}
+
+	private String encodeQueryParam(String value) {
+		return URLEncoder.encode(value, StandardCharsets.UTF_8);
+	}
+
 	private long getJobHeartTimeout() {
 		return settingService.getLong("jobHeartTimeout", 60000L);
 	}
@@ -885,7 +926,7 @@ public class TapdataTaskScheduler implements MemoryFetcher {
 		TaskClient<TaskDto> taskDtoTaskClient = taskClientMap.get(taskId);
 		if (null == taskDtoTaskClient) {
 			try {
-				clientMongoOperator.updateById(new Update(), ConnectorConstant.TASK_COLLECTION + "/stopped", taskId, TaskDto.class);
+				clientMongoOperator.updateById(new Update(), taskStatusResource(null, "stopped"), taskId, TaskDto.class);
 				Optional.ofNullable(ObsLoggerFactory.getInstance().getObsLogger(taskId)).ifPresent(log -> log.info("This task already stopped."));
 			} catch (Exception e) {
 				logger.warn(e.getMessage(), e);

--- a/iengine/iengine-app/src/test/java/io/tapdata/Schedule/Watcher/AgentLogConfigurationWatcherTest.java
+++ b/iengine/iengine-app/src/test/java/io/tapdata/Schedule/Watcher/AgentLogConfigurationWatcherTest.java
@@ -32,7 +32,7 @@ public class AgentLogConfigurationWatcherTest {
         try(MockedStatic<ObsLoggerFactory> obsLoggerFactoryMockedStatic = mockStatic(ObsLoggerFactory.class);
             MockedStatic<BeanUtil> beanUtilMockedStatic = mockStatic(BeanUtil.class)){
             ObsLoggerFactory obsLoggerFactory = mock(ObsLoggerFactory.class);
-            when(ObsLoggerFactory.getInstance()).thenReturn(obsLoggerFactory);
+            obsLoggerFactoryMockedStatic.when(ObsLoggerFactory::getInstance).thenReturn(obsLoggerFactory);
             SettingService settingService = mock(SettingService.class);
             when(BeanUtil.getBean(SettingService.class)).thenReturn(settingService);
             when(settingService.getString("scriptEngineHttpAppender", "false")).thenReturn("false");

--- a/iengine/iengine-app/src/test/java/io/tapdata/Schedule/Watcher/TaskLogConfigurationWatcherTest.java
+++ b/iengine/iengine-app/src/test/java/io/tapdata/Schedule/Watcher/TaskLogConfigurationWatcherTest.java
@@ -19,7 +19,7 @@ public class TaskLogConfigurationWatcherTest {
         TaskLogConfigurationWatcher taskLogConfigurationWatcher = new TaskLogConfigurationWatcher();
         try(MockedStatic<ObsLoggerFactory> obsLoggerFactoryMockedStatic = mockStatic(ObsLoggerFactory.class)){
             ObsLoggerFactory obsLoggerFactory = mock(ObsLoggerFactory.class);
-            when(ObsLoggerFactory.getInstance()).thenReturn(obsLoggerFactory);
+            obsLoggerFactoryMockedStatic.when(ObsLoggerFactory::getInstance).thenReturn(obsLoggerFactory);
             LogConfiguration logConfiguration = LogConfiguration.builder().logSaveTime(180).logSaveSize(10).logSaveCount(10).build();
             when(obsLoggerFactory.getLogConfiguration("task")).thenReturn(logConfiguration);
             LogConfiguration logConf = taskLogConfigurationWatcher.getLogConfig();
@@ -33,7 +33,7 @@ public class TaskLogConfigurationWatcherTest {
         LogConfiguration logConfiguration = LogConfiguration.builder().logSaveTime(180).logSaveSize(10).logSaveCount(100).build();
         try(MockedStatic<ObsLoggerFactory> obsLoggerFactoryMockedStatic = mockStatic(ObsLoggerFactory.class)){
             ObsLoggerFactory obsLoggerFactory = mock(ObsLoggerFactory.class);
-            when(ObsLoggerFactory.getInstance()).thenReturn(obsLoggerFactory);
+            obsLoggerFactoryMockedStatic.when(ObsLoggerFactory::getInstance).thenReturn(obsLoggerFactory);
             Map<String, TaskLogger> taskLoggerMap=new HashMap<>();
             TaskLogger mock1 = mock(TaskLogger.class);
             TaskLogger mock2 = mock(TaskLogger.class);

--- a/iengine/iengine-app/src/test/java/io/tapdata/flow/engine/V2/schedule/TapdataTaskSchedulerTest.java
+++ b/iengine/iengine-app/src/test/java/io/tapdata/flow/engine/V2/schedule/TapdataTaskSchedulerTest.java
@@ -17,6 +17,7 @@ import io.tapdata.flow.engine.V2.task.operation.StopTaskOperation;
 import io.tapdata.flow.engine.V2.task.operation.TaskOperation;
 import io.tapdata.flow.engine.V2.task.retry.task.TaskRetryFactory;
 import io.tapdata.flow.engine.V2.task.retry.task.TaskRetryService;
+import io.tapdata.dao.MessageDao;
 import io.tapdata.observable.logging.ObsLogger;
 import io.tapdata.observable.logging.ObsLoggerFactory;
 import io.tapdata.utils.AppType;
@@ -32,6 +33,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -203,7 +205,7 @@ public class TapdataTaskSchedulerTest {
 
 				when(taskClient.getStatus()).thenReturn(TaskDto.STATUS_STOPPING);
 				assertDoesNotThrow(() -> taskScheduler.startTask(taskDto));
-				verify(clientMongoOperator, times(2)).updateById(any(Update.class), eq(ConnectorConstant.TASK_COLLECTION + "/running"), eq(taskId.toString()), eq(TaskOpRespDto.class));
+				verify(clientMongoOperator, times(2)).updateById(any(Update.class), argThat(resource -> resource.startsWith(ConnectorConstant.TASK_COLLECTION + "/running")), eq(taskId.toString()), eq(TaskOpRespDto.class));
 			}
 		}
 
@@ -229,14 +231,14 @@ public class TapdataTaskSchedulerTest {
 				ClientMongoOperator clientMongoOperator = mock(ClientMongoOperator.class);
 				RestDoNotRetryException restDoNotRetryException = mock(RestDoNotRetryException.class);
 				when(restDoNotRetryException.getCode()).thenReturn("Transition.Not.Supported");
-				when(clientMongoOperator.updateById(any(Update.class), eq(ConnectorConstant.TASK_COLLECTION + "/running"), eq(taskId.toString()), eq(TaskOpRespDto.class)))
+				when(clientMongoOperator.updateById(any(Update.class), argThat(resource -> resource.startsWith(ConnectorConstant.TASK_COLLECTION + "/running")), eq(taskId.toString()), eq(TaskOpRespDto.class)))
 						.thenThrow(restDoNotRetryException);
 				ReflectionTestUtils.setField(taskScheduler, "clientMongoOperator", clientMongoOperator);
 				doCallRealMethod().when(taskScheduler).startTask(eq(taskDto));
 
 				when(taskClient.getStatus()).thenReturn(TaskDto.STATUS_RUNNING);
 				assertDoesNotThrow(() -> taskScheduler.startTask(taskDto));
-				verify(clientMongoOperator, times(1)).updateById(any(Update.class), eq(ConnectorConstant.TASK_COLLECTION + "/running"), eq(taskId.toString()), eq(TaskOpRespDto.class));
+				verify(clientMongoOperator, times(1)).updateById(any(Update.class), argThat(resource -> resource.startsWith(ConnectorConstant.TASK_COLLECTION + "/running")), eq(taskId.toString()), eq(TaskOpRespDto.class));
 			}
 		}
 
@@ -262,7 +264,7 @@ public class TapdataTaskSchedulerTest {
 				RuntimeException disableAndAvailableError = new RuntimeException("disable and available exception");
 				RuntimeException disableAndUnavailableError = new TmUnavailableException("disable and unavailable  exception", "post", null, new ResponseBody());
 				ClientMongoOperator mongoOperator = mock(ClientMongoOperator.class);
-				when(mongoOperator.updateById(any(), eq(ConnectorConstant.TASK_COLLECTION + "/running"), any(), any())).thenThrow(
+				when(mongoOperator.updateById(any(), argThat(resource -> resource.startsWith(ConnectorConstant.TASK_COLLECTION + "/running")), any(), any())).thenThrow(
 					enableAndAvailableError, enableUnavailableError, disableAndAvailableError, disableAndUnavailableError
 				);
 
@@ -321,6 +323,41 @@ public class TapdataTaskSchedulerTest {
 
 				instance.forceStoppingTask();
 			}
+		}
+
+		@Test
+		void shouldForceStopTimeoutStoppingTaskWithoutReporterConstraint() {
+			ObjectId taskId = new ObjectId();
+			TaskDto timeoutStoppingTask = new TaskDto();
+			timeoutStoppingTask.setId(taskId);
+			timeoutStoppingTask.setAgentId("fe2");
+			timeoutStoppingTask.setTaskRecordId(new ObjectId().toHexString());
+
+			TapdataTaskScheduler instance = new TapdataTaskScheduler() {
+				@Override
+				protected List<TaskDto> findStoppingTasks() {
+					return Collections.singletonList(timeoutStoppingTask);
+				}
+			};
+			ClientMongoOperator clientMongoOperator = mock(ClientMongoOperator.class);
+			ReflectionTestUtils.setField(instance, "clientMongoOperator", clientMongoOperator);
+			ReflectionTestUtils.setField(instance, "taskClientMap", new ConcurrentHashMap<>());
+			ReflectionTestUtils.setField(instance, "instanceNo", "fe1");
+
+			try (MockedStatic<AppType> appTypeMockedStatic = mockStatic(AppType.class)) {
+				AppType appType = mock(AppType.class);
+				when(appType.isCloud()).thenReturn(false);
+				appTypeMockedStatic.when(AppType::currentType).thenReturn(appType);
+
+				instance.forceStoppingTask();
+			}
+
+			verify(clientMongoOperator).updateById(
+					any(Update.class),
+					eq(ConnectorConstant.TASK_COLLECTION + "/stopped"),
+					eq(taskId.toHexString()),
+					eq(TaskDto.class)
+			);
 		}
 	}
 
@@ -539,6 +576,128 @@ public class TapdataTaskSchedulerTest {
 			verify(clientMongoOperator).findOne(any(Query.class), eq(ConnectorConstant.TASK_COLLECTION), eq(TaskDto.class));
 		}
 
+	}
+
+	@Nested
+	class ScanAndInternalStopRescheduledTasksTest {
+		@Test
+		void shouldMoveLocalTaskToInternalStopWhenDbAgentChanged() {
+			TapdataTaskScheduler scheduler = new TapdataTaskScheduler();
+			ObjectId taskObjectId = new ObjectId();
+			String taskId = taskObjectId.toHexString();
+			TaskDto taskDto = new TaskDto();
+			taskDto.setId(taskObjectId);
+			taskDto.setName("rescheduled-task");
+
+			TaskClient<TaskDto> taskClient = mock(TaskClient.class);
+			when(taskClient.getTask()).thenReturn(taskDto);
+			Map<String, TaskClient<TaskDto>> taskClientMap = new ConcurrentHashMap<>();
+			taskClientMap.put(taskId, taskClient);
+			Map<String, TaskClient<TaskDto>> internalStopTaskClientMap = (Map<String, TaskClient<TaskDto>>) ReflectionTestUtils.getField(scheduler, "internalStopTaskClientMap");
+			internalStopTaskClientMap.clear();
+
+			ClientMongoOperator clientMongoOperator = mock(ClientMongoOperator.class);
+			TaskDto rescheduledTask = new TaskDto();
+			rescheduledTask.setId(taskObjectId);
+			rescheduledTask.setAgentId("fe2");
+			when(clientMongoOperator.find(any(Query.class), eq(ConnectorConstant.TASK_COLLECTION), eq(TaskDto.class)))
+					.thenReturn(Collections.singletonList(rescheduledTask));
+			ReflectionTestUtils.setField(scheduler, "clientMongoOperator", clientMongoOperator);
+			ReflectionTestUtils.setField(scheduler, "taskClientMap", taskClientMap);
+			ReflectionTestUtils.setField(scheduler, "instanceNo", "fe1");
+
+			try (MockedStatic<TmStatusService> tmStatusServiceMockedStatic = mockStatic(TmStatusService.class)) {
+				ReflectionTestUtils.invokeMethod(scheduler, "scanAndInternalStopRescheduledTasks");
+
+				assertFalse(taskClientMap.containsKey(taskId));
+				assertSame(taskClient, internalStopTaskClientMap.get(taskId));
+				tmStatusServiceMockedStatic.verify(() -> TmStatusService.removeTask(taskId));
+			}
+		}
+
+		@Test
+		void shouldKeepLocalTaskWhenDbAgentNotChanged() {
+			TapdataTaskScheduler scheduler = new TapdataTaskScheduler();
+			ObjectId taskObjectId = new ObjectId();
+			String taskId = taskObjectId.toHexString();
+			TaskDto taskDto = new TaskDto();
+			taskDto.setId(taskObjectId);
+			taskDto.setName("local-task");
+
+			TaskClient<TaskDto> taskClient = mock(TaskClient.class);
+			when(taskClient.getTask()).thenReturn(taskDto);
+			Map<String, TaskClient<TaskDto>> taskClientMap = new ConcurrentHashMap<>();
+			taskClientMap.put(taskId, taskClient);
+			Map<String, TaskClient<TaskDto>> internalStopTaskClientMap = (Map<String, TaskClient<TaskDto>>) ReflectionTestUtils.getField(scheduler, "internalStopTaskClientMap");
+			internalStopTaskClientMap.clear();
+
+			ClientMongoOperator clientMongoOperator = mock(ClientMongoOperator.class);
+			when(clientMongoOperator.find(any(Query.class), eq(ConnectorConstant.TASK_COLLECTION), eq(TaskDto.class)))
+					.thenReturn(Collections.emptyList());
+			ReflectionTestUtils.setField(scheduler, "clientMongoOperator", clientMongoOperator);
+			ReflectionTestUtils.setField(scheduler, "taskClientMap", taskClientMap);
+			ReflectionTestUtils.setField(scheduler, "instanceNo", "fe1");
+
+			try (MockedStatic<TmStatusService> tmStatusServiceMockedStatic = mockStatic(TmStatusService.class)) {
+				ReflectionTestUtils.invokeMethod(scheduler, "scanAndInternalStopRescheduledTasks");
+
+				assertSame(taskClient, taskClientMap.get(taskId));
+				assertFalse(internalStopTaskClientMap.containsKey(taskId));
+				tmStatusServiceMockedStatic.verify(() -> TmStatusService.setAllowReport(taskId));
+			}
+		}
+	}
+
+	@Nested
+	class InternalStopTaskTest {
+		@Test
+		void shouldStopAndRemoveInternalTaskClient() {
+			TapdataTaskScheduler scheduler = new TapdataTaskScheduler();
+			Logger logger = mock(Logger.class);
+			MessageDao messageDao = mock(MessageDao.class);
+			TaskClient<TaskDto> taskClient = mock(TaskClient.class);
+			TaskDto taskDto = new TaskDto();
+			taskDto.setId(new ObjectId());
+			taskDto.setName("rebalance-residual-task");
+
+			Map<String, TaskClient<TaskDto>> internalStopTaskClientMap = (Map<String, TaskClient<TaskDto>>) ReflectionTestUtils.getField(scheduler, "internalStopTaskClientMap");
+			internalStopTaskClientMap.clear();
+			internalStopTaskClientMap.put(taskDto.getId().toHexString(), taskClient);
+			ReflectionTestUtils.setField(scheduler, "logger", logger);
+			ReflectionTestUtils.setField(scheduler, "messageDao", messageDao);
+			ReflectionTestUtils.setField(scheduler, "instanceNo", "fe1");
+			when(taskClient.getTask()).thenReturn(taskDto);
+			when(taskClient.stop()).thenReturn(true);
+			when(taskClient.getCacheName()).thenReturn("");
+
+			ReflectionTestUtils.invokeMethod(scheduler, "internalStopTask");
+
+			assertTrue(internalStopTaskClientMap.isEmpty());
+			verify(taskClient).stop();
+		}
+
+		@Test
+		void shouldKeepInternalTaskClientForRetryWhenStopReturnsFalse() {
+			TapdataTaskScheduler scheduler = new TapdataTaskScheduler();
+			Logger logger = mock(Logger.class);
+			TaskClient<TaskDto> taskClient = mock(TaskClient.class);
+			TaskDto taskDto = new TaskDto();
+			taskDto.setId(new ObjectId());
+			taskDto.setName("rebalance-residual-task");
+
+			Map<String, TaskClient<TaskDto>> internalStopTaskClientMap = (Map<String, TaskClient<TaskDto>>) ReflectionTestUtils.getField(scheduler, "internalStopTaskClientMap");
+			internalStopTaskClientMap.clear();
+			internalStopTaskClientMap.put(taskDto.getId().toHexString(), taskClient);
+			ReflectionTestUtils.setField(scheduler, "logger", logger);
+			ReflectionTestUtils.setField(scheduler, "instanceNo", "fe1");
+			when(taskClient.getTask()).thenReturn(taskDto);
+			when(taskClient.stop()).thenReturn(false);
+
+			ReflectionTestUtils.invokeMethod(scheduler, "internalStopTask");
+
+			assertTrue(internalStopTaskClientMap.containsKey(taskDto.getId().toHexString()));
+			verify(taskClient).stop();
+		}
 	}
 
 	@Nested

--- a/iengine/iengine-app/src/test/java/io/tapdata/flow/engine/V2/schedule/TapdataTaskSchedulerTest.java
+++ b/iengine/iengine-app/src/test/java/io/tapdata/flow/engine/V2/schedule/TapdataTaskSchedulerTest.java
@@ -75,7 +75,7 @@ public class TapdataTaskSchedulerTest {
 				ObsLoggerFactory obsLoggerFactory = mock(ObsLoggerFactory.class);
 				try (MockedStatic<ObsLoggerFactory> of = Mockito
 						.mockStatic(ObsLoggerFactory.class)) {
-					mb.when(ObsLoggerFactory::getInstance).thenReturn(obsLoggerFactory);
+					of.when(ObsLoggerFactory::getInstance).thenReturn(obsLoggerFactory);
 					when(obsLoggerFactory.getObsLogger(anyString())).thenReturn(mock(ObsLogger.class));
 					TaskRetryService taskRetryService = mock(TaskRetryService.class);
 					when(factory.getTaskRetryService(anyString())).thenReturn(Optional.ofNullable(taskRetryService));
@@ -656,13 +656,16 @@ public class TapdataTaskSchedulerTest {
 			Logger logger = mock(Logger.class);
 			MessageDao messageDao = mock(MessageDao.class);
 			TaskClient<TaskDto> taskClient = mock(TaskClient.class);
+			TaskRetryFactory taskRetryFactory = mock(TaskRetryFactory.class);
+			ObsLoggerFactory obsLoggerFactory = mock(ObsLoggerFactory.class);
 			TaskDto taskDto = new TaskDto();
 			taskDto.setId(new ObjectId());
 			taskDto.setName("rebalance-residual-task");
+			String taskId = taskDto.getId().toHexString();
 
 			Map<String, TaskClient<TaskDto>> internalStopTaskClientMap = (Map<String, TaskClient<TaskDto>>) ReflectionTestUtils.getField(scheduler, "internalStopTaskClientMap");
 			internalStopTaskClientMap.clear();
-			internalStopTaskClientMap.put(taskDto.getId().toHexString(), taskClient);
+			internalStopTaskClientMap.put(taskId, taskClient);
 			ReflectionTestUtils.setField(scheduler, "logger", logger);
 			ReflectionTestUtils.setField(scheduler, "messageDao", messageDao);
 			ReflectionTestUtils.setField(scheduler, "instanceNo", "fe1");
@@ -670,10 +673,18 @@ public class TapdataTaskSchedulerTest {
 			when(taskClient.stop()).thenReturn(true);
 			when(taskClient.getCacheName()).thenReturn("");
 
-			ReflectionTestUtils.invokeMethod(scheduler, "internalStopTask");
+			try (MockedStatic<TaskRetryFactory> taskRetryFactoryMockedStatic = mockStatic(TaskRetryFactory.class);
+				 MockedStatic<ObsLoggerFactory> obsLoggerFactoryMockedStatic = mockStatic(ObsLoggerFactory.class)) {
+				taskRetryFactoryMockedStatic.when(TaskRetryFactory::getInstance).thenReturn(taskRetryFactory);
+				obsLoggerFactoryMockedStatic.when(ObsLoggerFactory::getInstance).thenReturn(obsLoggerFactory);
+
+				ReflectionTestUtils.invokeMethod(scheduler, "internalStopTask");
+			}
 
 			assertTrue(internalStopTaskClientMap.isEmpty());
 			verify(taskClient).stop();
+			verify(taskRetryFactory).removeTaskRetryService(taskId);
+			verify(obsLoggerFactory).removeTaskLoggerMarkRemove(taskDto);
 		}
 
 		@Test
@@ -681,22 +692,33 @@ public class TapdataTaskSchedulerTest {
 			TapdataTaskScheduler scheduler = new TapdataTaskScheduler();
 			Logger logger = mock(Logger.class);
 			TaskClient<TaskDto> taskClient = mock(TaskClient.class);
+			TaskRetryFactory taskRetryFactory = mock(TaskRetryFactory.class);
+			ObsLoggerFactory obsLoggerFactory = mock(ObsLoggerFactory.class);
 			TaskDto taskDto = new TaskDto();
 			taskDto.setId(new ObjectId());
 			taskDto.setName("rebalance-residual-task");
+			String taskId = taskDto.getId().toHexString();
 
 			Map<String, TaskClient<TaskDto>> internalStopTaskClientMap = (Map<String, TaskClient<TaskDto>>) ReflectionTestUtils.getField(scheduler, "internalStopTaskClientMap");
 			internalStopTaskClientMap.clear();
-			internalStopTaskClientMap.put(taskDto.getId().toHexString(), taskClient);
+			internalStopTaskClientMap.put(taskId, taskClient);
 			ReflectionTestUtils.setField(scheduler, "logger", logger);
 			ReflectionTestUtils.setField(scheduler, "instanceNo", "fe1");
 			when(taskClient.getTask()).thenReturn(taskDto);
 			when(taskClient.stop()).thenReturn(false);
 
-			ReflectionTestUtils.invokeMethod(scheduler, "internalStopTask");
+			try (MockedStatic<TaskRetryFactory> taskRetryFactoryMockedStatic = mockStatic(TaskRetryFactory.class);
+				 MockedStatic<ObsLoggerFactory> obsLoggerFactoryMockedStatic = mockStatic(ObsLoggerFactory.class)) {
+				taskRetryFactoryMockedStatic.when(TaskRetryFactory::getInstance).thenReturn(taskRetryFactory);
+				obsLoggerFactoryMockedStatic.when(ObsLoggerFactory::getInstance).thenReturn(obsLoggerFactory);
 
-			assertTrue(internalStopTaskClientMap.containsKey(taskDto.getId().toHexString()));
+				ReflectionTestUtils.invokeMethod(scheduler, "internalStopTask");
+			}
+
+			assertTrue(internalStopTaskClientMap.containsKey(taskId));
 			verify(taskClient).stop();
+			verifyNoInteractions(taskRetryFactory);
+			verifyNoInteractions(obsLoggerFactory);
 		}
 	}
 

--- a/iengine/iengine-common/src/main/java/com/tapdata/mongo/HttpClientMongoOperator.java
+++ b/iengine/iengine-common/src/main/java/com/tapdata/mongo/HttpClientMongoOperator.java
@@ -263,7 +263,7 @@ public class HttpClientMongoOperator extends ClientMongoOperator {
 
 		validateToken();
 
-		final String resource = addToken(collection + "/" + id);
+		final String resource = addToken(resourceWithId(collection, id));
 
 		T result = null;
 		try {
@@ -511,9 +511,17 @@ public class HttpClientMongoOperator extends ClientMongoOperator {
 	public String addToken(String url) {
 		StringBuilder sb = new StringBuilder(url);
 
-		sb.append("?").append("access_token=").append(configCenter.getConfig(ConfigurationCenter.TOKEN));
+		sb.append(url.contains("?") ? "&" : "?").append("access_token=").append(configCenter.getConfig(ConfigurationCenter.TOKEN));
 
 		return sb.toString();
+	}
+
+	private String resourceWithId(String collection, String id) {
+		int queryStart = collection.indexOf('?');
+		if (queryStart < 0) {
+			return collection + "/" + id;
+		}
+		return collection.substring(0, queryStart) + "/" + id + collection.substring(queryStart);
 	}
 
 	public String cookies() {

--- a/iengine/iengine-common/src/test/java/com/tapdata/mongo/HttpClientMongoOperatorTest.java
+++ b/iengine/iengine-common/src/test/java/com/tapdata/mongo/HttpClientMongoOperatorTest.java
@@ -1,6 +1,7 @@
 package com.tapdata.mongo;
 
 import com.tapdata.constant.ConfigurationCenter;
+import com.tapdata.constant.ConnectorConstant;
 import com.tapdata.entity.LoginResp;
 import com.tapdata.entity.User;
 import org.apache.logging.log4j.Logger;
@@ -8,8 +9,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
@@ -59,6 +63,46 @@ public class HttpClientMongoOperatorTest {
             verify(httpClientMongoOperator,times(1)).refreshToken();
         }
     }
+    @Nested
+    class UpdateByIdTest {
+        HttpClientMongoOperator httpClientMongoOperator;
+        ConfigurationCenter configurationCenter;
+        CapturingRestTemplateOperator restTemplateOperator;
+
+        @BeforeEach
+        void init() {
+            configurationCenter = new ConfigurationCenter();
+            restTemplateOperator = new CapturingRestTemplateOperator();
+            httpClientMongoOperator = new HttpClientMongoOperator(null, null, restTemplateOperator, configurationCenter);
+            configurationCenter.putConfig(ConfigurationCenter.TOKEN, "token");
+            LoginResp loginResp = new LoginResp();
+            loginResp.setTtl(300L);
+            loginResp.setExpiredTimestamp(System.currentTimeMillis() + 300000L);
+            configurationCenter.putConfig(ConfigurationCenter.LOGIN_INFO, loginResp);
+        }
+
+        @Test
+        void shouldAppendIdBeforeQueryParameters() {
+            httpClientMongoOperator.updateById(new Update(), ConnectorConstant.TASK_COLLECTION + "/running?agentId=fe1&taskRecordId=record1", "task1", Object.class);
+
+            assertEquals(ConnectorConstant.TASK_COLLECTION + "/running/task1?agentId=fe1&taskRecordId=record1&access_token=token", restTemplateOperator.resource);
+        }
+
+        class CapturingRestTemplateOperator extends RestTemplateOperator {
+            String resource;
+
+            CapturingRestTemplateOperator() {
+                super(Collections.singletonList("http://localhost"), 0);
+            }
+
+            @Override
+            public <T> T postOne(Object obj, String resource, Class<T> className) {
+                this.resource = resource;
+                return null;
+            }
+        }
+    }
+
     @Nested
     class RefreshTokenClass{
         HttpClientMongoOperator httpClientMongoOperator;

--- a/iengine/modules/observable-module/src/main/java/io/tapdata/observable/logging/ObsLoggerFactory.java
+++ b/iengine/modules/observable-module/src/main/java/io/tapdata/observable/logging/ObsLoggerFactory.java
@@ -8,17 +8,11 @@ import com.tapdata.tm.commons.task.dto.TaskDto;
 import io.tapdata.common.SettingService;
 import io.tapdata.entity.memory.MemoryFetcher;
 import io.tapdata.entity.utils.DataMap;
-import io.tapdata.exception.TmUnavailableException;
-import io.tapdata.observable.logging.appender.FileAppender;
-import io.tapdata.observable.logging.debug.DataCache;
 import io.tapdata.observable.logging.debug.DataCacheFactory;
 import io.tapdata.observable.logging.util.Conf.LogConfiguration;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.bson.types.ObjectId;
-import org.springframework.data.mongodb.core.query.Criteria;
-import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
 
 import java.util.*;
@@ -51,31 +45,42 @@ public final class ObsLoggerFactory implements MemoryFetcher {
 		return INSTANCE;
 	}
 
-	private static final AtomicBoolean initialized = new AtomicBoolean(false);
 	private ObsLoggerFactory() {
-		this.settingService = Optional.ofNullable(BeanUtil.getBean(SettingService.class)).orElse((SettingService) getBeanAsync(SettingService.class));
-		this.clientMongoOperator = Optional.ofNullable(BeanUtil.getBean(ClientMongoOperator.class)).orElse((ClientMongoOperator) getBeanAsync(ClientMongoOperator.class));
+		this.settingService = getBeanWaitAvailableOrTimeout(SettingService.class);
+		this.clientMongoOperator = getBeanWaitAvailableOrTimeout(ClientMongoOperator.class);
 		this.scheduleExecutorService = new ScheduledThreadPoolExecutor(1);
 		scheduleExecutorService.scheduleWithFixedDelay(this::removeTaskLogger, PERIOD_SECOND, PERIOD_SECOND, TimeUnit.SECONDS);
 	}
 
-	Object getBeanAsync(Class<?> clz){
-		while (!initialized.get()) {
-			synchronized (initialized) {
+	<T> T getBeanWaitAvailableOrTimeout(Class<T> clz) {
+		return getBeanWaitAvailableOrTimeout(clz, GET_BEAN_TIMEOUT_MILLIS);
+	}
+
+	<T> T getBeanWaitAvailableOrTimeout(Class<T> clz, long timeoutMillis) {
+		long deadline = System.currentTimeMillis() + timeoutMillis;
+		T ins = BeanUtil.getBean(clz);
+		while (null == ins) {
+			long remainingMillis = deadline - System.currentTimeMillis();
+			if (remainingMillis <= 0L) {
+				logger.warn("Timed out waiting for bean {}, timeout {}ms", clz.getName(), timeoutMillis);
+				return null;
+			}
+			synchronized (GET_BEAN_LOCK) {
 				try {
-					initialized.wait(100L);
-					Object bean = BeanUtil.getBean(clz);
-					if (null != bean ){
-						return bean;
-					}
+					GET_BEAN_LOCK.wait(Math.min(GET_BEAN_WAIT_INTERVAL_MILLIS, remainingMillis));
 				} catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
 					throw new RuntimeException(e);
 				}
 			}
+			ins = BeanUtil.getBean(clz);
 		}
-		return null;
+		return ins;
 	}
 
+	private static final Object GET_BEAN_LOCK = new Object();
+	private static final long GET_BEAN_WAIT_INTERVAL_MILLIS = 100L;
+	private static final long GET_BEAN_TIMEOUT_MILLIS = TimeUnit.MINUTES.toMillis(5L);
 	private static final long PERIOD_SECOND = 10L;
 	private static final long LOGGER_REMOVE_WAIT_AFTER_MILLIS = TimeUnit.HOURS.toMillis(1L);
 	private final SettingService settingService;

--- a/iengine/modules/observable-module/src/test/java/io/tapdata/observable/logging/ObsLoggerFactoryTest.java
+++ b/iengine/modules/observable-module/src/test/java/io/tapdata/observable/logging/ObsLoggerFactoryTest.java
@@ -9,6 +9,7 @@ import io.tapdata.common.SettingService;
 import io.tapdata.flow.engine.V2.entity.GlobalConstant;
 import io.tapdata.observable.logging.util.Conf.LogConfiguration;
 import org.bson.types.ObjectId;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -17,6 +18,7 @@ import org.mockito.MockedStatic;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Map;
+import java.util.concurrent.ScheduledExecutorService;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
@@ -33,6 +35,7 @@ public class ObsLoggerFactoryTest {
 
     @BeforeEach
     void beforeEach() {
+        resetObsLoggerFactory();
         taskDto = new TaskDto();
         taskDto.setId(new ObjectId());
         taskDto.setName("taskName");
@@ -47,6 +50,22 @@ public class ObsLoggerFactoryTest {
         ConfigurationCenter configurationCenter = new ConfigurationCenter();
         configurationCenter.putConfig("workDir", "/tmp");
         GlobalConstant.getInstance().configurationCenter(configurationCenter);
+    }
+
+    @AfterEach
+    void afterEach() {
+        resetObsLoggerFactory();
+    }
+
+    private void resetObsLoggerFactory() {
+        ObsLoggerFactory obsLoggerFactory = (ObsLoggerFactory) ReflectionTestUtils.getField(ObsLoggerFactory.class, "INSTANCE");
+        if (obsLoggerFactory != null) {
+            ScheduledExecutorService scheduleExecutorService = (ScheduledExecutorService) ReflectionTestUtils.getField(obsLoggerFactory, "scheduleExecutorService");
+            if (scheduleExecutorService != null) {
+                scheduleExecutorService.shutdownNow();
+            }
+        }
+        ReflectionTestUtils.setField(ObsLoggerFactory.class, "INSTANCE", null);
     }
 
     @DisplayName("test Get Task Log Configuration ")
@@ -93,8 +112,6 @@ public class ObsLoggerFactoryTest {
             ObsLogger obsLogger = ObsLoggerFactory.getInstance().getObsLogger(taskDto, "nodeId", "nodeName");
             Assertions.assertNotNull(obsLogger);
             ObsLoggerFactory.getInstance().removeTaskLogger(taskDto);
-        } catch (Exception e) {
-            e.printStackTrace(System.err);
         }
 
     }
@@ -120,8 +137,6 @@ public class ObsLoggerFactoryTest {
             result = ObsLoggerFactory.getInstance().closeCatchData(taskDto.getId().toHexString());
             Assertions.assertTrue(result);
 
-        } catch (Exception e) {
-            e.printStackTrace(System.err);
         }
     }
 
@@ -155,8 +170,6 @@ public class ObsLoggerFactoryTest {
             Assertions.assertTrue(status.containsKey("taskLogger.enableDebugLogger"));
             Assertions.assertTrue((Boolean) status.get("taskLogger.enableDebugLogger"));
 
-        } catch (Exception e) {
-            e.printStackTrace(System.err);
         }
     }
 
@@ -178,6 +191,20 @@ public class ObsLoggerFactoryTest {
 
             ObsLoggerFactory.getInstance().onFetchCacheData("taskId");
             verify(taskLogger, times(1)).setIntervalCeiling(any());
+        }
+    }
+
+    @Test
+    void getBeanWaitAvailableOrTimeoutShouldReturnNullAfterTimeout() {
+        ObsLoggerFactory obsLoggerFactory = mock(ObsLoggerFactory.class);
+        ReflectionTestUtils.setField(obsLoggerFactory, "logger", org.apache.logging.log4j.LogManager.getLogger(ObsLoggerFactory.class));
+        try (MockedStatic<BeanUtil> beanUtilMock = mockStatic(BeanUtil.class)) {
+            beanUtilMock.when(() -> BeanUtil.getBean(eq(SettingService.class))).thenReturn(null);
+            doCallRealMethod().when(obsLoggerFactory).getBeanWaitAvailableOrTimeout(eq(SettingService.class), eq(10L));
+
+            Object bean = obsLoggerFactory.getBeanWaitAvailableOrTimeout(SettingService.class, 10L);
+
+            Assertions.assertNull(bean);
         }
     }
 }

--- a/iengine/modules/observable-module/src/test/java/io/tapdata/observable/logging/appender/FileAppenderTest.java
+++ b/iengine/modules/observable-module/src/test/java/io/tapdata/observable/logging/appender/FileAppenderTest.java
@@ -62,11 +62,13 @@ public class FileAppenderTest {
 
         @BeforeEach
         void before() {
-            try (MockedStatic<BeanUtil> mockStaticBeanUtil = mockStatic(BeanUtil.class)) {
+            try (MockedStatic<BeanUtil> mockStaticBeanUtil = mockStatic(BeanUtil.class);
+                 MockedStatic<ObsLoggerFactory> mockStaticObsLoggerFactory = mockStatic(ObsLoggerFactory.class)) {
                 mockStaticBeanUtil.when(() -> BeanUtil.getBean(any())).thenAnswer(answer -> {
                     Class<?> cls = answer.getArgument(0);
                     return mock(cls);
                 });
+                mockStaticObsLoggerFactory.when(ObsLoggerFactory::getInstance).thenReturn(mock(ObsLoggerFactory.class));
                 fileAppender = FileAppender.create("", "taskId");
                 Assertions.assertNotNull(fileAppender);
             }

--- a/manager/tm-api/src/main/java/com/tapdata/tm/task/service/TaskService.java
+++ b/manager/tm-api/src/main/java/com/tapdata/tm/task/service/TaskService.java
@@ -252,11 +252,19 @@ public abstract class TaskService extends BaseService<TaskDto, TaskEntity, Objec
 
     public abstract String running(ObjectId id, UserDetail user);
 
+    public abstract String running(ObjectId id, UserDetail user, String reportAgentId, String reportTaskRecordId);
+
     public abstract String runError(ObjectId id, UserDetail user, String errMsg, String errStack);
+
+    public abstract String runError(ObjectId id, UserDetail user, String errMsg, String errStack, String reportAgentId, String reportTaskRecordId);
 
     public abstract String complete(ObjectId id, UserDetail user);
 
+    public abstract String complete(ObjectId id, UserDetail user, String reportAgentId, String reportTaskRecordId);
+
     public abstract String stopped(ObjectId id, UserDetail user);
+
+    public abstract String stopped(ObjectId id, UserDetail user, String reportAgentId, String reportTaskRecordId);
 
     public abstract RunTimeInfo runtimeInfo(ObjectId id, Long endTime, UserDetail user);
 

--- a/manager/tm/src/main/java/com/tapdata/tm/task/controller/TaskController.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/task/controller/TaskController.java
@@ -761,13 +761,15 @@ public class TaskController extends BaseController {
 
     @Operation(summary = "子任务已经成功运行回调接口")
     @PostMapping("running/{id}")
-    public ResponseMessage<TaskOpResp> running(@PathVariable("id") String id) {
-        log.info("subTask running status report by http, id = {}", id);
+    public ResponseMessage<TaskOpResp> running(@PathVariable("id") String id,
+                                               @RequestParam(value = "agentId", required = false) String agentId,
+                                               @RequestParam(value = "taskRecordId", required = false) String taskRecordId) {
+        log.info("subTask running status report by http, id = {}, agentId = {}, taskRecordId = {}", id, agentId, taskRecordId);
         TaskDto taskDto = taskService.findById(MongoUtils.toObjectId(id));
         Assert.notNull(taskDto, "task is empty");
         UserDetail userDetail = userService.loadUserById(new ObjectId(taskDto.getUserId()));
 
-        String successId = taskService.running(MongoUtils.toObjectId(id), userDetail);
+        String successId = taskService.running(MongoUtils.toObjectId(id), userDetail, agentId, taskRecordId);
         TaskOpResp taskOpResp = new TaskOpResp();
         if (StringUtils.isNotBlank(successId)) {
             taskOpResp = new TaskOpResp(successId);
@@ -783,13 +785,15 @@ public class TaskController extends BaseController {
     @Operation(summary = "任务运行失败回调接口")
     @PostMapping("runError/{id}")
     public ResponseMessage<TaskOpResp> runError(@PathVariable("id") String id, @RequestParam(value = "errMsg", required = false) String errMsg,
-                                                @RequestParam(value = "errStack", required = false) String errStack) {
-        log.info("subTask error status report by http, id = {}", id);
+                                                @RequestParam(value = "errStack", required = false) String errStack,
+                                                @RequestParam(value = "agentId", required = false) String agentId,
+                                                @RequestParam(value = "taskRecordId", required = false) String taskRecordId) {
+        log.info("subTask error status report by http, id = {}, agentId = {}, taskRecordId = {}", id, agentId, taskRecordId);
         TaskDto taskDto = taskService.findById(MongoUtils.toObjectId(id));
         Assert.notNull(taskDto, "task is empty");
         UserDetail userDetail = userService.loadUserById(new ObjectId(taskDto.getUserId()));
 
-        String successId = taskService.runError(MongoUtils.toObjectId(id), userDetail, errMsg, errStack);
+        String successId = taskService.runError(MongoUtils.toObjectId(id), userDetail, errMsg, errStack, agentId, taskRecordId);
         TaskOpResp taskOpResp = new TaskOpResp();
         if (StringUtils.isNotBlank(successId)) {
             taskOpResp = new TaskOpResp(successId);
@@ -805,13 +809,15 @@ public class TaskController extends BaseController {
      */
     @Operation(summary = "任务执行完成回调接口")
     @PostMapping("complete/{id}")
-    public ResponseMessage<TaskOpResp> complete(@PathVariable("id") String id) {
-        log.info("subTask complete status report by http, id = {}", id);
+    public ResponseMessage<TaskOpResp> complete(@PathVariable("id") String id,
+                                                @RequestParam(value = "agentId", required = false) String agentId,
+                                                @RequestParam(value = "taskRecordId", required = false) String taskRecordId) {
+        log.info("subTask complete status report by http, id = {}, agentId = {}, taskRecordId = {}", id, agentId, taskRecordId);
         TaskDto taskDto = taskService.findById(MongoUtils.toObjectId(id));
         Assert.notNull(taskDto, "task is empty");
         UserDetail userDetail = userService.loadUserById(new ObjectId(taskDto.getUserId()));
 
-        String successId = taskService.complete(MongoUtils.toObjectId(id), userDetail);
+        String successId = taskService.complete(MongoUtils.toObjectId(id), userDetail, agentId, taskRecordId);
         TaskOpResp taskOpResp = new TaskOpResp();
         if (StringUtils.isNotBlank(successId)) {
             taskOpResp = new TaskOpResp(successId);
@@ -827,13 +833,15 @@ public class TaskController extends BaseController {
      */
     @Operation(summary = "停止成功回调接口")
     @PostMapping("stopped/{id}")
-    public ResponseMessage<TaskOpResp> stopped(@PathVariable("id") String id) {
-        log.info("subTask stopped status report by http, id = {}", id);
+    public ResponseMessage<TaskOpResp> stopped(@PathVariable("id") String id,
+                                               @RequestParam(value = "agentId", required = false) String agentId,
+                                               @RequestParam(value = "taskRecordId", required = false) String taskRecordId) {
+        log.info("subTask stopped status report by http, id = {}, agentId = {}, taskRecordId = {}", id, agentId, taskRecordId);
         TaskDto taskDto = taskService.findById(MongoUtils.toObjectId(id));
         Assert.notNull(taskDto, "task is empty");
         UserDetail userDetail = userService.loadUserById(new ObjectId(taskDto.getUserId()));
 
-        String successId = taskService.stopped(MongoUtils.toObjectId(id), userDetail);
+        String successId = taskService.stopped(MongoUtils.toObjectId(id), userDetail, agentId, taskRecordId);
         TaskOpResp taskOpResp = new TaskOpResp();
         if (StringUtils.isNotBlank(successId)) {
             taskOpResp = new TaskOpResp(successId);

--- a/manager/tm/src/main/java/com/tapdata/tm/task/service/TaskServiceImpl.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/task/service/TaskServiceImpl.java
@@ -4903,9 +4903,23 @@ public class TaskServiceImpl extends TaskService{
      * @param id
      */
     public String running(ObjectId id, UserDetail user) {
+        return runningInternal(id, user, null, null);
+    }
+
+    @Override
+    public String running(ObjectId id, UserDetail user, String reportAgentId, String reportTaskRecordId) {
+        return runningInternal(id, user, reportAgentId, reportTaskRecordId);
+    }
+
+    private String runningInternal(ObjectId id, UserDetail user, String reportAgentId, String reportTaskRecordId) {
 
         //判断子任务是否存在
-        TaskDto taskDto = checkExistById(id, user, "_id", STATUS, "name", TASK_RECORD_ID, START_TIME, SCHEDULE_DATE);
+        TaskDto taskDto = StringUtils.isBlank(reportAgentId) && StringUtils.isBlank(reportTaskRecordId)
+                ? checkExistById(id, user, "_id", STATUS, "name", TASK_RECORD_ID, START_TIME, SCHEDULE_DATE)
+                : checkExistById(id, user, "_id", STATUS, "name", TASK_RECORD_ID, AGENT_ID, START_TIME, SCHEDULE_DATE);
+        if (!isValidTaskStatusReporter(taskDto, reportAgentId, reportTaskRecordId, DataFlowEvent.RUNNING)) {
+            return null;
+        }
 				// 已经运行中，直接返回
 				if (TaskDto.STATUS_RUNNING.equals(taskDto.getStatus())) {
 					return id.toHexString();
@@ -4941,8 +4955,22 @@ public class TaskServiceImpl extends TaskService{
      * @param id
      */
     public String runError(ObjectId id, UserDetail user, String errMsg, String errStack) {
+        return runErrorInternal(id, user, errMsg, errStack, null, null);
+    }
+
+    @Override
+    public String runError(ObjectId id, UserDetail user, String errMsg, String errStack, String reportAgentId, String reportTaskRecordId) {
+        return runErrorInternal(id, user, errMsg, errStack, reportAgentId, reportTaskRecordId);
+    }
+
+    private String runErrorInternal(ObjectId id, UserDetail user, String errMsg, String errStack, String reportAgentId, String reportTaskRecordId) {
         //判断任务是否存在。
-        TaskDto taskDto = checkExistById(id, user, "_id", STATUS, "name", TASK_RECORD_ID,"dag");
+        TaskDto taskDto = StringUtils.isBlank(reportAgentId) && StringUtils.isBlank(reportTaskRecordId)
+                ? checkExistById(id, user, "_id", STATUS, "name", TASK_RECORD_ID, "dag")
+                : checkExistById(id, user, "_id", STATUS, "name", TASK_RECORD_ID, AGENT_ID, "dag");
+        if (!isValidTaskStatusReporter(taskDto, reportAgentId, reportTaskRecordId, DataFlowEvent.ERROR)) {
+            return null;
+        }
 
         //将子任务状态更新成错误.
         StateMachineResult stateMachineResult = stateMachineService.executeAboutTask(taskDto, DataFlowEvent.ERROR, user);
@@ -4967,8 +4995,22 @@ public class TaskServiceImpl extends TaskService{
      * @param id
      */
     public String complete(ObjectId id, UserDetail user) {
+        return completeInternal(id, user, null, null);
+    }
+
+    @Override
+    public String complete(ObjectId id, UserDetail user, String reportAgentId, String reportTaskRecordId) {
+        return completeInternal(id, user, reportAgentId, reportTaskRecordId);
+    }
+
+    private String completeInternal(ObjectId id, UserDetail user, String reportAgentId, String reportTaskRecordId) {
         //判断子任务是否存在
-        TaskDto taskDto = checkExistById(id, user, "_id", STATUS, "name", TASK_RECORD_ID);
+        TaskDto taskDto = StringUtils.isBlank(reportAgentId) && StringUtils.isBlank(reportTaskRecordId)
+                ? checkExistById(id, user, "_id", STATUS, "name", TASK_RECORD_ID)
+                : checkExistById(id, user, "_id", STATUS, "name", TASK_RECORD_ID, AGENT_ID);
+        if (!isValidTaskStatusReporter(taskDto, reportAgentId, reportTaskRecordId, DataFlowEvent.COMPLETED)) {
+            return null;
+        }
 
         StateMachineResult stateMachineResult = stateMachineService.executeAboutTask(taskDto, DataFlowEvent.COMPLETED, user);
         if (stateMachineResult.isFail()) {
@@ -4985,8 +5027,20 @@ public class TaskServiceImpl extends TaskService{
      * @param id
      */
     public String stopped(ObjectId id, UserDetail user) {
+        return stoppedInternal(id, user, null, null);
+    }
+
+    @Override
+    public String stopped(ObjectId id, UserDetail user, String reportAgentId, String reportTaskRecordId) {
+        return stoppedInternal(id, user, reportAgentId, reportTaskRecordId);
+    }
+
+    private String stoppedInternal(ObjectId id, UserDetail user, String reportAgentId, String reportTaskRecordId) {
         //判断子任务是否存在。
         TaskDto taskDto = checkExistById(id, user, "dag", "name", STATUS, "_id", TASK_RECORD_ID, AGENT_ID, STOPED_DATE, RESTART_FLAG);
+        if (!isValidTaskStatusReporter(taskDto, reportAgentId, reportTaskRecordId, DataFlowEvent.STOPPED)) {
+            return null;
+        }
 
         StateMachineResult stateMachineResult = stateMachineService.executeAboutTask(taskDto, DataFlowEvent.STOPPED, user);
 
@@ -5025,6 +5079,22 @@ public class TaskServiceImpl extends TaskService{
         }
         taskUpdateDagService.updateDag(taskDto.getId(), dag,false);
         return id.toHexString();
+    }
+
+    private boolean isValidTaskStatusReporter(TaskDto taskDto, String reportAgentId, String reportTaskRecordId, DataFlowEvent event) {
+        if (StringUtils.isNotBlank(reportAgentId) && !Objects.equals(taskDto.getAgentId(), reportAgentId)) {
+            log.warn("TaskHA event=ignore_status_report reason=agent_mismatch taskId={} taskName={} status={} event={} currentAgentId={} reportAgentId={}",
+                    taskDto.getId().toHexString(), taskDto.getName(), taskDto.getStatus(), event, taskDto.getAgentId(), reportAgentId);
+            return false;
+        }
+        if (StringUtils.isNotBlank(reportTaskRecordId)
+                && StringUtils.isNotBlank(taskDto.getTaskRecordId())
+                && !Objects.equals(taskDto.getTaskRecordId(), reportTaskRecordId)) {
+            log.warn("TaskHA event=ignore_status_report reason=task_record_mismatch taskId={} taskName={} status={} event={} currentTaskRecordId={} reportTaskRecordId={}",
+                    taskDto.getId().toHexString(), taskDto.getName(), taskDto.getStatus(), event, taskDto.getTaskRecordId(), reportTaskRecordId);
+            return false;
+        }
+        return true;
     }
 
     /**

--- a/manager/tm/src/main/java/com/tapdata/tm/taskrebalance/service/TaskRebalanceService.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/taskrebalance/service/TaskRebalanceService.java
@@ -647,7 +647,7 @@ public class TaskRebalanceService extends BaseService<TaskRebalanceDto, TaskReba
             jobService.runAsRebalanceOperation(() -> taskService.pause(task, taskUser, false));
         }
         assertCurrentExecuteOwner(rebalanceId, userDetail);
-        if (!waitTaskStatus(rebalanceId, job.getTaskId(), TaskDto.STATUS_STOP, getTaskStatusTimeoutMs(), userDetail)) {
+        if (!waitTaskStatus(rebalanceId, job.getTaskId(), TaskDto.STATUS_STOP, job.getSourceAgentId(), getTaskStatusTimeoutMs(), userDetail)) {
             String reason = formatStopTimeoutReason(job);
             finishJob(job, TaskRebalanceJobStatus.STOP_TIMEOUT, reason, userDetail);
             return;
@@ -692,7 +692,7 @@ public class TaskRebalanceService extends BaseService<TaskRebalanceDto, TaskReba
             if (!TaskDto.STATUS_STOP.equals(task.getStatus())) {
                 jobService.runAsRebalanceOperation(() -> taskService.pause(task, taskUser, false));
                 assertCurrentExecuteOwner(rebalanceId, userDetail);
-                if (!waitTaskStatus(rebalanceId, job.getTaskId(), TaskDto.STATUS_STOP, getTaskStatusTimeoutMs(), userDetail)) {
+                if (!waitTaskStatus(rebalanceId, job.getTaskId(), TaskDto.STATUS_STOP, job.getSourceAgentId(), getTaskStatusTimeoutMs(), userDetail)) {
                     String reason = formatStopTimeoutReason(job);
                     finishJob(job, TaskRebalanceJobStatus.STOP_TIMEOUT, reason, userDetail);
                     return;
@@ -738,7 +738,7 @@ public class TaskRebalanceService extends BaseService<TaskRebalanceDto, TaskReba
     private void waitTargetRunningOrRollback(String rebalanceId, TaskRebalanceJobDto job, UserDetail taskUser, UserDetail userDetail,
                                              AtomicBoolean abortFlag, AtomicReference<String> abortReason) throws InterruptedException {
         assertCurrentExecuteOwner(rebalanceId, userDetail);
-        if (!waitTaskStatus(rebalanceId, job.getTaskId(), TaskDto.STATUS_RUNNING, getTaskStatusTimeoutMs(), userDetail)) {
+        if (!waitTaskStatus(rebalanceId, job.getTaskId(), TaskDto.STATUS_RUNNING, job.getTargetAgentId(), getTaskStatusTimeoutMs(), userDetail)) {
             if (isTaskRunningOnTarget(job)) {
                 finishJob(job, TaskRebalanceJobStatus.OK, null, userDetail);
                 return;
@@ -798,7 +798,7 @@ public class TaskRebalanceService extends BaseService<TaskRebalanceDto, TaskReba
         try {
             if (!TaskDto.STATUS_STOP.equals(current.getStatus())) {
                 jobService.runAsRebalanceOperation(() -> taskService.pause(current, taskUser, false));
-                waitTaskStatus(rebalanceId, job.getTaskId(), TaskDto.STATUS_STOP, getTaskStatusTimeoutMs(), userDetail);
+                waitTaskStatus(rebalanceId, job.getTaskId(), TaskDto.STATUS_STOP, job.getTargetAgentId(), getTaskStatusTimeoutMs(), userDetail);
             }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
@@ -892,15 +892,16 @@ public class TaskRebalanceService extends BaseService<TaskRebalanceDto, TaskReba
         }
     }
 
-    private boolean waitTaskStatus(String rebalanceId, String taskId, String expectedStatus, long timeoutMs, UserDetail userDetail) throws InterruptedException {
+    private boolean waitTaskStatus(String rebalanceId, String taskId, String expectedStatus, String expectedAgentId, long timeoutMs, UserDetail userDetail) throws InterruptedException {
         long deadline = System.currentTimeMillis() + timeoutMs;
         while (System.currentTimeMillis() < deadline) {
             if (Thread.currentThread().isInterrupted()) {
                 throw new InterruptedException("Task rebalance execution interrupted");
             }
             assertCurrentExecuteOwner(rebalanceId, userDetail);
-            TaskDto task = taskService.findByTaskId(new ObjectId(taskId), "status");
-            if (task != null && expectedStatus.equals(task.getStatus())) {
+            TaskDto task = taskService.findByTaskId(new ObjectId(taskId), "status", "agentId");
+            if (task != null && expectedStatus.equals(task.getStatus())
+                    && (StringUtils.isBlank(expectedAgentId) || Objects.equals(expectedAgentId, task.getAgentId()))) {
                 return true;
             }
             Thread.sleep(POLL_INTERVAL_MS);

--- a/manager/tm/src/test/java/com/tapdata/tm/task/service/TaskServiceImplTest.java
+++ b/manager/tm/src/test/java/com/tapdata/tm/task/service/TaskServiceImplTest.java
@@ -3961,6 +3961,52 @@ class TaskServiceImplTest {
             assertEquals(id.toHexString(),actual);
         }
     }
+
+    @Nested
+    class TaskStatusReporterValidationTest {
+        private ObjectId id;
+        private TaskDto dto;
+        private StateMachineService stateMachineService;
+
+        @BeforeEach
+        void beforeEach() {
+            id = mock(ObjectId.class);
+            dto = mock(TaskDto.class);
+            when(dto.getId()).thenReturn(id);
+            when(dto.getName()).thenReturn("rebalance-task");
+            stateMachineService = mock(StateMachineService.class);
+            ReflectionTestUtils.setField(taskService, "stateMachineService", stateMachineService);
+        }
+
+        @Test
+        @DisplayName("ignore running report from stale agent")
+        void ignoreRunningReportFromStaleAgent() {
+            when(taskService.checkExistById(id, user, "_id", "status", "name", "taskRecordId", "agentId", "startTime", "scheduleDate")).thenReturn(dto);
+            when(dto.getAgentId()).thenReturn("fe2");
+            when(dto.getTaskRecordId()).thenReturn("record-1");
+            doCallRealMethod().when(taskService).running(id, user, "fe1", "record-1");
+
+            String actual = taskService.running(id, user, "fe1", "record-1");
+
+            assertNull(actual);
+            verify(stateMachineService, never()).executeAboutTask(any(TaskDto.class), any(DataFlowEvent.class), any(UserDetail.class));
+        }
+
+        @Test
+        @DisplayName("ignore stopped report from stale task record")
+        void ignoreStoppedReportFromStaleTaskRecord() {
+            when(taskService.checkExistById(id, user, "dag", "name", "status", "_id", "taskRecordId", "agentId", "stopedDate", "restartFlag")).thenReturn(dto);
+            when(dto.getAgentId()).thenReturn("fe2");
+            when(dto.getTaskRecordId()).thenReturn("record-2");
+            doCallRealMethod().when(taskService).stopped(id, user, "fe2", "record-1");
+
+            String actual = taskService.stopped(id, user, "fe2", "record-1");
+
+            assertNull(actual);
+            verify(stateMachineService, never()).executeAboutTask(any(TaskDto.class), any(DataFlowEvent.class), any(UserDetail.class));
+        }
+    }
+
     @Nested
     class RunTimeInfoTest{
         private ObjectId id;


### PR DESCRIPTION
Stop residual local task clients after a task is reassigned to another engine and keep the global stopping timeout fallback unchanged. Add task status reporter validation by agent and task record so stale engine callbacks and pings cannot overwrite the active owner state. Fix HTTP update-by-id URL construction for status callback query parameters and cover the rebalance cleanup and reporter validation paths with tests.

Refs: TAP-12016