### PR TITLE
fix(TAP-12108): 修复批量启动限流信号量泄漏导致任务卡在“启动中”

### DIFF
--- a/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/schedule/TapdataTaskScheduler.java
+++ b/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/schedule/TapdataTaskScheduler.java
@@ -64,7 +64,6 @@ import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
@@ -139,9 +138,10 @@ public class TapdataTaskScheduler implements MemoryFetcher {
 	// 批量启动任务的并发控制
 	private static final double BATCH_SIZE_RATIO = 0.7; // 使用线程池70%的线程用于批量启动
 	private static final int MIN_BATCH_SIZE = 1; // 最小批次大小
-	private final Semaphore startTaskSemaphore = new Semaphore(calculateBatchSize()); // 控制并发启动任务数量
-	private volatile long lastBatchStartTime = 0L; // 上一批次启动时间
-	private final AtomicInteger currentBatchCount = new AtomicInteger(0); // 当前批次已启动任务数
+	// 并发启动上限：只计算一次并复用，避免"初始许可数与运行期归还阈值不一致"导致的信号量死锁（TAP-12108）
+	private final int maxConcurrentStartTask = calculateBatchSize();
+	// 控制并发启动任务数量；acquire/release 严格成对（见 applyBatchStartTaskRateLimit / releaseStartTaskPermit）
+	private final Semaphore startTaskSemaphore = new Semaphore(maxConcurrentStartTask);
 
 	@Bean(name = "taskControlScheduler")
 	public TaskScheduler taskControlScheduler() {
@@ -271,14 +271,11 @@ public class TapdataTaskScheduler implements MemoryFetcher {
 		};
 	}
 
-	protected void handleTaskOperation(TaskOperation taskOperation) throws InterruptedException, ExecutionException {
-		// 将处理变成单线程处理，避免操作在线程池中积压
+	protected void handleTaskOperation(TaskOperation taskOperation) {
+		// 异步提交后立即返回，继续消费队列；启动并发由 startTaskSemaphore 控制。
+		// 不再对 START 操作 future.get() 串行等待，避免单个任务启动阻塞拖垮整条启动队列（TAP-12108）。
 		Runnable runnable = getHandleTaskOperationRunnable(taskOperation);
-		Future<?> future = taskOperationThreadPool.submit(runnable);
-		if (taskOperation.getOpType() == OpType.START) {
-			// 启动任务有限流，单线程处理
-			future.get();
-		}
+		taskOperationThreadPool.submit(runnable);
 	}
 
 	public void sendStartTask(TaskDto taskDto) {
@@ -506,61 +503,31 @@ public class TapdataTaskScheduler implements MemoryFetcher {
 	}
 
 	/**
-	 * Apply batch-based rate limiting for task startup
-	 * Allows concurrent task startup within batch size limit, with 5-second interval between batches
+	 * 启动并发控制：获取一个启动许可，限制同时启动的任务数不超过 {@code maxConcurrentStartTask}。
+	 * 许可用完即还——必须由 {@link #releaseStartTaskPermit()} 成对归还（见 startTask 的 finally）。
+	 *
+	 * <p>历史缺陷（TAP-12028/TAP-12108）：旧实现只在"凑满一整批 batchSize"时才批量 release，
+	 * 且初始许可数与运行期归还阈值可能不一致，导致 release 从不触发、许可只减不还，最终耗尽为 0，
+	 * 所有任务永久阻塞在 acquire。现改为 acquire/release 严格成对，彻底消除该泄漏。
 	 *
 	 * @param taskDto the task to start
 	 */
 	public void applyBatchStartTaskRateLimit(TaskDto taskDto) {
 		try {
-			// Acquire semaphore permit (blocks if batch is full)
+			// 获取一个启动许可（上限 = maxConcurrentStartTask），阻塞直到有空位
 			startTaskSemaphore.acquire();
-
-			synchronized (startTaskLock) {
-				int batchCount = currentBatchCount.incrementAndGet();
-				int batchSize = calculateBatchSize();
-
-				logger.debug("Task {} ({}) acquired startup permit, current batch count: {}/{}",
-					taskDto.getName(), taskDto.getId().toHexString(), batchCount, batchSize);
-
-				// Check if this is the first task in a new batch
-				if (batchCount == 1) {
-					long currentTime = System.currentTimeMillis();
-					long timeSinceLastBatch = currentTime - lastBatchStartTime;
-
-					// If less than 5 seconds since last batch, wait
-					if (lastBatchStartTime > 0 && timeSinceLastBatch < START_TASK_RATE_LIMIT_MILLIS) {
-						long waitTime = START_TASK_RATE_LIMIT_MILLIS - timeSinceLastBatch;
-						logger.info("Rate limiting batch startup, waiting {}ms to maintain 5-second batch interval", waitTime);
-
-						try {
-							startTaskLock.wait(waitTime);
-						} catch (InterruptedException e) {
-							Thread.currentThread().interrupt();
-							logger.warn("Batch rate limit wait interrupted");
-							throw new RuntimeException("Batch rate limit wait interrupted", e);
-						}
-					}
-
-					// Update last batch start time
-					lastBatchStartTime = System.currentTimeMillis();
-					logger.info("Starting new batch of tasks, batch size limit: {}, batch start time: {}",
-						batchSize, lastBatchStartTime);
-				}
-
-				// If batch is full, reset counter and release all permits for next batch
-				if (batchCount >= batchSize) {
-					logger.info("Batch full ({}/{}), resetting for next batch", batchCount, batchSize);
-					currentBatchCount.set(0);
-					startTaskSemaphore.release(batchSize);
-				}
-			}
 		} catch (InterruptedException e) {
 			Thread.currentThread().interrupt();
-			logger.error("Failed to acquire startup permit for task {} ({}): {}",
-				taskDto.getName(), taskDto.getId().toHexString(), e.getMessage());
-			throw new RuntimeException("Failed to acquire startup permit", e);
+			throw new RuntimeException(String.format("Interrupted while acquiring start-task permit for %s (%s)",
+				taskDto.getName(), taskDto.getId().toHexString()), e);
 		}
+	}
+
+	/**
+	 * 归还一个启动许可，与 {@link #applyBatchStartTaskRateLimit(TaskDto)} 成对使用。
+	 */
+	public void releaseStartTaskPermit() {
+		startTaskSemaphore.release();
 	}
 
 	protected void startTask(TaskDto taskDto) {
@@ -577,6 +544,7 @@ public class TapdataTaskScheduler implements MemoryFetcher {
 		}
 
 		ObsLoggerFactory.getInstance().removeTaskLoggerClearMark(taskDto);
+		boolean permitAcquired = false;
 		try {
 			logger.info("The task to be scheduled is found, task name {}, task id {}", taskDto.getName(), taskId);
 			TmStatusService.addNewTask(taskId);
@@ -592,6 +560,7 @@ public class TapdataTaskScheduler implements MemoryFetcher {
 			// Apply rate limiting after claiming: TM already knows the task is running so the
 			// wait_run overtime timer will not fire while we wait here.
 			applyBatchStartTaskRateLimit(taskDto);
+			permitAcquired = true;
 
 			// 使用 computeIfAbsent 防止创建重复的 TaskClient
 			taskClientMap.computeIfAbsent(taskId, id -> hazelcastTaskService.startTask(taskDto));
@@ -614,6 +583,10 @@ public class TapdataTaskScheduler implements MemoryFetcher {
 			ObsLoggerFactory.getInstance().removeTaskLoggerMarkRemove(taskDto);
 			Optional.of(taskDto).ifPresent(task -> ConnectorConstant.TASK_STATUS_GAUGE.set(1, taskId, task.getName(), task.getSyncType()));
 		} finally {
+			// 与 applyBatchStartTaskRateLimit 成对归还许可；无论启动成功或失败都归还，杜绝许可泄漏（TAP-12108）
+			if (permitAcquired) {
+				releaseStartTaskPermit();
+			}
 			ThreadContext.clearAll();
 		}
 	}

--- a/iengine/iengine-app/src/test/java/io/tapdata/flow/engine/V2/schedule/TapdataTaskSchedulerStartPermitTest.java
+++ b/iengine/iengine-app/src/test/java/io/tapdata/flow/engine/V2/schedule/TapdataTaskSchedulerStartPermitTest.java
@@ -1,0 +1,75 @@
+package io.tapdata.flow.engine.V2.schedule;
+
+import com.tapdata.tm.commons.task.dto.TaskDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.concurrent.Semaphore;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.mock;
+
+/**
+ * TAP-12108 回归测试：启动限流信号量必须 acquire/release 严格成对。
+ *
+ * <p>旧实现（applyBatchStartTaskRateLimit）只在"凑满一整批 batchSize"时才批量 release，
+ * 且初始许可数与运行期归还阈值可能不一致，导致 release 从不触发、许可只减不还，
+ * 最终耗尽为 0，所有任务永久阻塞在 acquire，单通道消费线程随之卡死，任务卡在"启动中"。
+ * 本测试锁定修复后的两点契约：<br>
+ * 1) 每次启动结束都归还许可，反复启停后许可池不泄漏；<br>
+ * 2) 许可用尽时新的启动会阻塞（并发上限生效），一旦有任务归还许可即被放行（不再死锁）。
+ */
+public class TapdataTaskSchedulerStartPermitTest {
+
+	private TapdataTaskScheduler schedulerWithSemaphore(int permits) {
+		TapdataTaskScheduler scheduler = mock(TapdataTaskScheduler.class);
+		ReflectionTestUtils.setField(scheduler, "startTaskSemaphore", new Semaphore(permits));
+		doCallRealMethod().when(scheduler).applyBatchStartTaskRateLimit(any());
+		doCallRealMethod().when(scheduler).releaseStartTaskPermit();
+		return scheduler;
+	}
+
+	@Test
+	@DisplayName("TAP-12108: acquire/release 成对，反复启停后许可不泄漏")
+	void permitReturnedAfterEachStart_noLeak() {
+		int permits = 2;
+		TapdataTaskScheduler scheduler = schedulerWithSemaphore(permits);
+		Semaphore sem = (Semaphore) ReflectionTestUtils.getField(scheduler, "startTaskSemaphore");
+		TaskDto task = mock(TaskDto.class);
+
+		// 远多于许可数的启停循环；旧实现会把许可逐步漏光直至 0
+		for (int i = 0; i < 100; i++) {
+			scheduler.applyBatchStartTaskRateLimit(task);
+			scheduler.releaseStartTaskPermit();
+		}
+
+		assertEquals(permits, sem.availablePermits(),
+			"每次启动都应归还许可，100 次启停后可用许可应回到初始值");
+	}
+
+	@Test
+	@DisplayName("TAP-12108: 许可用尽时阻塞，release 后立即放行（旧实现 release 从不触发导致死锁）")
+	void releaseUnblocksWaiter() throws Exception {
+		TapdataTaskScheduler scheduler = schedulerWithSemaphore(1);
+		TaskDto task = mock(TaskDto.class);
+
+		scheduler.applyBatchStartTaskRateLimit(task); // 占用唯一许可
+
+		Thread waiter = new Thread(() -> scheduler.applyBatchStartTaskRateLimit(task), "permit-waiter");
+		waiter.setDaemon(true);
+		waiter.start();
+		waiter.join(500);
+		assertTrue(waiter.isAlive(), "许可已用尽，第二个启动应被阻塞（并发上限生效）");
+
+		scheduler.releaseStartTaskPermit(); // 归还许可 → 阻塞者应被唤醒
+		waiter.join(2000);
+		assertFalse(waiter.isAlive(), "release 后阻塞的启动应立即放行；旧实现只在凑满整批才归还，会永久阻塞");
+
+		scheduler.releaseStartTaskPermit(); // 清理 waiter 占用的许可
+	}
+}


### PR DESCRIPTION
## 背景
Jira: [TAP-12108](https://tapdata.atlassian.net/browse/TAP-12108) 【Wynn】任务卡在启动中状态

## 根因
引擎批量启动限流器 `TapdataTaskScheduler.applyBatchStartTaskRateLimit` 用信号量限制并发启动，但 **acquire/release 不对称**：每启动一个任务消耗 1 个许可，却只在"凑满一整批 batchSize"时才 `release(batchSize)` 批量归还。初始许可数在进程启动时按当时可见 CPU 计算，运行期归还阈值又重新计算——**启动时 CPU < 运行期 CPU 时"凑满整批"的条件永远达不到，release 从不触发，许可只减不还，最终耗尽为 0**。

此后第一个尝试启动的任务永久阻塞在 `startTaskSemaphore.acquire()`；而所有启动操作由单个 `Task-Operation-Consumer` 线程串行处理、并对 START 执行 `future.get()`，于是消费线程被永久卡死，其后所有任务都无法启动，全部卡在"启动中"。

现场证据：引擎线程栈 `Task-Operation-Consumer` 阻塞在 `future.get()`、启动线程阻塞在 `Semaphore.acquire()`；日志 `Batch full` 全天 0 次、`Send start task operation` 上千次但 `Handled task operation` 仅 4 次、17:20 后再无任务成功启动。

## 修复
- 许可数 `maxConcurrentStartTask` **只计算一次并复用**（消除初始/运行期不一致）。
- `applyBatchStartTaskRateLimit` 只 `acquire`；新增成对的 `releaseStartTaskPermit()`；删除"凑满一批批量归还"逻辑。
- `startTask` 在 `finally` 中**成对归还许可**（成功/失败都归还，杜绝泄漏）。
- `handleTaskOperation` 去掉对 START 的 `future.get()` 串行等待，避免单个启动堵死整条启动队列（线程池 17 > 信号量并发上限 ≈12，安全）。
- 新增回归测试 `TapdataTaskSchedulerStartPermitTest`。

## 临时恢复
重启引擎进程即可（信号量重置），无需本补丁。

## 测试状态
- ⚠️ 尚未编译/跑测试：当前沙箱 reactor 依赖私有源 `spring-ai-bom:2.0.0`，离线无法解析。请在联网、已按构建顺序装好 common-lib 的环境验证：
  - `mvn -pl iengine/iengine-app -am test-compile`
  - `mvn -pl iengine/iengine-app -Dtest=TapdataTaskSchedulerStartPermitTest test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[TAP-12108]: https://tapdata.atlassian.net/browse/TAP-12108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ