### PR TITLE
Chore(ci): TAP-12161 extend build image timeout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -218,7 +218,7 @@ jobs:
 
   Build-Image:
     runs-on: office-scan
-    timeout-minutes: 60
+    timeout-minutes: 120
     needs:
       - Build-Tapdata
       - Build-Connectors


### PR DESCRIPTION
Increase the Build-Image workflow timeout to allow longer image build jobs to finish.

Refs: TAP-12161