### PR TITLE
test(TaskNodeServiceImplTest): assert rethrown BizException by identity

### DIFF
--- a/manager/tm/src/test/java/com/tapdata/tm/task/service/impl/TaskNodeServiceImplTest.java
+++ b/manager/tm/src/test/java/com/tapdata/tm/task/service/impl/TaskNodeServiceImplTest.java
@@ -854,10 +854,17 @@ class TaskNodeServiceImplTest {
             when(connDto.getCapabilities()).thenReturn(caps);
             when(dataSourceService.findOne(any())).thenReturn(connDto);
 
+            // Use the varargs constructor so errorCode is preserved verbatim. The single-arg
+            // BizException(String) constructor downgrades errorCode to "SystemError" whenever the
+            // message key can't be resolved (which is the case in unit tests, where the resolved
+            // resource bundle falls back to the base messages.properties that has no MockData keys).
+            BizException bizException = new BizException("MockData.SampleDataError", "boom");
             when(taskService.callEngineRpc(anyString(), any(), anyString(), anyString(), anyString(), anyString(), any()))
-                    .thenThrow(new BizException("MockData.SampleDataError"));
+                    .thenThrow(bizException);
 
             BizException ex = Assertions.assertThrows(BizException.class, () -> taskNodeService.mockDateRPC(dto, userDetail));
+            // A BizException from the RPC must be rethrown as-is (same object), not wrapped.
+            Assertions.assertSame(bizException, ex);
             Assertions.assertEquals("MockData.SampleDataError", ex.getErrorCode());
         }
 


### PR DESCRIPTION
## Problem

`TaskNodeServiceImplTest$MockDateRPCTest.testRpcThrowsBizException_rethrown` failed:

```
Expected :MockData.SampleDataError
Actual   :SystemError
```

## Root cause (test-side, not production)

The test built the expected exception with the single-arg ctor `new BizException("MockData.SampleDataError")`. That ctor does:

```java
this.errorCode = getMessage().equals(errorCode) ? SYSTEM_ERROR : errorCode;
```

and calls `MessageUtil.getMessage(errorCode)` **with no args**. In a unit test there is no request locale, so bundle resolution walks the `NoFallback` chain down to the base `messages.properties`, which has **no `MockData.*` keys** (those live only in `messages_en_US/zh_CN/zh_TW`). The lookup returns the key unchanged, so the ctor silently downgrades `errorCode` to `"SystemError"` — at construction time, before the mock even fires.

The production path `catch (BizException e) { throw e; }` in `TaskNodeServiceImpl.mockDateRPC` is correct and rethrows the same object; **no production code changed.**

## Fix

Construct the expected exception with the varargs ctor (sets `errorCode` verbatim, no locale-dependent downgrade) and assert the rethrow by object identity, which is what `_rethrown` means:

```java
BizException bizException = new BizException("MockData.SampleDataError", "boom");
when(...).thenThrow(bizException);
BizException ex = assertThrows(BizException.class, () -> taskNodeService.mockDateRPC(dto, userDetail));
assertSame(bizException, ex);
assertEquals("MockData.SampleDataError", ex.getErrorCode());
```

## Verification

`mvn -pl tm test -Dtest=TaskNodeServiceImplTest` → **41 tests, 0 failures, 0 errors** (nested `MockDateRPCTest`: 14 tests, 0 failures).