### PR TITLE
Fix(tm): TAP-11880 restrict interface permission updates

### DIFF
--- a/manager/tm-api/src/main/java/com/tapdata/tm/user/service/UserService.java
+++ b/manager/tm-api/src/main/java/com/tapdata/tm/user/service/UserService.java
@@ -37,7 +37,11 @@ public abstract class UserService extends BaseService<UserDto, User, ObjectId, U
 
     public abstract User buildUserFromTcmUser(UserInfoDto userInfoDto, String externalUserId);
 
-    public abstract UserDto updateUserSetting(String id, String settingJson, UserDetail userDetail, Locale locale);
+    public UserDto updateUserSetting(String id, String settingJson, UserDetail userDetail, Locale locale) {
+        return updateUserSetting(id, settingJson, userDetail, locale, false);
+    }
+
+    public abstract UserDto updateUserSetting(String id, String settingJson, UserDetail userDetail, Locale locale, boolean userManagementAllowed);
 
     public abstract UpdateResult updateById(User user);
 
@@ -81,4 +85,3 @@ public abstract class UserService extends BaseService<UserDto, User, ObjectId, U
 
     public abstract String refreshAccessCode(UserDetail userDetail);
 }
-

--- a/manager/tm/src/main/java/com/tapdata/tm/roleMapping/controller/RoleMappingController.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/roleMapping/controller/RoleMappingController.java
@@ -6,13 +6,17 @@
  */
 package com.tapdata.tm.roleMapping.controller;
 
+import com.tapdata.tm.Permission.service.PermissionService;
 import com.tapdata.tm.base.controller.BaseController;
 import com.tapdata.tm.base.dto.Field;
 import com.tapdata.tm.base.dto.Filter;
 import com.tapdata.tm.base.dto.Page;
 import com.tapdata.tm.base.dto.ResponseMessage;
 import com.tapdata.tm.base.dto.Where;
+import com.tapdata.tm.base.exception.BizException;
 import com.tapdata.tm.config.security.UserDetail;
+import com.tapdata.tm.permissions.constants.DataPermissionEnumsName;
+import com.tapdata.tm.roleMapping.dto.PrincipleType;
 import com.tapdata.tm.roleMapping.dto.RoleMappingDto;
 import com.tapdata.tm.roleMapping.service.RoleMappingService;
 import com.tapdata.tm.utils.MongoUtils;
@@ -23,14 +27,19 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
+import io.tapdata.utils.AppType;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.bson.Document;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -41,6 +50,8 @@ import org.springframework.web.bind.annotation.*;
 public class RoleMappingController extends BaseController {
 
     private final RoleMappingService roleMappingService;
+    @Autowired
+    private PermissionService permissionService;
 
     public RoleMappingController(RoleMappingService roleMappingService) {
         this.roleMappingService = roleMappingService;
@@ -55,6 +66,7 @@ public class RoleMappingController extends BaseController {
     @Operation(summary = "Create a new instance of the model and persist it into the data source")
     @PostMapping
     public ResponseMessage<RoleMappingDto> save(@RequestBody RoleMappingDto roleDto) {
+        checkRoleMappingPermission(roleDto);
         roleDto.setId(null);
         return success(roleMappingService.save(roleDto, getLoginUser()));
     }
@@ -70,6 +82,7 @@ public class RoleMappingController extends BaseController {
     public ResponseMessage<List<RoleMappingDto>> saveAll(@RequestBody List<RoleMappingDto> roleDtos) {
 //		return success(roleDtos.stream().map(roleDto -> save(roleDto).getData()).collect(Collectors.toList()));
         if (CollectionUtils.isNotEmpty(roleDtos)){
+            checkRoleMappingPermission(roleDtos);
             UserDetail userDetail=getLoginUser();
             roleMappingService.saveAll(roleDtos,userDetail);
         }
@@ -85,6 +98,7 @@ public class RoleMappingController extends BaseController {
     @Operation(summary = "Patch an existing model instance or insert a new one into the data source")
     @PatchMapping()
     public ResponseMessage<RoleMappingDto> update(@RequestBody RoleMappingDto roleDto) {
+        checkRoleMappingPermission(roleDto);
         return success(roleMappingService.save(roleDto, getLoginUser()));
     }
 
@@ -122,6 +136,7 @@ public class RoleMappingController extends BaseController {
     @Operation(summary = "Replace an existing model instance or insert a new one into the data source")
     @PutMapping
     public ResponseMessage<RoleMappingDto> put(@RequestBody RoleMappingDto roleDto) {
+        checkRoleMappingPermission(roleDto);
         return success(roleMappingService.replaceOrInsert(roleDto, getLoginUser()));
     }
 
@@ -149,6 +164,7 @@ public class RoleMappingController extends BaseController {
     @Operation(summary = "Patch attributes for a model instance and persist it into the data source")
     @PatchMapping("{id}")
     public ResponseMessage<RoleMappingDto> updateById(@PathVariable("id") String id, @RequestBody RoleMappingDto roleDto) {
+        checkRoleMappingPermission(id, roleDto);
         roleDto.setId(MongoUtils.toObjectId(id));
         return success(roleMappingService.save(roleDto, getLoginUser()));
     }
@@ -177,6 +193,7 @@ public class RoleMappingController extends BaseController {
     @Operation(summary = "Replace attributes for a model instance and persist it into the data source.")
     @PutMapping("{id}")
     public ResponseMessage<RoleMappingDto> replceById(@PathVariable("id") String id, @RequestBody RoleMappingDto roleDto) {
+        checkRoleMappingPermission(id, roleDto);
         return success(roleMappingService.replaceById(MongoUtils.toObjectId(id), roleDto, getLoginUser()));
     }
 
@@ -189,6 +206,7 @@ public class RoleMappingController extends BaseController {
     @Operation(summary = "Replace attributes for a model instance and persist it into the data source.")
     @PostMapping("{id}/replace")
     public ResponseMessage<RoleMappingDto> replaceById2(@PathVariable("id") String id, @RequestBody RoleMappingDto roleDto) {
+        checkRoleMappingPermission(id, roleDto);
         return success(roleMappingService.replaceById(MongoUtils.toObjectId(id), roleDto, getLoginUser()));
     }
 
@@ -202,6 +220,8 @@ public class RoleMappingController extends BaseController {
     @Operation(summary = "Delete a model instance by {{id}} from the data source")
     @DeleteMapping("{id}")
     public ResponseMessage<Void> delete(@PathVariable("id") String id) {
+        RoleMappingDto roleMappingDto = roleMappingService.findById(MongoUtils.toObjectId(id), new Field());
+        checkRoleMappingPermission(roleMappingDto);
         roleMappingService.removeRoleFromUser(id);
         return success();
     }
@@ -277,6 +297,7 @@ public class RoleMappingController extends BaseController {
             _body.put("$set", update);
             update = _body;
         }
+        checkRoleMappingUpdateByWherePermission(where, update);
 
         long count = roleMappingService.updateByWhere(where, update, getLoginUser());
         HashMap<String, Long> countValue = new HashMap<>();
@@ -293,7 +314,108 @@ public class RoleMappingController extends BaseController {
     @Operation(summary = "Update an existing model instance or insert a new one into the data source based on the where criteria.")
     @PostMapping("upsertWithWhere")
     public ResponseMessage<RoleMappingDto> upsertByWhere(@RequestParam("where") String whereJson, @RequestBody RoleMappingDto roleDto) {
+        checkRoleMappingPermission(roleDto);
         Where where = parseWhere(whereJson);
         return success(roleMappingService.upsertByWhere(where, roleDto, getLoginUser()));
+    }
+
+    private void checkRoleMappingPermission(List<RoleMappingDto> roleDtos) {
+        for (RoleMappingDto roleDto : roleDtos) {
+            checkRoleMappingPermission(roleDto);
+        }
+    }
+
+    private void checkRoleMappingPermission(RoleMappingDto roleDto) {
+        if (roleDto == null) {
+            throw new BizException("IllegalArgument", "roleMapping");
+        }
+        if (roleDto.getId() != null) {
+            checkRoleMappingPermission(roleDto.getId().toHexString(), roleDto);
+            return;
+        }
+        checkRoleMappingPrincipalTypePermission(roleDto.getPrincipalType());
+    }
+
+    private void checkRoleMappingPermission(String id, RoleMappingDto roleDto) {
+        RoleMappingDto oldRoleMapping = roleMappingService.findById(MongoUtils.toObjectId(id), new Field());
+        if (oldRoleMapping != null) {
+            checkRoleMappingPrincipalTypePermission(oldRoleMapping.getPrincipalType());
+        }
+        if (roleDto != null && roleDto.getPrincipalType() != null) {
+            checkRoleMappingPrincipalTypePermission(roleDto.getPrincipalType());
+            return;
+        }
+        if (oldRoleMapping == null) {
+            throw new BizException("IllegalArgument", "roleMapping");
+        }
+    }
+
+    private void checkRoleMappingPrincipalTypePermission(String principalType) {
+        if (PrincipleType.USER.getValue().equals(principalType)) {
+            checkUserManagementPermission();
+        } else if (PrincipleType.PERMISSION.getValue().equals(principalType)) {
+            checkRoleManagementPermission();
+        } else {
+            throw new BizException("IllegalArgument", "principalType");
+        }
+    }
+
+    private void checkRoleMappingUpdateByWherePermission(Where where, Document update) {
+        Set<String> principalTypes = new HashSet<>();
+        if (where != null) {
+            collectPrincipalTypes(where.get("principalType"), principalTypes);
+        }
+        Object set = update.get("$set");
+        if (set instanceof Map) {
+            collectPrincipalTypes(((Map<?, ?>) set).get("principalType"), principalTypes);
+        }
+        if (principalTypes.isEmpty()) {
+            checkUserManagementPermission();
+            checkRoleManagementPermission();
+            return;
+        }
+        for (String principalType : principalTypes) {
+            checkRoleMappingPrincipalTypePermission(principalType);
+        }
+    }
+
+    private void collectPrincipalTypes(Object value, Set<String> principalTypes) {
+        if (value instanceof String) {
+            principalTypes.add((String) value);
+        } else if (value instanceof Collection) {
+            ((Collection<?>) value).stream()
+                    .filter(String.class::isInstance)
+                    .map(String.class::cast)
+                    .forEach(principalTypes::add);
+        } else if (value instanceof Map) {
+            Map<?, ?> map = (Map<?, ?>) value;
+            collectPrincipalTypes(map.get("$eq"), principalTypes);
+            collectPrincipalTypes(map.get("$in"), principalTypes);
+        }
+    }
+
+    private void checkUserManagementPermission() {
+        if (!hasUserManagementPermission()) {
+            throw new BizException("NotAuthorized");
+        }
+    }
+
+    private boolean hasUserManagementPermission() {
+        if (AppType.currentType().isCloud()) {
+            return true;
+        }
+        UserDetail userDetail = getLoginUser();
+        String userId = userDetail.getUserId();
+        return permissionService.checkCurrentUserHasPermission(DataPermissionEnumsName.V2_USER_MANAGEMENT, userId);
+    }
+
+    private void checkRoleManagementPermission() {
+        UserDetail userDetail = getLoginUser();
+        String userId = userDetail.getUserId();
+        if (AppType.currentType().isCloud()
+            || permissionService.checkCurrentUserHasPermission(DataPermissionEnumsName.V2_ROLE_MANAGEMENT, userId)) {
+            return;
+        }
+        throw new BizException("NotAuthorized");
     }
 }

--- a/manager/tm/src/main/java/com/tapdata/tm/user/controller/UserController.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/user/controller/UserController.java
@@ -35,6 +35,7 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import io.tapdata.utils.AppType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
@@ -42,7 +43,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.bson.types.ObjectId;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.caffeine.CaffeineCacheManager;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
@@ -93,8 +93,6 @@ public class UserController extends BaseController {
     @Autowired
     UserLogService userLogService;
 
-    @Value("#{'${spring.profiles.include:idaas}'.split(',')}")
-    private List<String> productList;
     @Autowired
     @Qualifier("caffeineCache")
     private CaffeineCacheManager userCache;
@@ -127,7 +125,9 @@ public class UserController extends BaseController {
         ServletRequestAttributes attributes = (ServletRequestAttributes) RequestContextHolder.currentRequestAttributes();
         HttpServletRequest request = attributes.getRequest();
         Locale locale = WebUtils.getLocale(request);
-        return success(userService.updateUserSetting(id, settingJson, getLoginUser(),locale));
+        UserDetail userDetail = getLoginUser();
+        boolean hasPermission = checkUserPermission(DataPermissionEnumsName.V2_ROLE_MANAGEMENT, userDetail.getUserId());
+        return success(userService.updateUserSetting(id, settingJson, userDetail, locale, hasPermission));
     }
 
     /**
@@ -194,7 +194,7 @@ public class UserController extends BaseController {
      */
     @GetMapping("{userId}")
     public ResponseMessage<UserDto> getUser(@PathVariable(value = "userId") String userId) {
-        if (productList != null && productList.contains("dfs")) {
+        if (AppType.currentType().isDfs()) {
             return success(Optional.ofNullable(userCache.getCache("userCache"))
                     .map(cache -> cache.get(userId, () -> userService.getUserDetail(userId)))
                     .orElseGet(() -> userService.getUserDetail(userId)));
@@ -429,8 +429,9 @@ public class UserController extends BaseController {
     @Operation(summary = "user deletePermissionRoleMapping")
     @DeleteMapping("/deletePermissionRoleMapping")
     public ResponseMessage<Page<RoleDto>> deletePermissionRoleMapping(@RequestParam(value = "id") String id, @RequestBody DeletePermissionRoleMappingDto dto) {
-
         UserDetail userDetail = getLoginUser();
+        checkRoleManagementPermission(userDetail);
+
         roleMappingService.deleteAll(Query.query(Criteria.where("roleId").is(toObjectId(id)).and("principalType").is("PERMISSION")));
         if (CollectionUtils.isNotEmpty(dto.getData())) {
             roleMappingService.save(dto.getData(), userDetail);
@@ -442,8 +443,10 @@ public class UserController extends BaseController {
     @Operation(summary = "user updatePermissionRoleMapping")
     @PutMapping("/updatePermissionRoleMapping")
     public ResponseMessage<Page<RoleDto>> updatePermissionRoleMapping(@RequestBody UpdatePermissionRoleMappingDto dto) {
-        userService.updatePermissionRoleMapping(dto, getLoginUser());
+        UserDetail userDetail = getLoginUser();
+        checkRoleManagementPermission(userDetail);
 
+        userService.updatePermissionRoleMapping(dto, userDetail);
         return success();
 
     }
@@ -463,8 +466,11 @@ public class UserController extends BaseController {
     @Operation(summary = "Update instances of the model matched by {{where}} from the data source")
     @PostMapping("update")
     public ResponseMessage<Map<String, Long>> updateByWhere(@RequestParam("where") String whereJson, @RequestBody UserDto userDto) {
+        UserDetail userDetail = getLoginUser();
+        checkUserManagementPermission(userDetail);
+
         Where where = parseWhere(whereJson);
-        long count = userService.updateByWhere(where, userDto, getLoginUser());
+        long count = userService.updateByWhere(where, userDto, userDetail);
         HashMap<String, Long> countValue = new HashMap<>();
         countValue.put("count", count);
         return success(countValue);
@@ -473,12 +479,10 @@ public class UserController extends BaseController {
     @Operation(summary = "Create a new instance of the model and persist it into the data source")
     @PostMapping
     public ResponseMessage<UserDto> save(@RequestBody @Validated CreateUserRequest request) {
-        if ((productList != null && productList.contains("dfs")) ||
-                Boolean.TRUE.equals(permissionService.checkCurrentUserHasPermission(DataPermissionEnumsName.V2_USER_MANAGEMENT, getLoginUser().getUserId()))) {
-            return success(userService.save(request, getLoginUser()));
-        } else {
-            throw new BizException("NotAuthorized");
-        }
+        UserDetail userDetail = getLoginUser();
+        checkUserManagementPermission(userDetail);
+
+        return success(userService.save(request, userDetail));
     }
 
     @Operation(summary = "User change password")
@@ -529,7 +533,10 @@ public class UserController extends BaseController {
     @Operation(summary = "企业版重置密码")
     @DeleteMapping("{id}")
     public ResponseMessage<Long> delete(@PathVariable("id") String id) {
-        userService.delete(id, getLoginUser());
+        UserDetail userDetail = getLoginUser();
+        checkUserManagementPermission(userDetail);
+
+        userService.delete(id, userDetail);
         return success();
     }
 
@@ -558,10 +565,33 @@ public class UserController extends BaseController {
     @Operation(summary = " 批量修改所属类别")
     @PatchMapping("batchUpdateListtags")
     public ResponseMessage<String> batchUpdateListTags( @RequestBody BatchUpdateParam batchUpdateParam) {
+        UserDetail userDetail = getLoginUser();
+        checkUserManagementPermission(userDetail);
+
         List<String> idList = batchUpdateParam.getId();
         List<com.tapdata.tm.commons.schema.Tag> listTags = batchUpdateParam.getListtags();
         Update update = new Update().set("listtags", listTags);
-        userService.update(new Query(Criteria.where("id").in(idList)), update, getLoginUser());
+        userService.update(new Query(Criteria.where("id").in(idList)), update, userDetail);
         return success();
+    }
+
+    private void checkUserManagementPermission(UserDetail userDetail) {
+        if (!checkUserPermission(DataPermissionEnumsName.V2_USER_MANAGEMENT, userDetail.getUserId())) {
+            throw new BizException("NotAuthorized");
+        }
+    }
+
+    private void checkRoleManagementPermission(UserDetail userDetail) {
+        if (!checkUserPermission(DataPermissionEnumsName.V2_ROLE_MANAGEMENT, userDetail.getUserId())) {
+            throw new BizException("NotAuthorized");
+        }
+    }
+
+    private boolean checkUserPermission(String permissionName, String userId) {
+        if (AppType.currentType().isCloud()) {
+            return true;
+        }
+
+        return permissionService.checkCurrentUserHasPermission(permissionName, userId);
     }
 }

--- a/manager/tm/src/main/java/com/tapdata/tm/user/service/UserServiceImpl.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/user/service/UserServiceImpl.java
@@ -89,6 +89,34 @@ public class UserServiceImpl extends UserService{
      * 权限过滤关键字：包含这些关键字的子权限不会被自动添加，需要用户手动指定
      */
     private static final List<String> EXCLUDED_PERMISSION_KEYWORDS = List.of("import", "export", "all_data", "copy", "creation");
+    private static final Set<String> SELF_UPDATE_FIELDS = Set.of(
+            "notification",
+            "guideData",
+            "isCompleteGuide",
+            "locale",
+            "photo"
+    );
+    private static final Set<String> USER_MANAGEMENT_UPDATE_FIELDS = Set.of(
+            "id",
+            "username",
+            "email",
+            "ldapAccount",
+            "roleusers",
+            "status",
+            "password",
+            "accesscode",
+            "emailVerified",
+            "emailVerified_from_frontend",
+            "account_status",
+            "listtags",
+            "phone",
+            "photo",
+            "locale"
+    );
+    private static final Set<String> IGNORED_USER_UPDATE_FIELDS = Set.of(
+            "id",
+            "groups"
+    );
 
     public UserServiceImpl(@NonNull UserRepository repository) {
         super(repository);
@@ -331,11 +359,17 @@ public class UserServiceImpl extends UserService{
      *                                                                                                                                                               {\"guideData\":{\"noShow\":false,\"updateTime\":1632380823831,\"action\":false}}"
      * @return
      */
-    public UserDto updateUserSetting(String id, String settingJson, UserDetail userDetail,Locale locale) {
+    @Override
+    public UserDto updateUserSetting(String id, String settingJson, UserDetail userDetail, Locale locale, boolean userManagementAllowed) {
         JSONObject jsonObject = new JSONObject(settingJson);
+        validateUserSettingFields(id, jsonObject, userDetail, userManagementAllowed);
+        boolean updateRoleUsers = jsonObject.containsKey("roleusers");
         Iterator<String> iterator = jsonObject.keySet().iterator();
         while (iterator.hasNext()) {
             String key = iterator.next();
+            if (IGNORED_USER_UPDATE_FIELDS.contains(key) || "roleusers".equals(key)) {
+                continue;
+            }
             Object value = jsonObject.get(key);
             if ("password".equals(key) && value != null) {
                 if (StringUtils.isEmpty(value.toString())) {
@@ -350,10 +384,37 @@ public class UserServiceImpl extends UserService{
             UpdateResult updateResult = repository.getMongoOperations().updateMulti(query, update, User.class);
         }
         UserDto userDto = findById(toObjectId(id));
-        List<RoleMappingDto> roleMappingDtos = updateRoleMapping(id, userDto.getRoleusers(), userDetail);
-        userDto.setRoleMappings(roleMappingDtos);
+        if (updateRoleUsers) {
+            List<Object> roleusers = jsonObject.getJSONArray("roleusers") == null
+                    ? Collections.emptyList()
+                    : jsonObject.getJSONArray("roleusers").toList(Object.class);
+            List<RoleMappingDto> roleMappingDtos = updateRoleMapping(id, roleusers, userDetail);
+            userDto.setRoleMappings(roleMappingDtos);
+        }
         userLogService.addUserLog(Modular.USER, Operation.UPDATE, userDetail.getUserId(), userDto.getUserId(), StringUtils.isNotBlank(userDto.getLdapAccount()) ? userDto.getLdapAccount() : userDto.getEmail());
         return userDto;
+    }
+
+    protected void validateUserSettingFields(String id, JSONObject jsonObject, UserDetail userDetail, boolean userManagementAllowed) {
+        if (jsonObject == null || jsonObject.isEmpty()) {
+            throw new BizException("IllegalArgument", "settingJson");
+        }
+        boolean selfUpdate = StringUtils.equals(id, userDetail.getUserId());
+        Set<String> allowedFields = userManagementAllowed ? USER_MANAGEMENT_UPDATE_FIELDS : SELF_UPDATE_FIELDS;
+        for (String key : jsonObject.keySet()) {
+            if (IGNORED_USER_UPDATE_FIELDS.contains(key)) {
+                if (!"id".equals(key) && !userManagementAllowed) {
+                    throw new BizException("NotAuthorized");
+                }
+                continue;
+            }
+            if (!allowedFields.contains(key)) {
+                throw new BizException("NotAuthorized");
+            }
+        }
+        if (!userManagementAllowed && !selfUpdate) {
+            throw new BizException("NotAuthorized");
+        }
     }
 
     /**
@@ -431,7 +492,8 @@ public class UserServiceImpl extends UserService{
     }
     protected List<RoleMappingDto> updateRoleMapping(String userId, List<Object> roleusers, UserDetail userDetail) {
         // delete old role mapping
-        if (CollectionUtils.isNotEmpty(roleusers)) {
+        if (roleusers != null) {
+            validateRoleUsers(roleusers);
             long deleted = roleMappingService.deleteAll(Query.query(Criteria.where("principalId").is(userId).and("principalType").is("USER")));
             log.info("delete old role mapping for userId {}, deleted: {}", userId, deleted);
         // add new role mapping
@@ -447,6 +509,24 @@ public class UserServiceImpl extends UserService{
             }
         }
         return null;
+    }
+
+    protected void validateRoleUsers(List<Object> roleusers) {
+        if (CollectionUtils.isEmpty(roleusers)) {
+            return;
+        }
+        List<ObjectId> roleIds = roleusers.stream()
+                .map(roleId -> {
+                    if (!(roleId instanceof String) || !ObjectId.isValid((String) roleId)) {
+                        throw new BizException("IllegalArgument", "roleusers");
+                    }
+                    return new ObjectId((String) roleId);
+                })
+                .collect(Collectors.toList());
+        long roleCount = roleService.count(Query.query(Criteria.where("_id").in(roleIds)));
+        if (roleCount != new HashSet<>(roleIds).size()) {
+            throw new BizException("IllegalArgument", "roleusers");
+        }
     }
 
     protected String randomHexString() {

--- a/manager/tm/src/test/java/com/tapdata/tm/user/service/UserServiceImplTest.java
+++ b/manager/tm/src/test/java/com/tapdata/tm/user/service/UserServiceImplTest.java
@@ -92,9 +92,19 @@ public class UserServiceImplTest {
 
         @Test
         void testForAdmin(){
-            doCallRealMethod().when(userService).updateRoleMapping(userId,roleusers,userDetail);
-            List<RoleMappingDto> actual = userService.updateRoleMapping(userId, roleusers, userDetail);
+            doCallRealMethod().when(userService).updateRoleMapping(userId,null,userDetail);
+            List<RoleMappingDto> actual = userService.updateRoleMapping(userId, null, userDetail);
             verify(roleMappingService,new Times(0)).deleteAll(any(Query.class));
+            assertNull(actual);
+        }
+
+        @Test
+        void testForClearRoles(){
+            doCallRealMethod().when(userService).updateRoleMapping(userId,roleusers,userDetail);
+            doCallRealMethod().when(userService).validateRoleUsers(roleusers);
+            List<RoleMappingDto> actual = userService.updateRoleMapping(userId, roleusers, userDetail);
+            verify(roleMappingService,new Times(1)).deleteAll(any(Query.class));
+            verify(roleMappingService,new Times(0)).updateUserRoleMapping(anyList(), any(UserDetail.class));
             assertNull(actual);
         }
 
@@ -103,6 +113,8 @@ public class UserServiceImplTest {
             when(userDetail.getEmail()).thenReturn("test@tapdata.com");
             roleusers.add("5d31ae1ab953565ded04badd");
             doCallRealMethod().when(userService).updateRoleMapping(userId,roleusers,userDetail);
+            doCallRealMethod().when(userService).validateRoleUsers(roleusers);
+            when(roleService.count(any(Query.class))).thenReturn(1L);
             List<RoleMappingDto> actual = userService.updateRoleMapping(userId, roleusers, userDetail);
             verify(roleMappingService,new Times(1)).deleteAll(any(Query.class));
             verify(roleMappingService,new Times(1)).updateUserRoleMapping(anyList(), any(UserDetail.class));
@@ -769,9 +781,47 @@ public class UserServiceImplTest {
         when(userService.findById(any(ObjectId.class))).thenReturn(userDto);
         when(userDto.getUserId()).thenReturn("671b091f4193690843a27c9a");
         when(userDto.getEmail()).thenReturn("test@tapdata.io");
-        doCallRealMethod().when(userService).updateUserSetting(id, settingJson, userDetail, locale);
-        userService.updateUserSetting(id, settingJson, userDetail, locale);
+        when(roleService.count(any(Query.class))).thenReturn(1L);
+        doCallRealMethod().when(userService).updateUserSetting(id, settingJson, userDetail, locale, true);
+        doCallRealMethod().when(userService).validateUserSettingFields(anyString(), any(), any(UserDetail.class), anyBoolean());
+        doCallRealMethod().when(userService).validateRoleUsers(anyList());
+        userService.updateUserSetting(id, settingJson, userDetail, locale, true);
         verify(userLogService, new Times(1)).addUserLog(Modular.USER, Operation.UPDATE, "671b091f4193690843a27c9a", "671b091f4193690843a27c9a", "test@tapdata.io");
+    }
+
+    @Test
+    void testUpdateUserSettingWithoutUserManagementCannotUpdateRoleUsers() {
+        String id = "675fa0e310853b4b042db50c";
+        String settingJson = "{\"roleusers\":[\"671b07fd4193690843a27bd4\"]}";
+        UserDetail userDetail = mock(UserDetail.class);
+        when(userDetail.getUserId()).thenReturn(id);
+        doCallRealMethod().when(userService).updateUserSetting(id, settingJson, userDetail, Locale.CHINA, false);
+        doCallRealMethod().when(userService).validateUserSettingFields(anyString(), any(), any(UserDetail.class), anyBoolean());
+
+        BizException exception = assertThrows(BizException.class, () -> userService.updateUserSetting(id, settingJson, userDetail, Locale.CHINA, false));
+        assertEquals("NotAuthorized", exception.getErrorCode());
+        verify(roleMappingService, never()).deleteAll(any(Query.class));
+    }
+
+    @Test
+    void testUpdateUserSettingWithoutUserManagementCanUpdateSelfNotification() {
+        String id = "675fa0e310853b4b042db50c";
+        String settingJson = "{\"notification\":{\"connected\":{\"email\":true,\"sms\":false}}}";
+        UserDetail userDetail = mock(UserDetail.class);
+        MongoTemplate mongoTemplate = mock(MongoTemplate.class);
+        UserDto userDto = mock(UserDto.class);
+        when(repository.getMongoOperations()).thenReturn(mongoTemplate);
+        when(userDetail.getUserId()).thenReturn(id);
+        when(userDto.getUserId()).thenReturn(id);
+        when(userDto.getEmail()).thenReturn("test@tapdata.io");
+        when(userService.findById(any(ObjectId.class))).thenReturn(userDto);
+        doCallRealMethod().when(userService).updateUserSetting(id, settingJson, userDetail, Locale.CHINA, false);
+        doCallRealMethod().when(userService).validateUserSettingFields(anyString(), any(), any(UserDetail.class), anyBoolean());
+
+        userService.updateUserSetting(id, settingJson, userDetail, Locale.CHINA, false);
+
+        verify(mongoTemplate, new Times(1)).updateMulti(any(Query.class), any(Update.class), eq(User.class));
+        verify(roleMappingService, never()).deleteAll(any(Query.class));
     }
 
     @Nested


### PR DESCRIPTION
Add permission checks for user and role mapping mutation APIs so user-management and role-management operations require the matching permission outside cloud deployments.

Restrict user setting updates to self-service fields unless user management is allowed, and validate role assignments before replacing role mappings.

Refs: TAP-11880