### PR TITLE
fix:TAP-12357 When copying a UNION processing node of a task, dynamic…

### DIFF
--- a/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/node/hazelcast/HazelcastBaseNode.java
+++ b/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/node/hazelcast/HazelcastBaseNode.java
@@ -126,6 +126,7 @@ public abstract class HazelcastBaseNode extends AbstractProcessor {
 	protected static final String INSERT_METADATA_INFO_KEY = "INSERT_METADATA";
 	protected static final String REMOVE_METADATA_INFO_KEY = "REMOVE_METADATA";
 	protected static final String QUALIFIED_NAME_ID_MAP_INFO_KEY = "QUALIFIED_NAME_ID_MAP";
+	protected static final String SKIP_TARGET_CREATE_TABLE_INFO_KEY = "SKIP_TARGET_CREATE_TABLE";
 	private static final String TAG = HazelcastBaseNode.class.getSimpleName();
 
 	private static final Integer ERROR_EVENT_LIMIT = 10;
@@ -900,6 +901,10 @@ public abstract class HazelcastBaseNode extends AbstractProcessor {
 
 
 	public void updateMemoryFromDDLInfoMap(TapdataEvent tapdataEvent) {
+		updateMemoryFromDDLInfoMap(tapdataEvent, true);
+	}
+
+	protected void updateMemoryFromDDLInfoMap(TapdataEvent tapdataEvent, boolean updateTapTable) {
 		if (null == tapdataEvent) {
 			return;
 		}
@@ -915,6 +920,9 @@ public abstract class HazelcastBaseNode extends AbstractProcessor {
 			updateNode(tapdataEvent);
 		} catch (Exception e) {
 			throw new TapCodeException(TaskProcessorExCode_11.UPDATE_MEMORY_NODE_CONFIG_FAILED, e);
+		}
+		if (!updateTapTable) {
+			return;
 		}
 		try {
 			if (getNode() instanceof MergeTableNode) {

--- a/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/node/hazelcast/data/pdk/HazelcastTargetPdkBaseNode.java
+++ b/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/node/hazelcast/data/pdk/HazelcastTargetPdkBaseNode.java
@@ -1037,8 +1037,11 @@ public abstract class HazelcastTargetPdkBaseNode extends HazelcastPdkBaseNode {
                         return;
                     }
                 }
-                updateMemoryFromDDLInfoMap(consumeEvent);
-                obsLogger.trace("The target node refreshes the memory model according to the ddl event({})", consumeEvent.getTapEvent());
+				boolean skipTargetTableUpdate = consumeEvent.getTapEvent() instanceof TapCreateTableEvent
+						&& Boolean.TRUE.equals(consumeEvent.getTapEvent().getInfo(SKIP_TARGET_CREATE_TABLE_INFO_KEY));
+				updateMemoryFromDDLInfoMap(consumeEvent, !skipTargetTableUpdate);
+				obsLogger.trace("The target node refreshes the memory model according to the ddl event({}), skip target table model: {}",
+						consumeEvent.getTapEvent(), skipTargetTableUpdate);
             }
             enqueue(this.tapEventProcessQueue, consumeEvent);
         }
@@ -2519,4 +2522,3 @@ public abstract class HazelcastTargetPdkBaseNode extends HazelcastPdkBaseNode {
 		}
 	}
 }
-

--- a/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/node/hazelcast/data/pdk/HazelcastTargetPdkDataNode.java
+++ b/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/node/hazelcast/data/pdk/HazelcastTargetPdkDataNode.java
@@ -993,6 +993,10 @@ public class HazelcastTargetPdkDataNode extends HazelcastTargetPdkBaseNode {
 	}
 
 	private boolean executeCreateTableFunction(TapCreateTableEvent tapCreateTableEvent) {
+		if (Boolean.TRUE.equals(tapCreateTableEvent.getInfo(SKIP_TARGET_CREATE_TABLE_INFO_KEY))) {
+			obsLogger.info("Skip physical table creation while retaining model updates, tableName: {}", tapCreateTableEvent.getTableId());
+			return true;
+		}
 		String tgtTableName = getTgtTableNameFromTapEvent(tapCreateTableEvent);
 		TapTable tgtTapTable = dataProcessorContext.getTapTableMap().get(tgtTableName);
 		return createTable(tgtTapTable, new AtomicBoolean(),false);

--- a/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/node/hazelcast/processor/HazelcastMigrateUnionProcessorNode.java
+++ b/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/node/hazelcast/processor/HazelcastMigrateUnionProcessorNode.java
@@ -5,7 +5,7 @@ import com.tapdata.entity.task.context.ProcessorBaseContext;
 import com.tapdata.tm.commons.dag.process.MigrateUnionProcessorNode;
 import io.tapdata.entity.event.TapBaseEvent;
 import io.tapdata.entity.event.TapEvent;
-import io.tapdata.entity.event.ddl.TapDDLEvent;
+import io.tapdata.entity.event.ddl.table.TapCreateTableEvent;
 import io.tapdata.flow.engine.V2.util.TapEventUtil;
 
 import java.util.function.BiConsumer;
@@ -24,8 +24,10 @@ public class HazelcastMigrateUnionProcessorNode extends HazelcastProcessorBaseNo
     @Override
     protected void tryProcess(TapdataEvent tapdataEvent, BiConsumer<TapdataEvent, ProcessResult> consumer) {
         TapEvent tapEvent = tapdataEvent.getTapEvent();
-        if(tapEvent instanceof TapDDLEvent){
-            obsLogger.info("The UnionProcessor does not support DDL event filtering, and the events will be filtered out,tableName: {}", ((TapDDLEvent) tapEvent).getTableId());
+        if(tapEvent instanceof TapCreateTableEvent){
+            tapEvent.addInfo(SKIP_TARGET_CREATE_TABLE_INFO_KEY, true);
+            obsLogger.info("The UnionProcessor detected a create table event. The target will skip physical table creation while continuing model updates, tableName: {}", ((TapCreateTableEvent) tapEvent).getTableId());
+            consumer.accept(tapdataEvent, getProcessResult(TapEventUtil.getTableId(tapEvent)));
             return;
         }
         if (tapEvent instanceof TapBaseEvent) {

--- a/iengine/iengine-app/src/test/java/io/tapdata/flow/engine/V2/node/hazelcast/HazelcastBaseNodeTest.java
+++ b/iengine/iengine-app/src/test/java/io/tapdata/flow/engine/V2/node/hazelcast/HazelcastBaseNodeTest.java
@@ -1796,6 +1796,23 @@ class HazelcastBaseNodeTest extends BaseHazelcastNodeTest {
 	@DisplayName("UpdateMemoryFromDDLInfoMap method test")
 	class UpdateMemoryFromDDLInfoMapTest {
 		@Test
+		@DisplayName("When target table update is disabled, expect DAG and node updated without resolving target table")
+		void testSkipTargetTableUpdate() {
+			HazelcastBaseNode spyNode = spy(hazelcastBaseNode);
+			TapCreateTableEvent createTableEvent = new TapCreateTableEvent();
+			TapdataEvent tapdataEvent = new TapdataEvent();
+			tapdataEvent.setTapEvent(createTableEvent);
+			doNothing().when(spyNode).updateDAG(tapdataEvent);
+			doNothing().when(spyNode).updateNode(tapdataEvent);
+
+			spyNode.updateMemoryFromDDLInfoMap(tapdataEvent, false);
+
+			verify(spyNode).updateDAG(tapdataEvent);
+			verify(spyNode).updateNode(tapdataEvent);
+			verify(spyNode, never()).getTgtTableNameFromTapEvent(any(TapEvent.class));
+		}
+
+		@Test
 		@DisplayName("When tap event is TapDDLWarningEvent, expect skip and not throw NPE")
 		void testSkipTapDDLWarningEvent() {
 			HazelcastBaseNode spyNode = spy(hazelcastBaseNode);

--- a/iengine/iengine-app/src/test/java/io/tapdata/flow/engine/V2/node/hazelcast/data/pdk/HazelcastTargetPdkBaseNodeTest.java
+++ b/iengine/iengine-app/src/test/java/io/tapdata/flow/engine/V2/node/hazelcast/data/pdk/HazelcastTargetPdkBaseNodeTest.java
@@ -1828,6 +1828,20 @@ class HazelcastTargetPdkBaseNodeTest extends BaseHazelcastNodeTest {
 	@Nested
 	@DisplayName("Method processTargetEvents test")
 	class processTargetEventsTest {
+		private long countUpdateMemoryInvocations(TapdataEvent tapdataEvent) {
+			return countUpdateMemoryInvocations(tapdataEvent, true)
+					+ countUpdateMemoryInvocations(tapdataEvent, false);
+		}
+
+		private long countUpdateMemoryInvocations(TapdataEvent tapdataEvent, boolean updateTapTable) {
+			return mockingDetails(hazelcastTargetPdkBaseNode).getInvocations().stream()
+					.filter(invocation -> "updateMemoryFromDDLInfoMap".equals(invocation.getMethod().getName()))
+					.filter(invocation -> invocation.getMethod().getParameterCount() == 2)
+					.filter(invocation -> tapdataEvent.equals(invocation.getArgument(0)))
+					.filter(invocation -> Boolean.valueOf(updateTapTable).equals(invocation.getArgument(1)))
+					.count();
+		}
+
 		@BeforeEach
 		void setUp() {
 			doCallRealMethod().when(hazelcastTargetPdkBaseNode).processTargetEvents(any(List.class));
@@ -1923,7 +1937,7 @@ class HazelcastTargetPdkBaseNodeTest extends BaseHazelcastNodeTest {
 			})).start();
 			hazelcastTargetPdkBaseNode.processTargetEvents(tapdataEvents);
 			verify(hazelcastTargetPdkBaseNode, never()).fromTapValueMergeInfo(any(TapdataEvent.class));
-			verify(hazelcastTargetPdkBaseNode).updateMemoryFromDDLInfoMap(tapdataEvent);
+			assertEquals(1L, countUpdateMemoryInvocations(tapdataEvent, true));
 		}
 
 		@Test
@@ -1940,7 +1954,7 @@ class HazelcastTargetPdkBaseNodeTest extends BaseHazelcastNodeTest {
 			thread.start();
 			assertDoesNotThrow(() -> TimeUnit.MILLISECONDS.sleep(300L));
 			thread.interrupt();
-			verify(hazelcastTargetPdkBaseNode, never()).updateMemoryFromDDLInfoMap(tapdataEvent);
+			assertEquals(0L, countUpdateMemoryInvocations(tapdataEvent));
 		}
 	}
 

--- a/iengine/iengine-app/src/test/java/io/tapdata/flow/engine/V2/node/hazelcast/data/pdk/HazelcastTargetPdkDataNodeTest.java
+++ b/iengine/iengine-app/src/test/java/io/tapdata/flow/engine/V2/node/hazelcast/data/pdk/HazelcastTargetPdkDataNodeTest.java
@@ -1735,6 +1735,25 @@ class HazelcastTargetPdkDataNodeTest extends BaseTaskTest {
 		verify(ddlEventHandlers,times(5)).handle(any());
 	}
 
+	@Test
+	@DisplayName("Skip physical table creation when create table event only updates models")
+	void testSkipCreateTableForModelUpdate() {
+		TapCreateTableEvent createTableEvent = new TapCreateTableEvent();
+		createTableEvent.setTableId("dynamic_table");
+		createTableEvent.addInfo("SKIP_TARGET_CREATE_TABLE", true);
+		ReflectionTestUtils.setField(hazelcastTargetPdkDataNode, "obsLogger", mockObsLogger);
+
+		Boolean result = ReflectionTestUtils.invokeMethod(
+				hazelcastTargetPdkDataNode,
+				"executeCreateTableFunction",
+				createTableEvent
+		);
+
+		assertTrue(result);
+		verify(hazelcastTargetPdkDataNode, never()).getTgtTableNameFromTapEvent(any(TapEvent.class));
+		verify(hazelcastTargetPdkDataNode, never()).createTable(any(), any(AtomicBoolean.class), anyBoolean());
+	}
+
 	@Nested
 	class testWriteRecord {
 

--- a/iengine/iengine-app/src/test/java/io/tapdata/flow/engine/V2/node/hazelcast/processor/HazelcastMigrateUnionProcessorNodeTest.java
+++ b/iengine/iengine-app/src/test/java/io/tapdata/flow/engine/V2/node/hazelcast/processor/HazelcastMigrateUnionProcessorNodeTest.java
@@ -52,6 +52,7 @@ public class HazelcastMigrateUnionProcessorNodeTest extends BaseHazelcastNodeTes
         tapdataEvent.setTapEvent(createTableEvent);
         BiConsumer<TapdataEvent, HazelcastProcessorBaseNode.ProcessResult> consumer = mock(BiConsumer.class);
         hazelcastMigrateUnionProcessorNode.tryProcess(tapdataEvent,consumer);
-        verify(consumer,times(0)).accept(any(),any());
+        Assertions.assertEquals(Boolean.TRUE, createTableEvent.getInfo("SKIP_TARGET_CREATE_TABLE"));
+        verify(consumer,times(1)).accept(eq(tapdataEvent),any());
     }
 }


### PR DESCRIPTION
…ally adding a new table fails to refresh the model of the task source node.