### PR TITLE
fix(TAP-12425): 项目导入的 API 发布后 404 —— ModulesDto.connection 被 Jackson 重建成随机 ObjectId (v4.22.0)

### DIFF
--- a/manager/tm-api/src/main/java/com/tapdata/tm/module/dto/ModulesDto.java
+++ b/manager/tm-api/src/main/java/com/tapdata/tm/module/dto/ModulesDto.java
@@ -2,7 +2,11 @@ package com.tapdata.tm.module.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.tapdata.tm.commons.base.IDataPermissionDto;
+import com.tapdata.tm.commons.base.convert.ObjectIdDeserialize;
+import com.tapdata.tm.commons.base.convert.ObjectIdSerialize;
 import com.tapdata.tm.commons.schema.Field;
 import com.tapdata.tm.commons.schema.Tag;
 import com.tapdata.tm.module.entity.ApiAlarmConfig;
@@ -71,6 +75,16 @@ public class ModulesDto extends BaseDto implements IDataPermissionDto {
 
     private String connectionId;
 
+    /**
+     * API 所属连接的 _id。
+     *
+     * <p>TAP-12425：必须显式声明 ObjectId 的序列化器。{@code JsonUtil} 的 ObjectMapper 没有注册全局
+     * ObjectId 处理器，缺省会把 ObjectId 当普通 bean 序列化成 {@code {"timestamp":..,"date":..}}，
+     * 回读时只能落到 ObjectId 的无参/单参构造上，得到一个全新的随机 ObjectId。项目导出/导入
+     * （group_import）走的正是 {@code JsonUtil}，导致导入后的 API 指向一个根本不存在的连接。</p>
+     */
+    @JsonSerialize(using = ObjectIdSerialize.class)
+    @JsonDeserialize(using = ObjectIdDeserialize.class)
     private ObjectId connection;
     private String access_token;
     private String user;

--- a/manager/tm/src/main/java/com/tapdata/tm/group/handler/ModuleResourceHandler.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/group/handler/ModuleResourceHandler.java
@@ -142,7 +142,12 @@ public class ModuleResourceHandler implements ResourceHandler {
         List<ModulesDto> modules = (List<ModulesDto>) resources;
 
         for (ModulesDto modulesDto : modules) {
-            String connectionId = modulesDto.getConnectionId();
+            // TAP-12425：datasource / connectionId 优先，connection 只作兜底——
+            // 历史导入可能把 connection 写成了一个不存在的 ObjectId，用它会导出错误的连接元数据。
+            String connectionId = modulesDto.getDataSource();
+            if (StringUtils.isBlank(connectionId)) {
+                connectionId = modulesDto.getConnectionId();
+            }
             if (StringUtils.isBlank(connectionId) && modulesDto.getConnection() != null) {
                 connectionId = modulesDto.getConnection().toHexString();
             }

--- a/manager/tm/src/main/java/com/tapdata/tm/modules/service/ModulesService.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/modules/service/ModulesService.java
@@ -123,6 +123,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
@@ -203,8 +204,12 @@ public class ModulesService extends BaseService<ModulesDto, ModulesEntity, Objec
 		parseTapType(modulesDto);
 		modulesDto.withPathSettingIfNeed();
 		final ModulesDetailVo modulesDetailVo = BeanUtil.copyProperties(modulesDto, ModulesDetailVo.class);
-		final String connectionId = modulesDto.getConnection().toString();
-		Optional.ofNullable(dataSourceService.findById(MongoUtils.toObjectId(connectionId)))
+		// TAP-12425：与 activeApis 保持同一套解析口径，datasource 优先、connection 兜底，
+		// 这样历史导入写坏 connection 的 API 详情页仍能展示正确的连接。
+		final ObjectId connection = resolveApiConnectionId(modulesDto);
+		final String connectionId = connection == null ? null : connection.toHexString();
+		Optional.ofNullable(connection)
+				.map(connectionObjectId -> dataSourceService.findById(connectionObjectId))
 				.ifPresent(dataSourceConnectionDto -> {
 					dataSourceConnectionDto.setDatabase_password(null);
 					dataSourceConnectionDto.setPlain_password(null);
@@ -587,9 +592,26 @@ public class ModulesService extends BaseService<ModulesDto, ModulesEntity, Objec
 			return new ArrayList<>();
 		}
 		List<ConnectionVo> connectionVos = new ArrayList<>();
-		Map<ObjectId, List<ModulesDto>> connectionMap = apis.stream().collect(Collectors.groupingBy(ModulesDto::getConnection));
-		Set<ObjectId> connections = connectionMap.keySet();
-		assert !connections.isEmpty();
+		// TAP-12425：优先按 datasource 解析连接——API Server 也是按 datasource 匹配数据源的
+		// （见 apiserver generators/tapDataCodeGenerator.js），而 connection 可能被历史导入写坏。
+		// 两者都解析不出连接的 API 直接跳过，避免 groupingBy/toHexString 在 null 上抛 NPE 拖垮整个发布。
+		Set<ObjectId> connections = new LinkedHashSet<>();
+		List<ModulesDto> resolvableApis = new ArrayList<>();
+		for (ModulesDto api : apis) {
+			ObjectId connectionId = resolveApiConnectionId(api);
+			if (connectionId == null) {
+				log.warn("Api {}({}) has no resolvable connection, skip publishing it",
+						api.getName(), api.getId());
+				continue;
+			}
+			api.setConnection(connectionId);
+			connections.add(connectionId);
+			resolvableApis.add(api);
+		}
+		if (connections.isEmpty()) {
+			return new ArrayList<>();
+		}
+		apis = resolvableApis;
 		Query query = Query.query(Criteria.where("id").in(connections));
 		List<DataSourceConnectionDto> dataSourceConnectionDtoList = dataSourceService.findAll(query);
 		List<String> databaseTypes = dataSourceConnectionDtoList.stream()
@@ -643,6 +665,19 @@ public class ModulesService extends BaseService<ModulesDto, ModulesEntity, Objec
 		apiDefinitionVo.setApis(apis);
 		withEncryptionRule(apis);
 		return apis;
+	}
+
+	/**
+	 * TAP-12425：解析 API 实际指向的连接 _id，datasource 优先、connection 兜底。
+	 *
+	 * @return 解析不出时返回 null
+	 */
+	protected ObjectId resolveApiConnectionId(ModulesDto api) {
+		if (null == api) {
+			return null;
+		}
+		ObjectId fromDataSource = MongoUtils.toObjectId(api.getDataSource());
+		return fromDataSource != null ? fromDataSource : api.getConnection();
 	}
 
 	protected String parseUri(Map<String, Object> connectionConfig) {
@@ -1849,6 +1884,7 @@ public class ModulesService extends BaseService<ModulesDto, ModulesEntity, Objec
 			try {
 				modulesDto.setIsDeleted(false);
 				modulesDto.setStatus(ModuleStatusEnum.PENDING.getValue());
+				alignConnectionWithDataSource(modulesDto);
 
 				// 根据导入模式处理
 				switch (importMode) {
@@ -1892,6 +1928,27 @@ public class ModulesService extends BaseService<ModulesDto, ModulesEntity, Objec
 			}
 		}
 		return importResult;
+	}
+
+	/**
+	 * TAP-12425：以 datasource（回退 connectionId）为准重建 connection。
+	 *
+	 * <p>导入包里的 connection 不可信：老包把 ObjectId 序列化成了 {@code {"timestamp":..,"date":..}}，
+	 * 回读时会得到一个随机 ObjectId 或 null。datasource / connectionId 是字符串，能原样往返，
+	 * 且 API Server 本身就是按 datasource 去匹配数据源的，因此它们才是权威来源。</p>
+	 *
+	 * <p>两者都不可用时保持原值不动，交由后续 {@link #updateConnectionIds} 的 conMap 映射处理。</p>
+	 */
+	protected void alignConnectionWithDataSource(ModulesDto modulesDto) {
+		String connectionId = StringUtils.isNotBlank(modulesDto.getDataSource())
+				? modulesDto.getDataSource() : modulesDto.getConnectionId();
+		ObjectId connection = MongoUtils.toObjectId(connectionId);
+		if (connection == null) {
+			return;
+		}
+		modulesDto.setConnection(connection);
+		modulesDto.setConnectionId(connectionId);
+		modulesDto.setDataSource(connectionId);
 	}
 
 	/**

--- a/manager/tm/src/test/java/com/tapdata/tm/modules/dto/ModulesDtoTest.java
+++ b/manager/tm/src/test/java/com/tapdata/tm/modules/dto/ModulesDtoTest.java
@@ -1,14 +1,89 @@
 package com.tapdata.tm.modules.dto;
 
 
+import com.tapdata.tm.commons.util.JsonUtil;
 import com.tapdata.tm.module.dto.ModulesDto;
 import com.tapdata.tm.module.dto.PathSetting;
+import org.bson.types.ObjectId;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class ModulesDtoTest {
 
+    /**
+     * TAP-12425：项目导出/导入用 {@link JsonUtil} 序列化 ModulesDto，connection 必须原样往返。
+     * 曾因该字段没有 ObjectId 序列化器，被 Jackson 当普通 bean 写成 {"timestamp":..,"date":..}，
+     * 回读时构造出一个全新的随机 ObjectId，导致导入后的 API 指向一个不存在的连接。
+     */
+    @Nested
+    @DisplayName("connection 字段 JSON 往返（TAP-12425）")
+    class ConnectionJsonRoundTripTest {
+
+        @Test
+        @DisplayName("导出再导入后 connection 保持不变")
+        void testConnectionSurvivesJsonRoundTrip() {
+            ObjectId connectionId = new ObjectId("68a1b2c3d4e5f60718293a4b");
+            ModulesDto dto = new ModulesDto();
+            dto.setId(new ObjectId("6a68995344ec8e331a7f4119"));
+            dto.setName("cpi_case");
+            dto.setConnection(connectionId);
+            dto.setConnectionId(connectionId.toHexString());
+            dto.setDataSource(connectionId.toHexString());
+
+            String json = JsonUtil.toJsonUseJackson(dto);
+            ModulesDto parsed = JsonUtil.parseJsonUseJackson(json, ModulesDto.class);
+
+            Assertions.assertNotNull(parsed);
+            Assertions.assertEquals(connectionId, parsed.getConnection(),
+                    "connection 在 JSON 往返后被改写，导入的 API 将指向不存在的连接：" + json);
+        }
+
+        @Test
+        @DisplayName("connection 序列化为 24 位 hex 字符串，而非 {timestamp,date} 对象")
+        void testConnectionSerializedAsHexString() {
+            ObjectId connectionId = new ObjectId("68a1b2c3d4e5f60718293a4b");
+            ModulesDto dto = new ModulesDto();
+            dto.setConnection(connectionId);
+
+            String json = JsonUtil.toJsonUseJackson(dto);
+
+            Assertions.assertTrue(json.contains("\"connection\":\"68a1b2c3d4e5f60718293a4b\""),
+                    "connection 应序列化为 hex 字符串，实际为：" + json);
+        }
+
+        @Test
+        @DisplayName("老导出包的 {timestamp,date} 形态解析为 null，而不是随机 ObjectId")
+        void testLegacyObjectShapeParsesToNullInsteadOfRandomId() {
+            // 修复前生成的导出包长这样：connection 被当普通 bean 序列化，原始 id 已不可恢复。
+            // 此时必须给出 null（由导入侧按 datasource 重建），而不是编一个能通过校验的假 id。
+            String legacyJson = "{\"id\":\"6a68995344ec8e331a7f4119\",\"name\":\"cpi_case\","
+                    + "\"connectionId\":\"68a1b2c3d4e5f60718293a4b\","
+                    + "\"connection\":{\"timestamp\":1755427523,\"date\":1755427523000},"
+                    + "\"datasource\":\"68a1b2c3d4e5f60718293a4b\"}";
+
+            ModulesDto parsed = JsonUtil.parseJsonUseJackson(legacyJson, ModulesDto.class);
+
+            Assertions.assertNotNull(parsed);
+            Assertions.assertNull(parsed.getConnection());
+            Assertions.assertEquals("68a1b2c3d4e5f60718293a4b", parsed.getDataSource());
+            Assertions.assertEquals("68a1b2c3d4e5f60718293a4b", parsed.getConnectionId());
+        }
+
+        @Test
+        @DisplayName("connection 为 null 时不落字段，回读同样为 null")
+        void testNullConnection() {
+            ModulesDto dto = new ModulesDto();
+            dto.setName("no_connection");
+
+            String json = JsonUtil.toJsonUseJackson(dto);
+            ModulesDto parsed = JsonUtil.parseJsonUseJackson(json, ModulesDto.class);
+
+            Assertions.assertNotNull(parsed);
+            Assertions.assertNull(parsed.getConnection());
+        }
+    }
 
     @Nested
     class WithPathSettingIfNeedTest {

--- a/manager/tm/src/test/java/com/tapdata/tm/modules/service/ModulesServiceTest.java
+++ b/manager/tm/src/test/java/com/tapdata/tm/modules/service/ModulesServiceTest.java
@@ -1272,6 +1272,64 @@ class ModulesServiceTest {
 			assertTrue(result.isEmpty());
 			verify(dataSourceDefinitionService, never()).findAllDto(any(Query.class), eq(userDetail));
 		}
+
+		@Test
+		@DisplayName("connection 已被历史导入写坏时，按 datasource 解析连接（TAP-12425）")
+		void testActiveApisResolvesConnectionByDataSource() {
+			ApiDefinitionVo apiDefinitionVo = new ApiDefinitionVo();
+			ObjectId realConnection = new ObjectId("68a1b2c3d4e5f60718293a4b");
+			List<ModulesDto> apis = new ArrayList<>();
+			ModulesDto modulesDto = new ModulesDto();
+			modulesDto.setId(new ObjectId());
+			// 库里存量脏数据：connection 是导入时被 Jackson 重建出来的随机 ObjectId
+			modulesDto.setConnection(new ObjectId("68a1b2c33861f4f43eb56485"));
+			modulesDto.setDataSource(realConnection.toHexString());
+			apis.add(modulesDto);
+			doReturn(apis).when(modulesService).findAllActiveApi(ModuleStatusEnum.ACTIVE);
+
+			DataSourceConnectionDto dataSourceConnectionDto = new DataSourceConnectionDto();
+			dataSourceConnectionDto.setId(realConnection);
+			dataSourceConnectionDto.setDatabase_type("MongoDB");
+			Map<String, Object> config = new HashMap<>();
+			config.put("uri", "mongodb://root:test123@localhost:27017/test?authSource=admin");
+			dataSourceConnectionDto.setConfig(config);
+			when(dataSourceService.findAll(any(Query.class))).thenReturn(Lists.newArrayList(dataSourceConnectionDto));
+
+			DataSourceDefinitionDto definitionDto = new DataSourceDefinitionDto();
+			definitionDto.setType("MongoDB");
+			LinkedHashMap<String, Object> properties = new LinkedHashMap<>();
+			LinkedHashMap<String, Object> connection = new LinkedHashMap<>();
+			connection.put("properties", new LinkedHashMap<>());
+			properties.put("connection", connection);
+			definitionDto.setProperties(properties);
+			when(dataSourceDefinitionService.findAllDto(any(Query.class), eq(userDetail)))
+					.thenReturn(Lists.newArrayList(definitionDto));
+
+			List<ModulesDto> result = modulesService.activeApis(apiDefinitionVo, userDetail);
+
+			assertEquals(1, result.size());
+			assertNotNull(apiDefinitionVo.getConnections());
+			assertEquals(1, apiDefinitionVo.getConnections().size());
+			assertEquals(realConnection.toHexString(), String.valueOf(apiDefinitionVo.getConnections().get(0).getId()));
+		}
+
+		@Test
+		@DisplayName("connection 与 datasource 均缺失的 API 被跳过而非抛 NPE（TAP-12425）")
+		void testActiveApisSkipsApiWithoutResolvableConnection() {
+			ApiDefinitionVo apiDefinitionVo = new ApiDefinitionVo();
+			List<ModulesDto> apis = new ArrayList<>();
+			ModulesDto broken = new ModulesDto();
+			broken.setId(new ObjectId());
+			broken.setName("broken_api");
+			apis.add(broken);
+			doReturn(apis).when(modulesService).findAllActiveApi(ModuleStatusEnum.ACTIVE);
+
+			List<ModulesDto> result = assertDoesNotThrow(
+					() -> modulesService.activeApis(apiDefinitionVo, userDetail));
+
+			assertTrue(result.isEmpty());
+			verify(dataSourceService, never()).findAll(any(Query.class));
+		}
 	}
 
 	@Nested
@@ -1983,6 +2041,69 @@ class ModulesServiceTest {
 
             // Verify
             verify(modulesService, times(1)).handleImportAsCopyMode(moduleDto, user, conMap);
+        }
+
+        @Test
+        @DisplayName("GROUP_IMPORT：connection 被 JSON 往返改写后，按 datasource 重建（TAP-12425）")
+        void testBatchImportGroupModeRepairsConnectionFromDataSource() {
+            importMode = com.tapdata.tm.commons.task.dto.ImportModeEnum.GROUP_IMPORT;
+            ObjectId realConnection = new ObjectId("68a1b2c3d4e5f60718293a4b");
+            // 导出包里 connection 被 Jackson 写成 {"timestamp":..,"date":..}，回读得到的是另一个 ObjectId
+            moduleDto.setConnection(new ObjectId("68a1b2c33861f4f43eb56485"));
+            moduleDto.setConnectionId(realConnection.toHexString());
+            moduleDto.setDataSource(realConnection.toHexString());
+            doNothing().when(modulesService).handleGroupImportModuleMode(eq(moduleDto), eq(user), any());
+
+            modulesService.batchImport(modulesDtos, user, importMode, conMap, metaMap);
+
+            assertEquals(realConnection, moduleDto.getConnection());
+        }
+
+        @Test
+        @DisplayName("GROUP_IMPORT：connection 反序列化为 null 时，同样按 datasource 重建（TAP-12425）")
+        void testBatchImportGroupModeRepairsNullConnection() {
+            importMode = com.tapdata.tm.commons.task.dto.ImportModeEnum.GROUP_IMPORT;
+            ObjectId realConnection = new ObjectId("68a1b2c3d4e5f60718293a4b");
+            moduleDto.setConnection(null);
+            moduleDto.setConnectionId(null);
+            moduleDto.setDataSource(realConnection.toHexString());
+            doNothing().when(modulesService).handleGroupImportModuleMode(eq(moduleDto), eq(user), any());
+
+            modulesService.batchImport(modulesDtos, user, importMode, conMap, metaMap);
+
+            assertEquals(realConnection, moduleDto.getConnection());
+            assertEquals(realConnection.toHexString(), moduleDto.getConnectionId());
+        }
+
+        @Test
+        @DisplayName("datasource 不可用时回退到 connectionId 重建 connection（TAP-12425）")
+        void testBatchImportRepairsConnectionFromConnectionId() {
+            importMode = com.tapdata.tm.commons.task.dto.ImportModeEnum.GROUP_IMPORT;
+            ObjectId realConnection = new ObjectId("68a1b2c3d4e5f60718293a4b");
+            moduleDto.setConnection(new ObjectId("68a1b2c33861f4f43eb56485"));
+            moduleDto.setConnectionId(realConnection.toHexString());
+            moduleDto.setDataSource(null);
+            doNothing().when(modulesService).handleGroupImportModuleMode(eq(moduleDto), eq(user), any());
+
+            modulesService.batchImport(modulesDtos, user, importMode, conMap, metaMap);
+
+            assertEquals(realConnection, moduleDto.getConnection());
+            assertEquals(realConnection.toHexString(), moduleDto.getDataSource());
+        }
+
+        @Test
+        @DisplayName("datasource / connectionId 都不可用时保留原 connection，交由 conMap 映射（TAP-12425）")
+        void testBatchImportKeepsConnectionWhenNoTrustedSource() {
+            importMode = com.tapdata.tm.commons.task.dto.ImportModeEnum.GROUP_IMPORT;
+            ObjectId original = new ObjectId("68a1b2c33861f4f43eb56485");
+            moduleDto.setConnection(original);
+            moduleDto.setConnectionId(null);
+            moduleDto.setDataSource(null);
+            doNothing().when(modulesService).handleGroupImportModuleMode(eq(moduleDto), eq(user), any());
+
+            modulesService.batchImport(modulesDtos, user, importMode, conMap, metaMap);
+
+            assertEquals(original, moduleDto.getConnection());
         }
     }
 


### PR DESCRIPTION
## 问题

TAP-12425：项目包以 `group_import` 导入新环境后，编辑并发布 API 提示成功，但调试返回 404。API Server 日志：

```
[WARN] app - Can't find connection for api 6a68995344ec8e331a7f4119, ignoring it...
```

中间库里这些 API 的 `connection` 字段是一个库中根本不存在的 ObjectId。测试环境与客户环境均可复现。

## 根因

`ModulesDto.connection` 是裸的 `org.bson.types.ObjectId`，没有声明序列化器；项目导出/导入走的 `JsonUtil` 的 ObjectMapper 也没有注册全局 ObjectId 处理器。于是 ObjectId 被 Jackson 当普通 bean 序列化：

```json
"connection": {"timestamp": 1755427523, "date": 1755427523000}
```

（driver 4.x/5.x 已删掉 `getCounter()`，只剩 `getTimestamp()`/`getDate()`）

回读时这个 JSON object 落到 ObjectId 的构造函数上，**静默造出一个时间戳相同、后 8 字节随机的新 id**。已用生产类实测：

```
orig  connection = 68a1b2c3d4e5f60718293a4b
back  connection = 68a1b2c33861f4f43eb56485   ← 随机重建
back  connectionId = 68a1b2c3d4e5f60718293a4b ← String，完好
back  datasource   = 68a1b2c3d4e5f60718293a4b ← String，完好
```

而 `GROUP_IMPORT` 是 `ModulesService.batchImport` 里**唯一不调 `updateConnectionIds` 兜底**的分支（`handleGroupImportModuleMode` 的注释假设 Connection._id 已保留、无需重映射），脏值因此直接落库。REPLACE / IMPORT_AS_COPY 因为会走 `updateConnectionIds` 从 conMap 重映射，反而把这个错误盖掉了——这就是为什么只有 group_import 暴雷。

链路终点：`activeApis()` 按 `connection` 查 Connections 查不到 → `apiDefinition` 的 `connections` 里没有这条 → API Server 按 `datasource` 匹配不到数据源 → 丢弃该 API → 404。

## 修复

1. **`ModulesDto.connection`** 补 `@JsonSerialize(ObjectIdSerialize)` / `@JsonDeserialize(ObjectIdDeserialize)`，今后导出为 hex 字符串、无损往返。
2. **`ModulesService.batchImport`** 新增 `alignConnectionWithDataSource`，按 `datasource`（回退 `connectionId`）重建 `connection`。这一层是必需的：存量导出包里 `connection` 是 `{timestamp,date}`，加了反序列化器后只会得到 `null`，原 id 已不可恢复，只能由字符串字段重建。
3. **`activeApis` / `findById`** 改为 `datasource` 优先解析连接（API Server 本来就按 `datasource` 匹配，见 apiserver `generators/tapDataCodeGenerator.js:23`），`connection` 兜底；解析不出的 API 跳过并告警，避免 `groupingBy` / `toHexString` 在 null 上抛 NPE 拖垮整个发布。**库里已被写坏的存量数据据此可在重新发布时自愈，无需改库或重新导入。**
4. **`ModuleResourceHandler.loadConnections`** 统一同一套优先级，避免脏行导出错误的连接元数据。

## 测试

新增 9 个回归测试：

- `ModulesDtoTest`：`connection` JSON 往返 / hex 序列化形态 / 老包 `{timestamp,date}` 解析为 null（而非随机 id）
- `ModulesServiceTest`：GROUP_IMPORT 下按 datasource 重建、null 重建、connectionId 回退、无可信来源时保持原值；`activeApis` 按 datasource 解析、无连接 API 跳过不抛 NPE

`mvn -pl tm -am test -Dtest=ModulesDtoTest,ModulesServiceTest,ModuleResourceHandlerTest,GroupInfoServiceTest` → **321 通过 / 0 失败**。
