### PR TITLE
fix(tm): null-guard reqTime in ApiCall audit list to prevent NPE

### DIFF
--- a/manager/tm/src/main/java/com/tapdata/tm/apiCalls/service/ApiCallService.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/apiCalls/service/ApiCallService.java
@@ -424,7 +424,9 @@ public class ApiCallService {
         item.setBody(e.getBody());
         item.setApiPath(e.getApiPath());
         item.setCreateTime(e.getCreateTime());
-        item.setReqTime(new Date(e.getReqTime()));
+        // Legacy/imported ApiCall docs (e.g. old Node apiserver records) may have no reqTime;
+        // guard the unboxing so the whole audit page doesn't NPE on a single such row.
+        item.setReqTime(e.getReqTime() == null ? null : new Date(e.getReqTime()));
         item.setCreateAt(e.getApiCreateAt());
         item.setMethod(e.getMethod());
         item.setFailed(!e.isSucceed());

--- a/manager/tm/src/main/java/com/tapdata/tm/apiCalls/service/ApiCallService.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/apiCalls/service/ApiCallService.java
@@ -424,8 +424,8 @@ public class ApiCallService {
         item.setBody(e.getBody());
         item.setApiPath(e.getApiPath());
         item.setCreateTime(e.getCreateTime());
-        // Legacy/imported ApiCall docs (e.g. old Node apiserver records) may have no reqTime;
-        // guard the unboxing so the whole audit page doesn't NPE on a single such row.
+        // Some legacy and imported audit rows, such as old Node apiserver records, have no
+        // request time, so the null check stops one such row from breaking the whole page.
         item.setReqTime(e.getReqTime() == null ? null : new Date(e.getReqTime()));
         item.setCreateAt(e.getApiCreateAt());
         item.setMethod(e.getMethod());


### PR DESCRIPTION
## Problem

The audit list page (`GET /api/ApiCalls`) throws `NullPointerException` and returns nothing:

```
java.lang.NullPointerException: Cannot invoke "java.lang.Long.longValue()" because
the return value of "...ApiCallDataVo.getReqTime()" is null
  at ApiCallService.mapToApiCallDetailVo(ApiCallService.java:427)
  at ApiCallService.find(ApiCallService.java:400)
```

`mapToApiCallDetailVo` did `new Date(e.getReqTime())`, unboxing `Long reqTime` with no null check. A **single** `ApiCall` document lacking `reqTime` blows up the entire page.

## Where the null records come from

Confirmed **not** new data — they are legacy records from the **old Node apiserver** (LoopBack/"Moa") that predate the `reqTime` field, plus imported datasets. On one affected DB, 2,799 / 2,803 docs lacked `reqTime`, all carrying the Node `api_worker_uuid` fingerprint, dated 2025-07 → 2025-08. The Java apiserver (`apiserver-java`) always sets `reqTime`, so it is not the source.

## Fix

Null-guard the unboxing so legacy rows render with an empty request time instead of failing the whole page:

```java
item.setReqTime(e.getReqTime() == null ? null : new Date(e.getReqTime()));
```

`ApiCallDetailVo.reqTime` is a `Date`, so `null` is a valid value. This is the only unguarded `getReqTime()` read site in the audit paths — the detail view (`findById`) already null-guards it, and every other `getReqTime()` use in TM is already guarded.

## Scope / risk

- One line + comment, read path only. No write/schema change. No behavior change for records that already have `reqTime`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)