### PR TITLE
Fix TAP-12289 disable default Elasticsearch health check

### DIFF
--- a/manager/tm/src/main/resources/application-default.yml
+++ b/manager/tm/src/main/resources/application-default.yml
@@ -164,6 +164,9 @@ openapi:
     where-max-deep: ${openapi.setting.whereMaxDeep:10}
 
 management:
+  health:
+    elasticsearch:
+      enabled: false
   prometheus:
     metrics:
       export:

--- a/manager/tm/src/test/java/com/tapdata/tm/TMApplicationTest.java
+++ b/manager/tm/src/test/java/com/tapdata/tm/TMApplicationTest.java
@@ -3,6 +3,12 @@ package com.tapdata.tm;
 import com.tapdata.tm.user.service.UserService;
 import io.tapdata.pdk.core.utils.CommonUtils;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.env.YamlPropertySourceLoader;
+import org.springframework.core.env.PropertySource;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.IOException;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -18,18 +24,35 @@ public class TMApplicationTest {
         when(userService.isSsl()).thenReturn("test_ssl");
         when(userService.getCaPath()).thenReturn("test_caPath");
         when(userService.getKeyPath()).thenReturn("test_keyPath");
+        when(userService.getSslPass()).thenReturn("test_sslPass");
         TMApplication.buildProperty(userService);
         assertEquals("test_uri", CommonUtils.getProperty("tapdata_proxy_mongodb_uri"));
         assertEquals("test_port", CommonUtils.getProperty("tapdata_proxy_server_port"));
         assertEquals("test_ssl", CommonUtils.getProperty("tapdata_proxy_mongodb_ssl"));
         assertEquals("test_caPath", CommonUtils.getProperty("tapdata_proxy_mongodb_caPath"));
         assertEquals("test_keyPath", CommonUtils.getProperty("tapdata_proxy_mongodb_keyPath"));
+        assertEquals("test_sslPass", CommonUtils.getProperty("tapdata_proxy_mongodb_sslPass"));
         System.clearProperty("tapdata_proxy_mongodb_uri");
         System.clearProperty("tapdata_proxy_server_port");
         System.clearProperty("tapdata_proxy_mongodb_ssl");
         System.clearProperty("tapdata_proxy_mongodb_caPath");
         System.clearProperty("tapdata_proxy_mongodb_keyPath");
+        System.clearProperty("tapdata_proxy_mongodb_sslPass");
         assertNull(CommonUtils.getProperty("tapdata_proxy_mongodb_uri"));
 
+    }
+
+    @Test
+    void elasticsearchHealthIndicatorDisabledByDefault() throws IOException {
+        YamlPropertySourceLoader loader = new YamlPropertySourceLoader();
+        List<PropertySource<?>> propertySources = loader.load("application-default", new ClassPathResource("application-default.yml"));
+
+        Object enabled = propertySources.stream()
+                .map(propertySource -> propertySource.getProperty("management.health.elasticsearch.enabled"))
+                .filter(value -> value != null)
+                .findFirst()
+                .orElse(null);
+
+        assertEquals(false, enabled);
     }
 }


### PR DESCRIPTION
## 背景

TAP-12289：TM 每次启动都报 Elasticsearch health check connection refused。

## 原因

默认 profile 下日志仓库仍是 MongoDB，但 Spring Boot Actuator 会自动注册 Elasticsearch health indicator。未配置 Elasticsearch 时，健康检查会探测默认 endpoint，导致启动日志持续出现 connection refused。

## 修复

- 在 manager/tm/src/main/resources/application-default.yml 中关闭默认 Elasticsearch health indicator。
- 在 TMApplicationTest 中增加默认配置断言，确保 management.health.elasticsearch.enabled=false。
- 补齐既有 buildPropertyTest 中 userService.getSslPass() mock，保证测试可独立通过。

## 验证

已执行：

```sh
export JAVA_HOME=/Users/lhs/Library/Java/JavaVirtualMachines/azul-17.0.16/Contents/Home
export PATH="/Library/Java/JavaVirtualMachines/jdk1.8.0_202.jdk/Contents/Home/bin:/Users/lhs/.local/bin:/Users/lhs/go/bin:/Users/lhs/GolandProjects/bin:/Users/lhs/soft/mongodb-macos-x86_64-4.2.18/bin:/Users/lhs/soft/apache-maven-3.6.3/bin:/Library/Java/JavaVirtualMachines/jdk1.8.0_202.jdk/Contents/Home/bin:/Library/Java/JavaVirtualMachines/jdk1.8.0_202.jdk/Contents/Home/jre/bin:/Users/lhs/IdeaProjects/mine-j17/jshells:/Users/lhs/GolandProjects/hs-go-free/myshell:/Users/lhs/GolandProjects/hs-go-free/myshell/hosts:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Applications/VMware Fusion.app/Contents/Public:/usr/local/go/bin:/Users/lhs/.codex/tmp/arg0/codex-arg0nB1A74:/Users/lhs/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/override:/Users/lhs/.local/bin:/Users/lhs/.codebuddy/bin:/usr/local/anaconda3/bin:/usr/local/anaconda3/condabin:/opt/homebrew/bin:/opt/homebrew/sbin:/Users/lhs/go/bin:/Users/lhs/GolandProjects/bin:/Users/lhs/soft/mongodb-macos-x86_64-4.2.18/bin:/Users/lhs/soft/apache-maven-3.6.3/bin:/Library/Java/JavaVirtualMachines/jdk1.8.0_202.jdk/Contents/Home/bin:/Library/Java/JavaVirtualMachines/jdk1.8.0_202.jdk/Contents/Home/jre/bin:/Users/lhs/IdeaProjects/mine-j17/jshells:/Users/lhs/GolandProjects/hs-go-free/myshell:/Users/lhs/GolandProjects/hs-go-free/myshell/hosts:/Users/lhs/.cargo/bin:/Users/lhs/works/bin:/Users/lhs/soft/google-cloud-sdk/bin:/Applications/Docker.app/Contents/Resources/bin:/Users/lhs/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/fallback:/Applications/ChatGPT.app/Contents/Resources:/Users/lhs/works/bin:/Users/lhs/soft/google-cloud-sdk/bin:/usr/local/bin:/Applications/Docker.app/Contents/Resources/bin"
mvn -o -pl manager/tm -am -Dtest=TMApplicationTest -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false test
```

结果：

```text
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

## 风险

本次只关闭 default profile 下 Elasticsearch health indicator，不移除 Elasticsearch 依赖，不影响显式启用或其它 profile 的 Elasticsearch 能力。

Refs: TAP-12289