### PR TITLE
feat: Implement BatchListTagService for managing batch tag operations

### DIFF
--- a/manager/tm-api/src/main/java/com/tapdata/tm/task/param/BatchApplyListTagsParam.java
+++ b/manager/tm-api/src/main/java/com/tapdata/tm/task/param/BatchApplyListTagsParam.java
@@ -1,0 +1,21 @@
+package com.tapdata.tm.task.param;
+
+import com.tapdata.tm.commons.schema.Tag;
+import com.fasterxml.jackson.annotation.JsonAlias;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import java.util.List;
+
+@Data
+public class BatchApplyListTagsParam {
+    @JsonAlias("taskIds")
+    private List<String> ids;
+    private List<TagState> tags;
+
+    @Data
+    @EqualsAndHashCode(callSuper = true)
+    public static class TagState extends Tag {
+        private String desired;
+    }
+}

--- a/manager/tm/src/main/java/com/tapdata/tm/batchtags/service/BatchListTagService.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/batchtags/service/BatchListTagService.java
@@ -1,0 +1,115 @@
+package com.tapdata.tm.batchtags.service;
+
+import com.tapdata.tm.commons.schema.Tag;
+import com.tapdata.tm.task.param.BatchApplyListTagsParam;
+import lombok.Getter;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+public class BatchListTagService {
+
+    public BatchListTagChanges resolveTagChanges(List<BatchApplyListTagsParam.TagState> desiredTags) {
+        BatchListTagChanges tagChanges = new BatchListTagChanges();
+        if (CollectionUtils.isEmpty(desiredTags)) {
+            return tagChanges;
+        }
+
+        desiredTags.forEach(tag -> {
+            if (tag == null || StringUtils.isBlank(tag.getId())) {
+                return;
+            }
+
+            String desired = StringUtils.lowerCase(tag.getDesired());
+            if ("all".equals(desired)) {
+                tagChanges.removeTagIds.remove(tag.getId());
+                tagChanges.addTags.put(tag.getId(), new Tag(tag.getId(), tag.getValue()));
+            } else if ("none".equals(desired)) {
+                tagChanges.addTags.remove(tag.getId());
+                tagChanges.removeTagIds.add(tag.getId());
+            }
+        });
+
+        return tagChanges;
+    }
+
+    public List<Tag> applyDesiredTags(List<Tag> currentTags, BatchListTagChanges tagChanges) {
+        if (tagChanges == null || tagChanges.isEmpty()) {
+            return normalizeTags(currentTags);
+        }
+
+        Map<String, Tag> tagMap = new LinkedHashMap<>();
+        normalizeTags(currentTags).forEach(tag -> tagMap.put(tag.getId(), tag));
+
+        tagChanges.getRemoveTagIds().forEach(tagMap::remove);
+        tagChanges.getAddTags().forEach((id, tag) -> tagMap.put(id, new Tag(tag.getId(), tag.getValue())));
+
+        return new ArrayList<>(tagMap.values());
+    }
+
+    public boolean isSameTags(List<Tag> oldTags, List<Tag> newTags) {
+        return toTagValueMap(oldTags).equals(toTagValueMap(newTags));
+    }
+
+    public List<Tag> normalizeTags(List<Tag> tags) {
+        if (CollectionUtils.isEmpty(tags)) {
+            return Collections.emptyList();
+        }
+        return tags.stream()
+                .filter(tag -> tag != null && StringUtils.isNotBlank(tag.getId()))
+                .map(tag -> new Tag(tag.getId(), tag.getValue()))
+                .collect(Collectors.toList());
+    }
+
+    public List<Map<String, String>> toMapTags(List<Tag> tags) {
+        if (CollectionUtils.isEmpty(tags)) {
+            return Collections.emptyList();
+        }
+        return tags.stream()
+                .filter(tag -> tag != null && StringUtils.isNotBlank(tag.getId()))
+                .map(tag -> {
+                    Map<String, String> tagMap = new LinkedHashMap<>(2);
+                    tagMap.put("id", tag.getId());
+                    tagMap.put("value", tag.getValue());
+                    return tagMap;
+                })
+                .collect(Collectors.toList());
+    }
+
+    public List<Tag> fromMapTags(List<Map<String, String>> tags) {
+        if (CollectionUtils.isEmpty(tags)) {
+            return Collections.emptyList();
+        }
+        return tags.stream()
+                .filter(tag -> tag != null && StringUtils.isNotBlank(tag.get("id")))
+                .map(tag -> new Tag(tag.get("id"), tag.get("value")))
+                .collect(Collectors.toList());
+    }
+
+    private Map<String, String> toTagValueMap(List<Tag> tags) {
+        return Optional.ofNullable(tags).orElse(Collections.emptyList()).stream()
+                .filter(tag -> tag != null && StringUtils.isNotBlank(tag.getId()))
+                .collect(Collectors.toMap(Tag::getId, Tag::getValue, (oldValue, newValue) -> newValue, LinkedHashMap::new));
+    }
+
+    @Getter
+    public static class BatchListTagChanges {
+        private final Map<String, Tag> addTags = new LinkedHashMap<>();
+        private final Set<String> removeTagIds = new LinkedHashSet<>();
+
+        public boolean isEmpty() {
+            return addTags.isEmpty() && removeTagIds.isEmpty();
+        }
+    }
+}

--- a/manager/tm/src/main/java/com/tapdata/tm/ds/controller/DataSourceController.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/ds/controller/DataSourceController.java
@@ -25,7 +25,7 @@ import com.tapdata.tm.ds.param.ValidateTableParam;
 import com.tapdata.tm.ds.service.impl.DataSourceService;
 import com.tapdata.tm.ds.vo.AllDataSourceConnectionVo;
 import com.tapdata.tm.ds.vo.ValidateTableVo;
-import com.tapdata.tm.metadatadefinition.param.BatchUpdateParam;
+import com.tapdata.tm.task.param.BatchApplyListTagsParam;
 import com.tapdata.tm.metadatadefinition.service.MetadataDefinitionService;
 import com.tapdata.tm.permissions.constants.DataPermissionActionEnums;
 import com.tapdata.tm.permissions.constants.DataPermissionMenuEnums;
@@ -565,8 +565,8 @@ public class DataSourceController extends BaseController {
      */
     @Operation(summary = " 批量修改所属类别")
     @PatchMapping("batchUpdateListtags")
-    public ResponseMessage<List<String>> batchUpdateListTags(@RequestBody BatchUpdateParam batchUpdateParam) {
-        return success(metadataDefinitionService.batchUpdateListTags("Connections", batchUpdateParam, getLoginUser()));
+    public ResponseMessage<List<String>> batchUpdateListTags(@RequestBody BatchApplyListTagsParam batchApplyListTagsParam) {
+        return success(metadataDefinitionService.batchApplyListTags("Connections", batchApplyListTagsParam, getLoginUser()));
     }
 
     /**

--- a/manager/tm/src/main/java/com/tapdata/tm/inspect/controller/InspectController.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/inspect/controller/InspectController.java
@@ -21,7 +21,7 @@ import com.tapdata.tm.inspect.service.InspectService;
 import com.tapdata.tm.inspect.service.InspectTaskService;
 import com.tapdata.tm.inspect.vo.InspectRecoveryStartVerifyVo;
 import com.tapdata.tm.inspect.vo.InspectTaskVo;
-import com.tapdata.tm.metadatadefinition.param.BatchUpdateParam;
+import com.tapdata.tm.task.param.BatchApplyListTagsParam;
 import com.tapdata.tm.metadatadefinition.service.MetadataDefinitionService;
 import com.tapdata.tm.permissions.DataPermissionHelper;
 import com.tapdata.tm.permissions.constants.DataPermissionActionEnums;
@@ -442,8 +442,8 @@ public class InspectController extends BaseController {
 
     @Operation(summary = "批量修改标签")
     @PatchMapping("batchUpdateListtags")
-    public ResponseMessage<List<String>> batchUpdateListTags(@RequestBody BatchUpdateParam batchUpdateParam) {
-        return success(metadataDefinitionService.batchUpdateListTags("Inspect", batchUpdateParam, getLoginUser()));
+    public ResponseMessage<List<String>> batchUpdateListTags(@RequestBody BatchApplyListTagsParam batchApplyListTagsParam) {
+        return success(metadataDefinitionService.batchApplyListTags("Inspect", batchApplyListTagsParam, getLoginUser()));
     }
 
     @Operation(summary = "导出修复事件SQL")

--- a/manager/tm/src/main/java/com/tapdata/tm/metadatadefinition/service/MetadataDefinitionService.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/metadatadefinition/service/MetadataDefinitionService.java
@@ -9,6 +9,9 @@ import com.tapdata.tm.base.dto.Page;
 import com.tapdata.tm.base.dto.Where;
 import com.tapdata.tm.base.exception.BizException;
 import com.tapdata.tm.base.service.BaseService;
+import com.tapdata.tm.batchtags.service.BatchListTagService;
+import com.tapdata.tm.batchtags.service.BatchListTagService.BatchListTagChanges;
+import com.tapdata.tm.base.entity.BaseEntity;
 import com.tapdata.tm.commons.base.dto.BaseDto;
 import com.tapdata.tm.commons.schema.DataSourceDefinitionDto;
 import com.tapdata.tm.commons.schema.Tag;
@@ -25,6 +28,7 @@ import com.tapdata.tm.metadatadefinition.repository.MetadataDefinitionRepository
 import com.tapdata.tm.metadatainstance.service.MetadataInstancesService;
 import com.tapdata.tm.modules.entity.ModulesEntity;
 import com.tapdata.tm.task.constant.LdpDirEnum;
+import com.tapdata.tm.task.param.BatchApplyListTagsParam;
 import com.tapdata.tm.task.entity.TaskEntity;
 import com.tapdata.tm.task.service.LdpService;
 import com.tapdata.tm.user.entity.User;
@@ -77,6 +81,9 @@ public class MetadataDefinitionService extends BaseService<MetadataDefinitionDto
     MetadataInstancesService metadataInstancesService;
 
     @Autowired
+    BatchListTagService batchListTagService;
+
+    @Autowired
     private DiscoveryService discoveryService;
 
     @Autowired
@@ -117,12 +124,42 @@ public class MetadataDefinitionService extends BaseService<MetadataDefinitionDto
         if (entityClass != null) {
             mongoTemplate.updateMulti(Query.query(Criteria.where("id").in(idList)), update, entityClass);
         }
+        return idList;
+    }
 
-        // 更新成功后，需要将模型中的也跟着更新了
-        Criteria criteria = Criteria.where("source.id").in(idList).and("metaType").is("database").and("isDeleted").is(false);
-        Update classifications = Update.update("classifications", listTags);
-        metadataInstancesService.update(new Query(criteria), classifications, userDetail);
-        return null;
+    public List<String> batchApplyListTags(String tableName, BatchApplyListTagsParam batchApplyListTagsParam, UserDetail userDetail) {
+        if (batchApplyListTagsParam == null || CollectionUtils.isEmpty(batchApplyListTagsParam.getIds()) || CollectionUtils.isEmpty(batchApplyListTagsParam.getTags())) {
+            return Collections.emptyList();
+        }
+
+        BatchListTagChanges tagChanges = batchListTagService.resolveTagChanges(batchApplyListTagsParam.getTags());
+        if (tagChanges.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        Class<?> entityClass = ENTITY_MAP.get(tableName);
+        if (entityClass == null) {
+            return Collections.emptyList();
+        }
+
+        List<String> idList = batchApplyListTagsParam.getIds();
+        if (DataSourceEntity.class.equals(entityClass)) {
+            return applyBatchListTags(idList, tagChanges, DataSourceEntity.class,
+                    entity -> batchListTagService.fromMapTags(entity.getListtags()),
+                    batchListTagService::toMapTags);
+        }
+        if (InspectEntity.class.equals(entityClass)) {
+            return applyBatchListTags(idList, tagChanges, InspectEntity.class,
+                    InspectEntity::getListtags,
+                    tags -> tags);
+        }
+        if (TaskEntity.class.equals(entityClass)) {
+            return applyBatchListTags(idList, tagChanges, TaskEntity.class,
+                    TaskEntity::getListtags,
+                    tags -> tags);
+        }
+
+        return Collections.emptyList();
     }
 
     /**
@@ -142,6 +179,35 @@ public class MetadataDefinitionService extends BaseService<MetadataDefinitionDto
         }
 
         return idList;
+    }
+
+    private <T extends BaseEntity> List<String> applyBatchListTags(List<String> idList,
+                                                                   BatchListTagChanges tagChanges,
+                                                                   Class<T> entityClass,
+                                                                   Function<T, List<Tag>> currentTagsGetter,
+                                                                   Function<List<Tag>, Object> storedTagsConverter) {
+        Query query = Query.query(Criteria.where("id").in(idList));
+        query.fields().include("id", "listtags");
+        List<T> entities = mongoTemplate.find(query, entityClass);
+        List<String> updatedIds = new ArrayList<>();
+
+        for (T entity : entities) {
+            List<Tag> currentTags = Optional.ofNullable(currentTagsGetter.apply(entity)).orElse(Collections.emptyList());
+            List<Tag> nextTags = batchListTagService.applyDesiredTags(currentTags, tagChanges);
+            if (batchListTagService.isSameTags(currentTags, nextTags)) {
+                continue;
+            }
+
+            mongoTemplate.updateFirst(Query.query(Criteria.where("id").is(entity.getId())),
+                    Update.update("listtags", storedTagsConverter.apply(nextTags)),
+                    entityClass);
+
+            if (entity.getId() != null) {
+                updatedIds.add(entity.getId().toHexString());
+            }
+        }
+
+        return updatedIds;
     }
 
 

--- a/manager/tm/src/main/java/com/tapdata/tm/task/controller/TaskController.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/task/controller/TaskController.java
@@ -38,6 +38,7 @@ import com.tapdata.tm.permissions.constants.DataPermissionActionEnums;
 import com.tapdata.tm.permissions.constants.DataPermissionDataTypeEnums;
 import com.tapdata.tm.permissions.constants.DataPermissionMenuEnums;
 import com.tapdata.tm.task.bean.*;
+import com.tapdata.tm.task.param.BatchApplyListTagsParam;
 import com.tapdata.tm.task.entity.TaskEntity;
 import com.tapdata.tm.task.param.LogSettingParam;
 import com.tapdata.tm.task.service.*;
@@ -1187,6 +1188,12 @@ public class TaskController extends BaseController {
     @PatchMapping("batchUpdateListtags")
     public ResponseMessage<List<String>> batchUpdateListTags(@RequestBody BatchUpdateParam batchUpdateParam) {
         return success(metadataDefinitionService.batchUpdateListTags("Task", batchUpdateParam, getLoginUser()));
+    }
+
+    @Operation(summary = "批量增删任务标签")
+    @PatchMapping("batchApplyListtags")
+    public ResponseMessage<List<String>> batchApplyListTags(@RequestBody BatchApplyListTagsParam batchApplyListTagsParam) {
+        return success(metadataDefinitionService.batchApplyListTags("Task", batchApplyListTagsParam, getLoginUser()));
     }
 
     @Operation(summary = "获取建表语句")

--- a/manager/tm/src/test/java/com/tapdata/tm/batchtags/service/BatchListTagServiceTest.java
+++ b/manager/tm/src/test/java/com/tapdata/tm/batchtags/service/BatchListTagServiceTest.java
@@ -1,0 +1,108 @@
+package com.tapdata.tm.batchtags.service;
+
+import com.tapdata.tm.commons.schema.Tag;
+import com.tapdata.tm.task.param.BatchApplyListTagsParam;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BatchListTagServiceTest {
+
+    private final BatchListTagService service = new BatchListTagService();
+
+    @Test
+    void resolveTagChangesShouldIgnoreSomeAndInvalidTags() {
+        BatchListTagService.BatchListTagChanges changes = service.resolveTagChanges(Arrays.asList(
+                tagState("tag-a", "TagA", "all"),
+                tagState("tag-b", "TagB", "none"),
+                tagState("tag-c", "TagC", "some"),
+                tagState("", "Empty", "all"),
+                null
+        ));
+
+        assertFalse(changes.isEmpty());
+        assertEquals("TagA", changes.getAddTags().get("tag-a").getValue());
+        assertTrue(changes.getRemoveTagIds().contains("tag-b"));
+        assertFalse(changes.getAddTags().containsKey("tag-c"));
+        assertFalse(changes.getRemoveTagIds().contains("tag-c"));
+    }
+
+    @Test
+    void resolveTagChangesShouldLetLaterDesiredStateWin() {
+        BatchListTagService.BatchListTagChanges changes = service.resolveTagChanges(Arrays.asList(
+                tagState("tag-a", "TagA", "all"),
+                tagState("tag-a", "TagA", "none")
+        ));
+
+        assertFalse(changes.getAddTags().containsKey("tag-a"));
+        assertTrue(changes.getRemoveTagIds().contains("tag-a"));
+    }
+
+    @Test
+    void applyDesiredTagsShouldRemoveAndAppendTagsWithoutMutatingSource() {
+        List<Tag> currentTags = Arrays.asList(
+                new Tag("tag-a", "TagA"),
+                new Tag("tag-b", "TagB")
+        );
+        BatchListTagService.BatchListTagChanges changes = service.resolveTagChanges(Arrays.asList(
+                tagState("tag-b", "TagB", "none"),
+                tagState("tag-c", "TagC", "all")
+        ));
+
+        List<Tag> result = service.applyDesiredTags(currentTags, changes);
+
+        assertEquals(Arrays.asList(new Tag("tag-a", "TagA"), new Tag("tag-c", "TagC")), result);
+        assertEquals(Arrays.asList(new Tag("tag-a", "TagA"), new Tag("tag-b", "TagB")), currentTags);
+    }
+
+    @Test
+    void isSameTagsShouldCompareByIdAndValueIgnoringOrderAndInvalidItems() {
+        List<Tag> oldTags = Arrays.asList(
+                new Tag("tag-a", "TagA"),
+                new Tag("", "Blank"),
+                null,
+                new Tag("tag-b", "TagB")
+        );
+        List<Tag> newTags = Arrays.asList(
+                new Tag("tag-b", "TagB"),
+                new Tag("tag-a", "TagA")
+        );
+
+        assertTrue(service.isSameTags(oldTags, newTags));
+        assertFalse(service.isSameTags(oldTags, Collections.singletonList(new Tag("tag-a", "TagA"))));
+    }
+
+    @Test
+    void shouldConvertBetweenTagListAndMapList() {
+        List<Map<String, String>> mapTags = service.toMapTags(Arrays.asList(
+                new Tag("tag-a", "TagA"),
+                new Tag("", "Blank"),
+                null
+        ));
+
+        assertEquals(1, mapTags.size());
+        assertEquals("tag-a", mapTags.get(0).get("id"));
+        assertEquals("TagA", mapTags.get(0).get("value"));
+
+        Map<String, String> tagMap = new HashMap<>();
+        tagMap.put("id", "tag-b");
+        tagMap.put("value", "TagB");
+        assertEquals(Collections.singletonList(new Tag("tag-b", "TagB")), service.fromMapTags(Collections.singletonList(tagMap)));
+    }
+
+    private BatchApplyListTagsParam.TagState tagState(String id, String value, String desired) {
+        BatchApplyListTagsParam.TagState tagState = new BatchApplyListTagsParam.TagState();
+        tagState.setId(id);
+        tagState.setValue(value);
+        tagState.setDesired(desired);
+        return tagState;
+    }
+}

--- a/manager/tm/src/test/java/com/tapdata/tm/metadatadefinition/service/MetadataDefinitionServiceTest.java
+++ b/manager/tm/src/test/java/com/tapdata/tm/metadatadefinition/service/MetadataDefinitionServiceTest.java
@@ -3,18 +3,25 @@ package com.tapdata.tm.metadatadefinition.service;
 import com.mongodb.client.result.UpdateResult;
 import com.tapdata.tm.Settings.service.SettingsService;
 import com.tapdata.tm.agent.dto.GroupDto;
+import com.tapdata.tm.batchtags.service.BatchListTagService;
 import com.tapdata.tm.base.dto.Filter;
 import com.tapdata.tm.base.dto.Where;
 import com.tapdata.tm.base.exception.BizException;
 import com.tapdata.tm.commons.schema.Tag;
 import com.tapdata.tm.commons.task.dto.TaskDto;
 import com.tapdata.tm.config.security.UserDetail;
+import com.tapdata.tm.ds.entity.DataSourceEntity;
+import com.tapdata.tm.inspect.entity.InspectEntity;
 import com.tapdata.tm.metadatadefinition.dto.MetadataDefinitionDto;
 import com.tapdata.tm.metadatadefinition.entity.MetadataDefinitionEntity;
 import com.tapdata.tm.metadatadefinition.param.BatchUpdateParam;
 import com.tapdata.tm.metadatadefinition.repository.MetadataDefinitionRepository;
+import com.tapdata.tm.task.entity.TaskEntity;
+import com.tapdata.tm.task.param.BatchApplyListTagsParam;
 import com.tapdata.tm.utils.Lists;
+import org.bson.Document;
 import org.bson.types.ObjectId;
+import org.mockito.ArgumentCaptor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -83,6 +90,133 @@ class MetadataDefinitionServiceTest {
             doVerify("", 0);
         }
     }
+
+    @Nested
+    class BatchApplyListTagsTest {
+        BatchListTagService batchListTagService;
+        UserDetail userDetail;
+
+        @BeforeEach
+        void init() {
+            batchListTagService = new BatchListTagService();
+            userDetail = mock(UserDetail.class);
+            ReflectionTestUtils.setField(metadataDefinitionService, "batchListTagService", batchListTagService);
+            doCallRealMethod().when(metadataDefinitionService).batchApplyListTags(anyString(), any(BatchApplyListTagsParam.class), any(UserDetail.class));
+        }
+
+        @Test
+        void shouldReturnEmptyWhenParamInvalid() {
+            assertTrue(metadataDefinitionService.batchApplyListTags("Task", null, userDetail).isEmpty());
+            assertTrue(metadataDefinitionService.batchApplyListTags("Task", batchApplyParam(Collections.emptyList(), tagState("tag-a", "TagA", "all")), userDetail).isEmpty());
+            assertTrue(metadataDefinitionService.batchApplyListTags("Task", batchApplyParam(Collections.singletonList("id-1")), userDetail).isEmpty());
+
+            verify(mongoTemplate, never()).find(any(Query.class), any(Class.class));
+        }
+
+        @Test
+        void shouldReturnEmptyWhenDesiredTagsOnlyContainSomeState() {
+            BatchApplyListTagsParam param = batchApplyParam(Collections.singletonList(new ObjectId().toHexString()),
+                    tagState("tag-a", "TagA", "some"));
+
+            assertTrue(metadataDefinitionService.batchApplyListTags("Task", param, userDetail).isEmpty());
+
+            verify(mongoTemplate, never()).find(any(Query.class), any(Class.class));
+        }
+
+        @Test
+        void shouldApplyTagsForConnectionsUsingMapListTags() {
+            ObjectId id = new ObjectId();
+            DataSourceEntity entity = new DataSourceEntity();
+            entity.setId(id);
+            entity.setListtags(Arrays.asList(mapTag("tag-a", "TagA"), mapTag("tag-b", "TagB")));
+            BatchApplyListTagsParam param = batchApplyParam(Collections.singletonList(id.toHexString()),
+                    tagState("tag-b", "TagB", "none"),
+                    tagState("tag-c", "TagC", "all"));
+            when(mongoTemplate.find(any(Query.class), eq(DataSourceEntity.class))).thenReturn(Collections.singletonList(entity));
+
+            List<String> result = metadataDefinitionService.batchApplyListTags("Connections", param, userDetail);
+
+            assertEquals(Collections.singletonList(id.toHexString()), result);
+            ArgumentCaptor<Update> updateCaptor = ArgumentCaptor.forClass(Update.class);
+            verify(mongoTemplate).updateFirst(any(Query.class), updateCaptor.capture(), eq(DataSourceEntity.class));
+            List<Map<String, String>> updatedTags = getSetListTags(updateCaptor.getValue());
+            assertEquals(Arrays.asList(mapTag("tag-a", "TagA"), mapTag("tag-c", "TagC")), updatedTags);
+        }
+
+        @Test
+        void shouldApplyTagsForInspectUsingTagList() {
+            ObjectId id = new ObjectId();
+            InspectEntity entity = new InspectEntity();
+            entity.setId(id);
+            entity.setListtags(Arrays.asList(new Tag("tag-a", "TagA"), new Tag("tag-b", "TagB")));
+            BatchApplyListTagsParam param = batchApplyParam(Collections.singletonList(id.toHexString()),
+                    tagState("tag-a", "TagA", "none"),
+                    tagState("tag-c", "TagC", "all"));
+            when(mongoTemplate.find(any(Query.class), eq(InspectEntity.class))).thenReturn(Collections.singletonList(entity));
+
+            List<String> result = metadataDefinitionService.batchApplyListTags("Inspect", param, userDetail);
+
+            assertEquals(Collections.singletonList(id.toHexString()), result);
+            ArgumentCaptor<Update> updateCaptor = ArgumentCaptor.forClass(Update.class);
+            verify(mongoTemplate).updateFirst(any(Query.class), updateCaptor.capture(), eq(InspectEntity.class));
+            assertEquals(Arrays.asList(new Tag("tag-b", "TagB"), new Tag("tag-c", "TagC")), getSetListTags(updateCaptor.getValue()));
+        }
+
+        @Test
+        void shouldSkipTaskUpdateWhenTagsAreNotChanged() {
+            ObjectId id = new ObjectId();
+            TaskEntity entity = new TaskEntity();
+            entity.setId(id);
+            entity.setListtags(Collections.singletonList(new Tag("tag-a", "TagA")));
+            BatchApplyListTagsParam param = batchApplyParam(Collections.singletonList(id.toHexString()),
+                    tagState("tag-a", "TagA", "all"));
+            when(mongoTemplate.find(any(Query.class), eq(TaskEntity.class))).thenReturn(Collections.singletonList(entity));
+
+            List<String> result = metadataDefinitionService.batchApplyListTags("Task", param, userDetail);
+
+            assertTrue(result.isEmpty());
+            verify(mongoTemplate, never()).updateFirst(any(Query.class), any(Update.class), any(Class.class));
+        }
+
+        @Test
+        void shouldReturnEmptyForUnsupportedTableName() {
+            BatchApplyListTagsParam param = batchApplyParam(Collections.singletonList(new ObjectId().toHexString()),
+                    tagState("tag-a", "TagA", "all"));
+
+            assertTrue(metadataDefinitionService.batchApplyListTags("Unknown", param, userDetail).isEmpty());
+
+            verify(mongoTemplate, never()).find(any(Query.class), any(Class.class));
+        }
+
+        private BatchApplyListTagsParam batchApplyParam(List<String> ids, BatchApplyListTagsParam.TagState... tags) {
+            BatchApplyListTagsParam param = new BatchApplyListTagsParam();
+            param.setIds(ids);
+            param.setTags(Arrays.asList(tags));
+            return param;
+        }
+
+        private BatchApplyListTagsParam.TagState tagState(String id, String value, String desired) {
+            BatchApplyListTagsParam.TagState tagState = new BatchApplyListTagsParam.TagState();
+            tagState.setId(id);
+            tagState.setValue(value);
+            tagState.setDesired(desired);
+            return tagState;
+        }
+
+        private Map<String, String> mapTag(String id, String value) {
+            Map<String, String> tag = new LinkedHashMap<>();
+            tag.put("id", id);
+            tag.put("value", value);
+            return tag;
+        }
+
+        @SuppressWarnings("unchecked")
+        private <T> List<T> getSetListTags(Update update) {
+            Document updateObject = update.getUpdateObject();
+            return (List<T>) ((Document) updateObject.get("$set")).get("listtags");
+        }
+    }
+
     @Nested
     class FindTest{
         SettingsService settingsService;


### PR DESCRIPTION
- Added BatchListTagService to handle tag changes and apply desired tags.
- Updated DataSourceController and InspectController to use BatchApplyListTagsParam for batch tag updates.
- Introduced batchApplyListTags method in MetadataDefinitionService for processing batch tag applications.
- Created BatchApplyListTagsParam class to encapsulate task IDs and tag states for batch operations.
- Enhanced TaskController with a new endpoint for batch tag application.