### PR TITLE
fix(TAP-12120): [to 4.20] Risk of data loss in shared mining monitoring target …

### DIFF
--- a/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/common/StreamReadTag.java
+++ b/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/common/StreamReadTag.java
@@ -1,11 +1,11 @@
 package io.tapdata.flow.engine.V2.common;
 
+import com.tapdata.entity.TapdataCompleteTableSnapshotEvent;
 import com.tapdata.entity.TapdataEvent;
-import com.tapdata.entity.TapdataStartedCdcEvent;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 /**
  * @author <a href="2749984520@qq.com">Gavin'Xiao</a>
@@ -14,30 +14,29 @@ import java.util.List;
  * @description
  */
 public final class StreamReadTag {
-    final int sourceNodeCount;
-    public List<Runnable> startStreamRead;
-    int acceptedCount;
+    public Consumer<List<String>> startStreamRead;
+    public Function<List<String>, List<String>> targetTableName;
 
-    public StreamReadTag(int sourceNodeCount, Runnable ... startStreamRead) {
-        this.sourceNodeCount = sourceNodeCount;
-        if (startStreamRead != null) {
-            this.startStreamRead = Arrays.asList(startStreamRead);
-        } else {
-            this.startStreamRead = new ArrayList<>();
-        }
-        this.acceptedCount = 0;
+    public StreamReadTag(Function<List<String>, List<String>> targetTableName, Consumer<List<String>> startStreamRead) {
+        this.startStreamRead = startStreamRead;
+        this.targetTableName = targetTableName;
     }
 
     public void accept(TapdataEvent e) {
-        if (this.acceptedCount >= this.sourceNodeCount) {
+        if (startStreamRead == null) {
             return;
         }
-        if (!(e instanceof TapdataStartedCdcEvent)) {
+        if (!(e instanceof TapdataCompleteTableSnapshotEvent tableSnapshotEvent)) {
             return;
         }
-        this.acceptedCount++;
-        if (this.acceptedCount >= this.sourceNodeCount) {
-            this.startStreamRead.forEach(Runnable::run);
+        List<String> tableName = this.targetTableName.apply(List.of(tableSnapshotEvent.getSourceTableName()));
+        this.startStreamRead.accept(tableName);
+    }
+
+    public void accept(List<String> tableNames) {
+        if (startStreamRead == null) {
+            return;
         }
+        this.startStreamRead.accept(tableNames);
     }
 }

--- a/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/node/hazelcast/data/pdk/HazelcastTargetPdkBaseNode.java
+++ b/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/node/hazelcast/data/pdk/HazelcastTargetPdkBaseNode.java
@@ -243,7 +243,6 @@ public abstract class HazelcastTargetPdkBaseNode extends HazelcastPdkBaseNode {
         syncMetricCollector = ISyncMetricCollector.init(dataProcessorContext);
 		queueConsumerThreadPool.submitSync(() -> {
 			super.doInit(context);
-			initShareCdcCollectorIfNeed();
 			initOffsetCallbackEnable();
 			createPdkAndInit(context);
 			everHandleTapTablePrimaryKeysMap = new ConcurrentHashMap<>();
@@ -293,26 +292,23 @@ public abstract class HazelcastTargetPdkBaseNode extends HazelcastPdkBaseNode {
 			obsLogger.info("System configuration enables shared mining global configuration items, and the target node does not need to enable shared mining");
 			return;
 		}
+		if (taskDto.notCdcOpen()) {
+			obsLogger.info("Task not open cdc, and the target node does not need to enable shared mining");
+			return;
+		}
 		Node<?> node = getNode();
-		List<String> tables = new ArrayList<>();
-		if (node instanceof TableNode tableNode) {
-			tables.add(tableNode.getTableName());
-		} else if (node instanceof DatabaseNode) {
-			addDatabaseNodeTable(tables);
-		} else {
-			return;
-		}
-		if (tables.isEmpty()) {
-			return;
-		}
 		String connectionId = ((DataParentNode<?>) node).getConnectionId();
-		streamReadTag = new StreamReadTag(this.sourceNodeCount, () -> {
+		streamReadTag = new StreamReadTag(this::targetTableName, tableNames -> {
+			if (CollectionUtils.isEmpty(tableNames)) {
+				return;
+			}
 			long startTime = System.currentTimeMillis();
 			Map<String, Object> body = new HashMap<>();
 			body.put("connectionId", connectionId);
-			body.put("tableNames", tables);
+			body.put("tableNames", tableNames);
 			body.put("nodeConfig", Map.of("enableFillingModifiedData", false, "noCursorTimeout", false, "preImage", true, "writeConcern", "w1"));
 			try {
+				obsLogger.info("Table {} has been fully completed and is ready to be added to the shared mining task", tableNames);
 				this.clientMongoOperator.postOne(body, "logcollector/start-and-wait", Map.class);
 				long endTime = System.currentTimeMillis();
 				obsLogger.info("The system configuration has enabled the shared mining global configuration item, and the task has enabled the shared mining switch. The target table has been added to the mining task, time cost {}ms", endTime - startTime);
@@ -320,6 +316,37 @@ public abstract class HazelcastTargetPdkBaseNode extends HazelcastPdkBaseNode {
 				obsLogger.warn("The system configuration has enabled the global configuration item for shared mining, and the task has turned on the shared mining switch. However, the target table has not been properly added to the mining task: {}", e.getMessage());
 			}
 		});
+		if (taskDto.isCDCTask()) {
+			List<String> tables = new ArrayList<>();
+			if (node instanceof TableNode tableNode) {
+				tables.add(tableNode.getTableName());
+			} else if (node instanceof DatabaseNode) {
+				addDatabaseNodeTable(tables);
+			} else {
+				return;
+			}
+			streamReadTag.accept(tables);
+			streamReadTag = null;
+		}
+	}
+
+	List<String> targetTableName(List<String> sourceTableNames) {
+		if (CollectionUtils.isEmpty(sourceTableNames)) {
+			return new ArrayList<>();
+		}
+		Map<String, String> tableNameMapping = new HashMap<>();
+		processorBaseContext.getTapTableMap().forEach((key, value) -> {
+			tableNameMapping.put(value.getAncestorsName(), key);
+		});
+		Set<String> tables = new HashSet<>();
+		for (String sourceTableName : sourceTableNames) {
+			String tableName = tableNameMapping.get(sourceTableName);
+			if (StringUtils.isEmpty(tableName)) {
+				continue;
+			}
+			tables.add(tableName);
+		}
+		return new ArrayList<>(tables);
 	}
 
 	protected void initFlushOffsetConsumer() {

--- a/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/node/hazelcast/data/pdk/HazelcastTargetPdkDataNode.java
+++ b/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/node/hazelcast/data/pdk/HazelcastTargetPdkDataNode.java
@@ -123,6 +123,7 @@ public class HazelcastTargetPdkDataNode extends HazelcastTargetPdkBaseNode {
 				writeStrategy = ((DataParentNode<?>) getNode()).getWriteStrategy();
 			}
 			initTargetDB();
+			initShareCdcCollectorIfNeed();
 			this.writePolicyService = new PDkNodeInsertRecordPolicyService(dataProcessorContext.getTaskDto(), getNode(), associateId);
 			this.writePolicyService.setStartTransactionMap(startTransactionMap);
 			this.writePolicyService.setTransactionOperator(new TransactionOperator() {

--- a/manager/tm-common/src/main/java/com/tapdata/tm/commons/task/dto/TaskDto.java
+++ b/manager/tm-common/src/main/java/com/tapdata/tm/commons/task/dto/TaskDto.java
@@ -321,6 +321,10 @@ public class TaskDto extends ParentTaskDto implements IDataPermissionDto {
         return TYPE_INITIAL_SYNC.equals(getType()) || TYPE_INITIAL_SYNC_CDC.equals(getType());
     }
 
+    public boolean notCdcOpen() {
+        return TYPE_INITIAL_SYNC.equals(getType());
+    }
+
     public boolean hasSyncProgress() {
         return null != getAttrs() && getAttrs().containsKey("syncProgress");
     }


### PR DESCRIPTION
…table

After the shared mining is enabled, when the target node joins the shared mining task, it cannot wait for all tables to be fully loaded before joining the shared mining task. Instead, it should join a table after it is fully loaded. Otherwise, the table that is fully loaded first will lose some CDC events. At the same time, it is necessary to determine whether the task contains CDC (only full load tasks do not need to process the CDC of the target table)