### PR TITLE
fix(iengine): add write-behind cache backpressure to prevent merge-ta…

### DIFF
--- a/iengine/iengine-common/src/main/java/io/tapdata/construct/constructImpl/BytesIMap.java
+++ b/iengine/iengine-common/src/main/java/io/tapdata/construct/constructImpl/BytesIMap.java
@@ -29,7 +29,7 @@ public class BytesIMap<T> extends ConstructIMap<T> {
 
 	@Override
 	public int insert(String key, T data) throws Exception {
-		iMap.put(key, new Document(DATA_KEY, serialized(data)));
+		putInternal(key, new Document(DATA_KEY, serialized(data)));
 		return 1;
 	}
 
@@ -45,12 +45,8 @@ public class BytesIMap<T> extends ConstructIMap<T> {
 
 	@Override
 	public int delete(String key) throws Exception {
-		int delete = 0;
-
-		iMap.remove(key);
-		delete++;
-
-		return delete;
+		removeInternal(key);
+		return 1;
 	}
 
 	@Override

--- a/iengine/iengine-common/src/main/java/io/tapdata/construct/constructImpl/ConstructIMap.java
+++ b/iengine/iengine-common/src/main/java/io/tapdata/construct/constructImpl/ConstructIMap.java
@@ -23,6 +23,24 @@ import java.util.Set;
  **/
 public class ConstructIMap<T> extends BaseConstruct<T> {
 
+	/**
+	 * Process-wide write-side backpressure policy. It bounds the GLOBAL write-behind backlog (total pending
+	 * entries across all cache IMaps) so a slow/failing external storage cannot OOM the engine. Backlog is
+	 * read from the background sampler; every write path routes through {@link #applyBackpressure()}.
+	 */
+	private static final WriteBehindBackpressure BACKPRESSURE = WriteBehindBackpressure.fromEnv(
+			new WriteBehindBackpressure.BacklogSource() {
+				@Override
+				public long total() {
+					return WriteBehindBacklogSampler.getInstance().totalBacklog();
+				}
+
+				@Override
+				public long ofMap(String name) {
+					return WriteBehindBacklogSampler.getInstance().backlog(name);
+				}
+			});
+
 	protected IMap<String, Object> iMap;
 
 	public ConstructIMap(HazelcastInstance hazelcastInstance, String name) {
@@ -44,16 +62,38 @@ public class ConstructIMap<T> extends BaseConstruct<T> {
 			convertTtlDay2Second(ttlDay);
 			PersistenceStorage.getInstance().setImapTTL(this.iMap, this.ttlSecond);
 		}
+		// Only MapStore-backed (external storage) IMaps can have a write-behind queue, so only those are sampled.
+		if (BACKPRESSURE.isEnabled()) {
+			WriteBehindBacklogSampler.getInstance().register(name, iMap);
+		}
+	}
+
+	/** Apply global write-behind backpressure before a write. Delegates to the shared policy. */
+	protected void applyBackpressure() throws Exception {
+		BACKPRESSURE.apply(name);
+	}
+
+	/** Single guarded write path: every put goes through here so backpressure cannot be bypassed. */
+	protected void putInternal(String key, Object value) throws Exception {
+		applyBackpressure();
+		iMap.put(key, value);
+	}
+
+	/** Single guarded remove path: write-behind deletes also enqueue tombstones, so throttle them too. */
+	protected void removeInternal(String key) throws Exception {
+		applyBackpressure();
+		iMap.remove(key);
 	}
 
 	@Override
 	public int insert(String key, T data) throws Exception {
-		iMap.put(key, data);
+		putInternal(key, data);
 		return 1;
 	}
 
 	@Override
 	public long insertMany(Map<String, T> data) throws Exception {
+		applyBackpressure();
 		iMap.putAll(data);
 		return data.size();
 	}
@@ -70,12 +110,8 @@ public class ConstructIMap<T> extends BaseConstruct<T> {
 
 	@Override
 	public int delete(String key) throws Exception {
-		int delete = 0;
-
-		iMap.remove(key);
-		delete++;
-
-		return delete;
+		removeInternal(key);
+		return 1;
 	}
 
 	@Override
@@ -145,6 +181,7 @@ public class ConstructIMap<T> extends BaseConstruct<T> {
 
 	@Override
 	public void destroy() throws Exception {
+		WriteBehindBacklogSampler.getInstance().unregister(name);
 		if (PersistenceStorage.getInstance().destroy(referenceId, ConstructType.IMAP, name) && null != iMap) {
 			iMap.destroy();
 		}

--- a/iengine/iengine-common/src/main/java/io/tapdata/construct/constructImpl/DocumentIMap.java
+++ b/iengine/iengine-common/src/main/java/io/tapdata/construct/constructImpl/DocumentIMap.java
@@ -27,7 +27,7 @@ public class DocumentIMap<T> extends ConstructIMap<T> {
 	public int insert(String key, T data) throws Exception {
 		if (!(data instanceof Document)) {
 			Document document = new Document(DOCUMENT_KEY, data);
-			iMap.put(key, document);
+			putInternal(key, document);
 			return 1;
 		} else {
 			return super.insert(key, data);

--- a/iengine/iengine-common/src/main/java/io/tapdata/construct/constructImpl/WriteBehindBacklogSampler.java
+++ b/iengine/iengine-common/src/main/java/io/tapdata/construct/constructImpl/WriteBehindBacklogSampler.java
@@ -1,0 +1,141 @@
+package io.tapdata.construct.constructImpl;
+
+import com.hazelcast.map.IMap;
+import io.tapdata.pdk.core.utils.CommonUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Background sampler of the write-behind backlog for the registered cache IMaps, used by
+ * {@link ConstructIMap} for write-side "watermark backpressure" so that a slow or failing external storage
+ * (e.g. MongoDB) cannot let the write-behind queue grow unbounded into an engine OOM.
+ *
+ * Design notes:
+ * - Backlog is read from Hazelcast's public stats: {@code IMap.getLocalMapStats().getDirtyEntryCount()},
+ *   which equals the sum of the (primary) write-behind queue sizes for that map — no internal reflection,
+ *   no partition scan, no backup double-count.
+ * - A single daemon thread samples the registered maps periodically into volatile fields; the write path
+ *   does one O(1) read ({@link #totalBacklog()}), so there is no hot-path cost.
+ * - Robust by design: a transient per-map failure keeps the last known value (never reports a spurious 0 that
+ *   would release all blocked writers at once); a map that fails repeatedly (likely destroyed) is dropped;
+ *   the sampler is never permanently disabled.
+ *
+ * @author samuel
+ */
+final class WriteBehindBacklogSampler {
+
+	private static final Logger logger = LogManager.getLogger(WriteBehindBacklogSampler.class);
+
+	private static final WriteBehindBacklogSampler INSTANCE = new WriteBehindBacklogSampler();
+
+	static WriteBehindBacklogSampler getInstance() {
+		return INSTANCE;
+	}
+
+	/** Sampling interval (ms), configurable at process level via env / -D. */
+	private static final long SAMPLE_INTERVAL_MS =
+			Math.max(20L, CommonUtils.getPropertyLong("TAPDATA_IMAP_BACKLOG_SAMPLE_INTERVAL_MS", 200L));
+	/** Drop a map after this many consecutive sampling failures (it has almost certainly been destroyed). */
+	private static final int MAX_MAP_FAILURES = 10;
+
+	private final Map<String, IMap<?, ?>> registered = new ConcurrentHashMap<>();
+	private final Map<String, Integer> failures = new ConcurrentHashMap<>();
+	private volatile Map<String, Long> backlogByMap = Collections.emptyMap();
+	private volatile long totalBacklog = 0L;
+	private boolean started = false;
+
+	private WriteBehindBacklogSampler() {
+	}
+
+	/** Register a write-behind cache IMap to be sampled, and lazily start the sampling thread (idempotent). */
+	void register(String name, IMap<?, ?> imap) {
+		if (name == null || imap == null) {
+			return;
+		}
+		registered.put(name, imap);
+		ensureStarted();
+	}
+
+	/** Stop sampling a map (call on destroy) so we don't poll a dead IMap. */
+	void unregister(String name) {
+		if (name == null) {
+			return;
+		}
+		registered.remove(name);
+		failures.remove(name);
+	}
+
+	/** Total pending write-behind entries across all registered caches (last sample); 0 before the first sample. */
+	long totalBacklog() {
+		return totalBacklog;
+	}
+
+	/** Pending write-behind entries for one cache (last sample); 0 if unknown. */
+	long backlog(String name) {
+		if (name == null) {
+			return 0L;
+		}
+		Long v = backlogByMap.get(name);
+		return v == null ? 0L : v;
+	}
+
+	private synchronized void ensureStarted() {
+		if (started) {
+			return;
+		}
+		Thread t = new Thread(this::loop, "imap-writebehind-backlog-sampler");
+		t.setDaemon(true);
+		t.start();
+		started = true;
+		logger.info("Write-behind backlog sampler started, interval={}ms", SAMPLE_INTERVAL_MS);
+	}
+
+	private void loop() {
+		while (true) {
+			Map<String, Long> prev = backlogByMap;
+			try {
+				Map<String, Long> current = new HashMap<>(registered.size() * 2);
+				long total = 0L;
+				for (Map.Entry<String, IMap<?, ?>> e : registered.entrySet()) {
+					String name = e.getKey();
+					try {
+						long c = e.getValue().getLocalMapStats().getDirtyEntryCount();
+						current.put(name, c);
+						total += c;
+						failures.remove(name);
+					} catch (Throwable t) {
+						// Transient (migration/destroy in progress): keep the last known value so we never
+						// publish a spurious 0 that releases all blocked writers at once.
+						int f = failures.merge(name, 1, Integer::sum);
+						if (f >= MAX_MAP_FAILURES) {
+							registered.remove(name);
+							failures.remove(name);
+						} else {
+							Long last = prev.get(name);
+							if (last != null) {
+								current.put(name, last);
+								total += last;
+							}
+						}
+					}
+				}
+				backlogByMap = current;
+				totalBacklog = total;
+			} catch (Throwable t) {
+				// Never let the sampler die or permanently disable backpressure; keep the previous snapshot.
+				logger.debug("Write-behind backlog sampling cycle failed, keeping previous snapshot: {}", t.toString());
+			}
+			try {
+				Thread.sleep(SAMPLE_INTERVAL_MS);
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+				return;
+			}
+		}
+	}
+}

--- a/iengine/iengine-common/src/main/java/io/tapdata/construct/constructImpl/WriteBehindBackpressure.java
+++ b/iengine/iengine-common/src/main/java/io/tapdata/construct/constructImpl/WriteBehindBackpressure.java
@@ -1,0 +1,203 @@
+package io.tapdata.construct.constructImpl;
+
+import io.tapdata.pdk.core.utils.CommonUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Write-side "watermark backpressure" policy for write-behind cache IMaps.
+ *
+ * <p>When the GLOBAL write-behind backlog (total pending entries across all cache IMaps) exceeds the high
+ * watermark, the calling (non-cooperative) write thread is blocked until the backlog falls back below the low
+ * watermark, throttling producers to the external-storage drain rate so memory stays bounded instead of OOMing.</p>
+ *
+ * <p>All collaborators (backlog source, clock, sleeper, heap gauge) are injected so the policy can be unit
+ * tested without starting Hazelcast and without real waits. Production wiring is built by {@link #fromEnv}.</p>
+ *
+ * @author samuel
+ */
+class WriteBehindBackpressure {
+
+	/** Current write-behind backlog. */
+	interface BacklogSource {
+		long total();
+
+		long ofMap(String name);
+	}
+
+	@FunctionalInterface
+	interface Clock {
+		long nowMs();
+	}
+
+	@FunctionalInterface
+	interface Sleeper {
+		void sleepMs(long ms) throws InterruptedException;
+	}
+
+	@FunctionalInterface
+	interface HeapGauge {
+		int usedPercent();
+	}
+
+	private static final int HEAP_HYSTERESIS_PCT = 5;
+
+	private final boolean enabled;
+	private final long high;
+	private final long low;
+	private final long waitStepMs;
+	private final long timeoutMs;
+	private final long logAfterMs;
+	private final long logIntervalMs;
+	private final int heapPercent;
+	private final BacklogSource backlog;
+	private final Clock clock;
+	private final Sleeper sleeper;
+	private final HeapGauge heap;
+	private final Logger logger;
+
+	/** Shared timestamp (ms) of when backpressure was first entered; -1 = not blocked. Reset only on real recovery. */
+	private volatile long blockedSinceMs = -1L;
+
+	WriteBehindBackpressure(boolean enabled, long high, long low, long waitStepMs, long timeoutMs,
+							long logAfterMs, long logIntervalMs, int heapPercent,
+							BacklogSource backlog, Clock clock, Sleeper sleeper, HeapGauge heap, Logger logger) {
+		this.enabled = enabled;
+		this.high = high;
+		this.low = low;
+		this.waitStepMs = waitStepMs;
+		this.timeoutMs = timeoutMs;
+		this.logAfterMs = logAfterMs;
+		this.logIntervalMs = logIntervalMs;
+		this.heapPercent = heapPercent;
+		this.backlog = backlog;
+		this.clock = clock;
+		this.sleeper = sleeper;
+		this.heap = heap;
+		this.logger = logger;
+	}
+
+	/** Build the production policy from env / -D config with the real clock, sleeper and heap gauge. */
+	static WriteBehindBackpressure fromEnv(BacklogSource backlog) {
+		Logger log = LogManager.getLogger(WriteBehindBackpressure.class);
+		boolean enabled = CommonUtils.getPropertyBool("TAPDATA_IMAP_BACKPRESSURE_ENABLED", true);
+		long high = CommonUtils.getPropertyLong("TAPDATA_IMAP_BACKPRESSURE_HIGH", 300_000L);
+		long low = resolveLow(high, CommonUtils.getPropertyLong("TAPDATA_IMAP_BACKPRESSURE_LOW", 150_000L), log);
+		long waitStep = Math.max(1L, CommonUtils.getPropertyLong("TAPDATA_IMAP_BACKPRESSURE_WAIT_MS", 20L));
+		long timeout = CommonUtils.getPropertyLong("TAPDATA_IMAP_BACKPRESSURE_TIMEOUT_MS", 0L);
+		long logAfter = CommonUtils.getPropertyLong("TAPDATA_IMAP_BACKPRESSURE_LOG_AFTER_MS", 30_000L);
+		long logInterval = CommonUtils.getPropertyLong("TAPDATA_IMAP_BACKPRESSURE_LOG_INTERVAL_MS", 60_000L);
+		int heapPct = (int) CommonUtils.getPropertyLong("TAPDATA_IMAP_BACKPRESSURE_HEAP_PERCENT", 0L);
+		return new WriteBehindBackpressure(enabled, high, low, waitStep, timeout, logAfter, logInterval, heapPct,
+				backlog, System::currentTimeMillis, Thread::sleep, WriteBehindBackpressure::realHeapPercent, log);
+	}
+
+	/** Clamp LOW below HIGH so the watermark logic stays effective even if misconfigured. */
+	static long resolveLow(long high, long lowRaw, Logger logger) {
+		if (lowRaw >= high) {
+			long fixed = Math.max(1L, high / 2L);
+			if (logger != null) {
+				logger.warn("TAPDATA_IMAP_BACKPRESSURE_LOW ({}) must be < HIGH ({}); clamping LOW to {} to keep backpressure effective.",
+						lowRaw, high, fixed);
+			}
+			return fixed;
+		}
+		return lowRaw;
+	}
+
+	static int realHeapPercent() {
+		Runtime r = Runtime.getRuntime();
+		long max = r.maxMemory();
+		if (max <= 0L) {
+			return 0;
+		}
+		long used = r.totalMemory() - r.freeMemory();
+		return (int) (used * 100L / max);
+	}
+
+	boolean isEnabled() {
+		return enabled;
+	}
+
+	boolean overHigh() {
+		if (backlog.total() >= high) {
+			return true;
+		}
+		return heapPercent > 0 && heap.usedPercent() >= heapPercent;
+	}
+
+	boolean belowLow() {
+		if (backlog.total() > low) {
+			return false;
+		}
+		return !(heapPercent > 0 && heap.usedPercent() > heapPercent - HEAP_HYSTERESIS_PCT);
+	}
+
+	/**
+	 * Block the current thread while the global backlog is above the watermark band.
+	 *
+	 * @param mapName name of the cache being written (for diagnostics only)
+	 * @throws InterruptedException if the thread is interrupted while parked (interrupt flag is restored)
+	 * @throws RuntimeException     if the cumulative pause exceeds the configured timeout
+	 */
+	void apply(String mapName) throws Exception {
+		if (!enabled) {
+			return;
+		}
+		if (!overHigh()) {
+			if (belowLow()) {
+				blockedSinceMs = -1L;
+			}
+			return;
+		}
+		long enteredAt = clock.nowMs();
+		if (blockedSinceMs < 0L) {
+			blockedSinceMs = enteredAt;
+		}
+		long lastLog = 0L;
+		boolean logged = false;
+		while (!belowLow()) {
+			long now = clock.nowMs();
+			long waited = now - blockedSinceMs;
+			// Cumulative timeout: only fires if we never genuinely recovered (dropped below low watermark) for this long.
+			if (timeoutMs > 0L && waited > timeoutMs) {
+				blockedSinceMs = -1L;
+				throw new RuntimeException("Global write-behind cache backlog stayed above the low watermark for "
+						+ waited + "ms (total pending=" + backlog.total() + ", low=" + low
+						+ (heapPercent > 0 ? ", heapUsed=" + heap.usedPercent() + "%" : "")
+						+ "); the external storage appears unavailable. Failing the task to avoid engine OOM "
+						+ "(controlled by TAPDATA_IMAP_BACKPRESSURE_TIMEOUT_MS).");
+			}
+			// Only log after a sustained block (brief, normal throttling stays silent), then repeat at an interval.
+			if (waited >= logAfterMs && now - lastLog >= logIntervalMs) {
+				String heapClause = heapPercent > 0
+						? (", heapUsed=" + heap.usedPercent() + "% (guard " + heapPercent + "%)") : "";
+				String timeoutClause = timeoutMs > 0L
+						? ("The task will fail if this lasts ~" + (timeoutMs / 1000) + "s of cumulative pause without recovery.")
+						: ("No timeout is set (TAPDATA_IMAP_BACKPRESSURE_TIMEOUT_MS=0); it will keep waiting until the external storage recovers.");
+				logger.info("Data sync PAUSED by write-behind cache backpressure (expected behavior, protects the engine from OOM): "
+								+ "total pending write-behind entries across caches={} (high={}, low={}){}; this cache IMap[{}] pending={}; "
+								+ "waiting for the external storage (e.g. MongoDB) to flush. Paused for ~{}s. {} "
+								+ "Tunables: -DTAPDATA_IMAP_BACKPRESSURE_HIGH / -DTAPDATA_IMAP_BACKPRESSURE_LOW; "
+								+ "timeout -DTAPDATA_IMAP_BACKPRESSURE_TIMEOUT_MS=<ms> (0 = wait indefinitely); "
+								+ "optional heap guard -DTAPDATA_IMAP_BACKPRESSURE_HEAP_PERCENT.",
+						backlog.total(), high, low, heapClause, mapName, backlog.ofMap(mapName), waited / 1000, timeoutClause);
+				lastLog = now;
+				logged = true;
+			}
+			try {
+				sleeper.sleepMs(waitStepMs);
+			} catch (InterruptedException e) {
+				// Task is being stopped: restore the interrupt flag and let it propagate as an interrupt, not a failure.
+				Thread.currentThread().interrupt();
+				throw e;
+			}
+		}
+		blockedSinceMs = -1L;
+		if (logged) {
+			logger.info("Data sync RESUMED from write-behind cache backpressure: total pending dropped below the low watermark {}; "
+							+ "continuing sync. This pause lasted ~{}s.",
+					low, (clock.nowMs() - enteredAt) / 1000);
+		}
+	}
+}

--- a/iengine/iengine-common/src/test/java/io/tapdata/construct/constructImpl/WriteBehindBackpressureTest.java
+++ b/iengine/iengine-common/src/test/java/io/tapdata/construct/constructImpl/WriteBehindBackpressureTest.java
@@ -1,0 +1,140 @@
+package io.tapdata.construct.constructImpl;
+
+import org.apache.logging.log4j.LogManager;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Fast, pure-logic tests for {@link WriteBehindBackpressure} (no Hazelcast, virtual clock/sleeper).
+ * Verifies the watermark/hysteresis gate, cumulative timeout, resume, interrupt handling,
+ * the LOW&lt;HIGH clamp and the optional heap guard.
+ */
+class WriteBehindBackpressureTest {
+
+	/** Mutable backlog source. */
+	static final class FakeBacklog implements WriteBehindBackpressure.BacklogSource {
+		volatile long total;
+
+		FakeBacklog(long total) {
+			this.total = total;
+		}
+
+		@Override
+		public long total() {
+			return total;
+		}
+
+		@Override
+		public long ofMap(String name) {
+			return total;
+		}
+	}
+
+	private static WriteBehindBackpressure bp(long high, long low, long timeoutMs,
+											  WriteBehindBackpressure.BacklogSource backlog,
+											  WriteBehindBackpressure.Clock clock,
+											  WriteBehindBackpressure.Sleeper sleeper,
+											  WriteBehindBackpressure.HeapGauge heap, int heapPct) {
+		return new WriteBehindBackpressure(true, high, low, 10L, timeoutMs,
+				Long.MAX_VALUE, Long.MAX_VALUE, heapPct, backlog, clock, sleeper, heap,
+				LogManager.getLogger("WriteBehindBackpressureTest"));
+	}
+
+	@Test
+	void returnsImmediately_whenBelowHigh() throws Exception {
+		AtomicInteger sleeps = new AtomicInteger();
+		WriteBehindBackpressure p = bp(100, 50, 0,
+				new FakeBacklog(0), () -> 0L, ms -> sleeps.incrementAndGet(), () -> 0, 0);
+		p.apply("m");
+		assertEquals(0, sleeps.get(), "must not block below the high watermark");
+	}
+
+	@Test
+	void blocksThenResumes_whenBacklogDrainsBelowLow() throws Exception {
+		FakeBacklog b = new FakeBacklog(200);
+		AtomicLong now = new AtomicLong(0);
+		AtomicInteger sleeps = new AtomicInteger();
+		WriteBehindBackpressure.Sleeper sleeper = ms -> {
+			now.addAndGet(ms);
+			if (sleeps.incrementAndGet() == 3) {
+				b.total = 40; // drained below the low watermark
+			}
+		};
+		WriteBehindBackpressure p = bp(100, 50, 0, b, now::get, sleeper, () -> 0, 0);
+		p.apply("m");
+		assertTrue(sleeps.get() >= 3, "should have blocked until backlog dropped below low");
+		assertEquals(40, b.total);
+	}
+
+	@Test
+	void cumulativeTimeout_failsTaskWhenNeverRecovers() {
+		FakeBacklog b = new FakeBacklog(200); // stays high forever
+		AtomicLong now = new AtomicLong(0);
+		WriteBehindBackpressure.Sleeper sleeper = now::addAndGet; // advance virtual clock, never drains
+		WriteBehindBackpressure p = bp(100, 50, 1000, b, now::get, sleeper, () -> 0, 0);
+		RuntimeException ex = assertThrows(RuntimeException.class, () -> p.apply("m"));
+		assertTrue(ex.getMessage().contains("Failing the task"), ex.getMessage());
+	}
+
+	@Test
+	void interrupt_restoresFlagAndPropagates() {
+		FakeBacklog b = new FakeBacklog(200);
+		WriteBehindBackpressure.Sleeper sleeper = ms -> {
+			throw new InterruptedException("task stop");
+		};
+		WriteBehindBackpressure p = bp(100, 50, 0, b, () -> 0L, sleeper, () -> 0, 0);
+		assertThrows(InterruptedException.class, () -> p.apply("m"));
+		// Interrupt flag must be restored (and this also clears it for later tests).
+		assertTrue(Thread.interrupted(), "interrupt flag should be restored");
+	}
+
+	@Test
+	void resolveLow_clampsWhenNotBelowHigh() {
+		assertEquals(50, WriteBehindBackpressure.resolveLow(100, 150, null), "LOW>HIGH clamps to HIGH/2");
+		assertEquals(50, WriteBehindBackpressure.resolveLow(100, 100, null), "LOW==HIGH clamps to HIGH/2");
+		assertEquals(50, WriteBehindBackpressure.resolveLow(100, 50, null), "valid LOW unchanged");
+	}
+
+	@Test
+	void heapGuard_triggersOnHighHeapAndResumesWhenItDrops() throws Exception {
+		FakeBacklog b = new FakeBacklog(0); // backlog far below watermark
+		AtomicInteger heap = new AtomicInteger(95);
+		AtomicLong now = new AtomicLong(0);
+		AtomicInteger sleeps = new AtomicInteger();
+		WriteBehindBackpressure.Sleeper sleeper = ms -> {
+			now.addAndGet(ms);
+			if (sleeps.incrementAndGet() == 2) {
+				heap.set(80); // below the heap low band (90 - 5)
+			}
+		};
+		WriteBehindBackpressure p = bp(100, 50, 0, b, now::get, sleeper, heap::get, 90);
+		p.apply("m");
+		assertTrue(sleeps.get() >= 2, "heap guard should block until heap usage drops");
+	}
+
+	@Test
+	void heapGuard_disabledByDefault() throws Exception {
+		AtomicInteger sleeps = new AtomicInteger();
+		WriteBehindBackpressure p = bp(100, 50, 0,
+				new FakeBacklog(0), () -> 0L, ms -> sleeps.incrementAndGet(), () -> 99, 0);
+		p.apply("m");
+		assertEquals(0, sleeps.get(), "with heap guard off (0), high heap must not trigger backpressure");
+	}
+
+	@Test
+	void disabled_returnsImmediately() throws Exception {
+		AtomicInteger sleeps = new AtomicInteger();
+		WriteBehindBackpressure p = new WriteBehindBackpressure(false, 100, 50, 10, 0,
+				Long.MAX_VALUE, Long.MAX_VALUE, 0, new FakeBacklog(10_000),
+				() -> 0L, ms -> sleeps.incrementAndGet(), () -> 0,
+				LogManager.getLogger("WriteBehindBackpressureTest"));
+		p.apply("m");
+		assertEquals(0, sleeps.get(), "disabled policy must never block");
+	}
+}


### PR DESCRIPTION
…sk OOM

The master-slave merge cache is a Hazelcast IMap backed by a write-behind MapStore (writeCoalescing=true, writeDelaySeconds=10). When the external storage (e.g. MongoDB) is slow or keeps failing, Hazelcast retries failed batches indefinitely and the coalesced write-behind queue has no capacity limit, so it grows unbounded until the engine OOMs.

Add producer-side watermark backpressure, applied as a GLOBAL budget over the total pending write-behind entries across all cache IMaps:
- WriteBehindBacklogSampler: a daemon thread reads each registered IMap's backlog via the public IMap.getLocalMapStats().getDirtyEntryCount() (no internal reflection, primary-only, no backup double-count); keeps the last value on a transient failure (never publishes a spurious 0 that would release all blocked writers at once), drops a map after repeated failures, and never permanently disables itself.
- ConstructIMap routes every write path (insert/insertMany/update/upsert/ delete) through a single guarded helper, and BytesIMap / DocumentIMap overrides route through it too, so join/target/shared caches and deletes are covered as well. Writers block above the high watermark and resume below the low watermark; the timeout is cumulative (reset only on real recovery) and fails the task cleanly instead of hanging forever; InterruptedException restores the interrupt flag so task-stop is not turned into a failure.
- Optional used-heap guard (TAPDATA_IMAP_BACKPRESSURE_HEAP_PERCENT, default off) covers the "few keys, huge values" shape where entry count stays low.

All thresholds are configurable via JVM -D or env var (TAPDATA_IMAP_BACKPRESSURE_*). No Hazelcast core changes.