### PR TITLE
TAP-12433: 项目导入无法恢复已删除的任务

### DIFF
--- a/manager/tm/src/main/java/com/tapdata/tm/group/service/GroupInfoService.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/group/service/GroupInfoService.java
@@ -54,6 +54,7 @@ import com.tapdata.tm.ds.service.impl.DataSourceDefinitionService;
 import com.tapdata.tm.metadatainstance.service.MetadataInstancesService;
 import com.tapdata.tm.task.service.batchup.BatchUpChecker;
 import com.tapdata.tm.task.utils.TaskConfigCompareUtil;
+import com.tapdata.tm.task.utils.TaskDeletionState;
 import com.tapdata.tm.utils.BeanUtil;
 import com.tapdata.tm.metadatadefinition.dto.MetadataDefinitionDto;
 import com.tapdata.tm.metadatadefinition.service.MetadataDefinitionService;
@@ -1582,6 +1583,19 @@ public class GroupInfoService extends BaseService<GroupInfoDto, GroupInfoEntity,
         }
     }
 
+    /**
+     * 这批 id 中在目标环境已处于删除态（is_deleted 已置位，或仍停在 deleting / delete_failed）的任务 id。
+     * 这类记录不参与配置比对：删除时任务被改过名，比对只会产出一条无意义的 name 变更，而不会触发恢复。
+     */
+    private Set<String> findDeletedTaskIds(Collection<ObjectId> taskIds, UserDetail user) {
+        if (CollectionUtils.isEmpty(taskIds)) {
+            return Collections.emptySet();
+        }
+        return taskService.findAll(TaskDeletionState.deletedQuery(taskIds), user).stream()
+                .map(task -> task.getId().toHexString())
+                .collect(Collectors.toSet());
+    }
+
     private ResourceDiff buildTaskDiff(Map<String, List<TaskUpAndLoadDto>> payloads, UserDetail user) {
         ResourceDiff diff = new ResourceDiff();
 
@@ -1622,10 +1636,14 @@ public class GroupInfoService extends BaseService<GroupInfoDto, GroupInfoEntity,
                     : taskService
                         .findAllDto(new Query(Criteria.where("_id").in(regularTaskIds).and("is_deleted").ne(true)), user)
                         .stream().collect(Collectors.toMap(t -> t.getId().toHexString(), t -> t, (a, b) -> a));
+            // 已删除的任务必须算作变更（恢复），否则误删的任务再导入也找不回来。
+            // 只有删除是特例，其余运行状态差异仍按无变化处理。
+            Set<String> deletedTaskIds = findDeletedTaskIds(regularTaskIds, user);
             for (Map.Entry<TaskDto, String> entry : fileTaskEntries) {
                 TaskDto fileTask = entry.getKey();
                 String type = entry.getValue();
-                TaskDto existingTask = existingByKey.get(fileTask.getId().toHexString());
+                String fileTaskId = fileTask.getId().toHexString();
+                TaskDto existingTask = deletedTaskIds.contains(fileTaskId) ? null : existingByKey.get(fileTaskId);
                 if (existingTask == null) {
                     ResourceDiffItem item = new ResourceDiffItem(fileTask.getName(), type);
                     item.setSyncType(fileTask.getType());

--- a/manager/tm/src/main/java/com/tapdata/tm/task/service/TaskServiceImpl.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/task/service/TaskServiceImpl.java
@@ -46,6 +46,7 @@ import com.tapdata.tm.shareCdcTableMapping.service.ShareCdcTableMappingService;
 import com.tapdata.tm.task.bean.*;
 import com.tapdata.tm.task.res.CpuMemoryService;
 import com.tapdata.tm.task.utils.TaskConfigCompareUtil;
+import com.tapdata.tm.task.utils.TaskDeletionState;
 import com.tapdata.tm.task.vo.*;
 import com.tapdata.tm.userLog.constant.Operation;
 import io.github.openlg.graphlib.Graph;
@@ -3742,9 +3743,22 @@ public class TaskServiceImpl extends TaskService{
            try{
                taskDto.setTaskRecordId(new ObjectId().toHexString());
 
-               if(ImportModeEnum.GROUP_IMPORT.equals(importMode) && checkTaskConfig(taskDto, user, importMode, resetTaskList,externalStorageMap)){
+               // 目标环境该任务已被删除时，删除本身就是一种变更：必须导入并把记录从删除态拉回来，
+               // 否则误删的任务再导入也恢复不了。其余运行状态差异（如 stop → running）仍按无变化处理。
+               // 只在项目导入（GROUP_IMPORT）下恢复——REPLACE / IMPORT_AS_COPY 走按 name 查重，
+               // 复活后 DB 里的名字仍是删除时改过的「原名_随机6位」，查不到会另分配 _id 变成副本。
+               boolean restoreDeleted = ImportModeEnum.GROUP_IMPORT.equals(importMode)
+                       && isDeletedTask(taskDto.getId(), user);
+
+               if(ImportModeEnum.GROUP_IMPORT.equals(importMode)
+                       && checkTaskConfig(taskDto, user, importMode, resetTaskList,externalStorageMap, restoreDeleted)){
                    importResult.put(taskDto.getId().toHexString(),0L);
                    continue;
+               }
+
+               if (restoreDeleted) {
+                   // 先清掉删除标记，后面的查重才能命中这条记录，按「已存在 → 覆盖更新」正常走完
+                   reviveDeletedTask(taskDto.getId());
                }
 
                // 根据导入模式处理
@@ -3804,21 +3818,55 @@ public class TaskServiceImpl extends TaskService{
     }
 
     /**
+     * 目标环境该任务是否处于删除态：is_deleted 已置位，或仍停在 deleting / delete_failed。
+     * 两种状态下任务都已从列表消失（列表按 status $nin [deleting, delete_failed] 过滤），
+     * 对导入而言都必须算作「有变更、需要恢复」。
+     */
+    protected boolean isDeletedTask(ObjectId taskId, UserDetail user) {
+        if (taskId == null) {
+            return false;
+        }
+        return CollectionUtils.isNotEmpty(
+                findAll(TaskDeletionState.deletedQuery(Collections.singletonList(taskId)), user));
+    }
+
+    /**
+     * 把一条处于删除态的任务记录拉回可用状态。
+     *
+     * <p>只能走原生 update：{@code is_deleted} 与 {@code deleteName} 不在 TaskDto 上，
+     * {@code buildUpdateSet} 覆盖不到；{@code status} 又被 {@link com.tapdata.tm.task.repository.TaskRepository}
+     * 的 buildUpdateSet / filterStatus 显式拦掉。
+     */
+    protected void reviveDeletedTask(ObjectId taskId) {
+        Update update = new Update()
+                .set(IS_DELETED, false)
+                .set(STATUS, TaskDto.STATUS_EDIT)
+                .unset("deleteName");
+        repository.getMongoOperations().updateFirst(
+                new Query(Criteria.where("_id").is(taskId)), update, TaskEntity.class);
+        log.info("Restore deleted task on import, task id = {}", taskId);
+    }
+
+    /**
      * 校验任务配置是否一致
      * 如果配置一致则返回 true，不需要停止任务
      * 如果配置不一致则需要停止任务，返回 false
      *
-     * @param taskDto       导入的任务
-     * @param user          用户信息
-     * @param importMode    导入模式
-     * @param resetTaskList 需要重置的任务列表
+     * @param taskDto        导入的任务
+     * @param user           用户信息
+     * @param importMode     导入模式
+     * @param resetTaskList  需要重置的任务列表
+     * @param restoreDeleted 目标环境该任务已处于删除态，本次导入是一次恢复
      * @return true 表示配置一致，false 表示配置不一致
      */
-    protected boolean checkTaskConfig(TaskDto taskDto, UserDetail user, ImportModeEnum importMode, List<String> resetTaskList,Map<String,String> externalStorageMap){
+    protected boolean checkTaskConfig(TaskDto taskDto, UserDetail user, ImportModeEnum importMode, List<String> resetTaskList,Map<String,String> externalStorageMap, boolean restoreDeleted){
         boolean enableStatusPreserve = importMode == ImportModeEnum.GROUP_IMPORT && resetTaskList != null;
-        boolean shouldReset = enableStatusPreserve
+        // 恢复被删除的任务时必须重置状态：既不能因为「配置一致」跳过导入，
+        // 也不能把 deleting / delete_failed 抄回导入的任务上（抄回去列表里依然看不到）
+        boolean shouldReset = restoreDeleted
+                || (enableStatusPreserve
                 && taskDto.getId() != null
-                && resetTaskList.contains(taskDto.getId().toHexString());
+                && resetTaskList.contains(taskDto.getId().toHexString()));
 
         // GROUP_IMPORT 按 _id 查，其他模式按 name 查
         Query existingQuery;

--- a/manager/tm/src/main/java/com/tapdata/tm/task/utils/TaskDeletionState.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/task/utils/TaskDeletionState.java
@@ -1,0 +1,47 @@
+package com.tapdata.tm.task.utils;
+
+import com.tapdata.tm.commons.task.dto.TaskDto;
+import org.bson.types.ObjectId;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+
+import java.util.Collection;
+import java.util.Set;
+
+/**
+ * 任务「删除态」判定。
+ *
+ * <p>界面删除任务走 {@code TaskServiceImpl#remove}：先把 name 改成「原名_随机6位」、原名存进 deleteName、
+ * 状态置 deleting，等引擎确认后才由 {@code afterRemove} 置 is_deleted=true。所以一条被删除的记录可能停在
+ * 两种状态之一，且两种都对用户不可见（任务列表按 status $nin [deleting, delete_failed] 过滤）。
+ *
+ * <p>导入比对时这两种都必须视为「有变更、需要恢复」，否则误删的资源再导入也找不回来。注意这是删除的特例：
+ * 其余运行状态差异（如 stop → running）仍然按「无变化」处理，不参与比对。
+ */
+public class TaskDeletionState {
+
+    /** 删除流程进行中的状态：is_deleted 尚未置位，但任务已从列表消失 */
+    private static final Set<String> DELETING_STATUSES =
+            Set.of(TaskDto.STATUS_DELETING, TaskDto.STATUS_DELETE_FAILED);
+
+    private TaskDeletionState() {
+    }
+
+    public static boolean isDeletingStatus(String status) {
+        return status != null && DELETING_STATUSES.contains(status);
+    }
+
+    /**
+     * 构造「这批 id 里哪些处于删除态」的查询：is_deleted 已置位，或仍停在删除流程中。
+     * 只回读 _id，调用方拿 id 集合做判定即可。
+     */
+    public static Query deletedQuery(Collection<ObjectId> ids) {
+        Query query = new Query(new Criteria().andOperator(
+                Criteria.where("_id").in(ids),
+                new Criteria().orOperator(
+                        Criteria.where("is_deleted").is(true),
+                        Criteria.where("status").in(DELETING_STATUSES))));
+        query.fields().include("_id");
+        return query;
+    }
+}

--- a/manager/tm/src/test/java/com/tapdata/tm/group/service/GroupInfoServiceTest.java
+++ b/manager/tm/src/test/java/com/tapdata/tm/group/service/GroupInfoServiceTest.java
@@ -33,6 +33,7 @@ import com.tapdata.tm.commons.schema.DataSourceDefinitionDto;
 import com.tapdata.tm.module.dto.ModulesDto;
 import com.tapdata.tm.modules.service.ModulesService;
 import com.tapdata.tm.task.bean.TaskUpAndLoadDto;
+import com.tapdata.tm.task.entity.TaskEntity;
 import com.tapdata.tm.utils.SpringContextHelper;
 import jakarta.servlet.ServletOutputStream;
 import jakarta.servlet.WriteListener;
@@ -2695,6 +2696,123 @@ public class GroupInfoServiceTest {
             assertTrue(diff.getAdd().stream().anyMatch(i -> "m_task".equals(i.getName()) && "migrate".equals(i.getType())));
             assertTrue(diff.getAdd().stream().anyMatch(i -> "s_task".equals(i.getName()) && "sync".equals(i.getType())));
             assertTrue(diff.getAdd().stream().anyMatch(i -> "v_task".equals(i.getName()) && "validate".equals(i.getType())));
+        }
+    }
+
+    @Nested
+    @DisplayName("buildTaskDiff: 目标环境已删除的任务判定为变更（恢复）")
+    class BuildTaskDiffDeletedRestoreTest {
+
+        private ResourceDiff invoke(Map<String, List<TaskUpAndLoadDto>> payloads) {
+            return ReflectionTestUtils.invokeMethod(groupInfoService, "buildTaskDiff", payloads, user);
+        }
+
+        private TaskUpAndLoadDto migrateTaskPayload(String id, String name) {
+            Map<String, Object> json = new LinkedHashMap<>();
+            json.put("id", id);
+            json.put("name", name);
+            json.put("type", "initial_sync+cdc");
+            json.put("syncType", "migrate");
+            return new TaskUpAndLoadDto(GroupConstants.COLLECTION_TASK, JsonUtil.toJsonUseJackson(json));
+        }
+
+        /** remove() 删除任务时会把 name 改成「原名_随机6位」并把原名存进 deleteName */
+        private TaskDto halfDeletedTask(ObjectId id, String originalName, String status) {
+            TaskDto dto = new TaskDto();
+            dto.setId(id);
+            dto.setName(originalName + "_ab12cd");
+            dto.setDeleteName(originalName);
+            dto.setStatus(status);
+            dto.setType("initial_sync+cdc");
+            dto.setSyncType("migrate");
+            return dto;
+        }
+
+        private TaskEntity idOnlyEntity(ObjectId id) {
+            TaskEntity entity = new TaskEntity();
+            entity.setId(id);
+            return entity;
+        }
+
+        @Test
+        @DisplayName("status=deleting 且已被改名 → 落 add 桶，不是 name 变更")
+        void testDeletingTaskIsRestoreNotNameChange() {
+            ObjectId taskId = new ObjectId();
+            Map<String, List<TaskUpAndLoadDto>> payloads = Map.of(
+                    "MigrateTask.json", List.of(migrateTaskPayload(taskId.toHexString(), "task3")));
+
+            when(taskService.findAllDto(any(Query.class), any(UserDetail.class)))
+                    .thenReturn(List.of(halfDeletedTask(taskId, "task3", TaskDto.STATUS_DELETING)));
+            when(taskService.findAll(any(Query.class), any(UserDetail.class)))
+                    .thenReturn(List.of(idOnlyEntity(taskId)));
+
+            ResourceDiff diff = invoke(payloads);
+
+            assertEquals(1, diff.getAdd().size(), "被删除的任务应作为恢复项进入 add 桶");
+            assertEquals("task3", diff.getAdd().get(0).getName());
+            assertTrue(diff.getUpdate().isEmpty(), "不应把删除时的改名当成普通的 name 变更");
+        }
+
+        @Test
+        @DisplayName("status=delete_failed 且已被改名 → 落 add 桶")
+        void testDeleteFailedTaskIsRestore() {
+            ObjectId taskId = new ObjectId();
+            Map<String, List<TaskUpAndLoadDto>> payloads = Map.of(
+                    "MigrateTask.json", List.of(migrateTaskPayload(taskId.toHexString(), "task3")));
+
+            when(taskService.findAllDto(any(Query.class), any(UserDetail.class)))
+                    .thenReturn(List.of(halfDeletedTask(taskId, "task3", TaskDto.STATUS_DELETE_FAILED)));
+            when(taskService.findAll(any(Query.class), any(UserDetail.class)))
+                    .thenReturn(List.of(idOnlyEntity(taskId)));
+
+            ResourceDiff diff = invoke(payloads);
+
+            assertEquals(1, diff.getAdd().size());
+            assertEquals("task3", diff.getAdd().get(0).getName());
+            assertTrue(diff.getUpdate().isEmpty());
+        }
+
+        @Test
+        @DisplayName("回归：is_deleted=true（查不到活跃记录）仍落 add 桶")
+        void testFullyDeletedTaskIsRestore() {
+            ObjectId taskId = new ObjectId();
+            Map<String, List<TaskUpAndLoadDto>> payloads = Map.of(
+                    "MigrateTask.json", List.of(migrateTaskPayload(taskId.toHexString(), "task3")));
+
+            when(taskService.findAllDto(any(Query.class), any(UserDetail.class)))
+                    .thenReturn(Collections.emptyList());
+            when(taskService.findAll(any(Query.class), any(UserDetail.class)))
+                    .thenReturn(List.of(idOnlyEntity(taskId)));
+
+            ResourceDiff diff = invoke(payloads);
+
+            assertEquals(1, diff.getAdd().size());
+            assertEquals("task3", diff.getAdd().get(0).getName());
+            assertTrue(diff.getUpdate().isEmpty());
+        }
+
+        @Test
+        @DisplayName("回归：仅运行状态 stop→running、配置一致 → 既不 add 也不 update")
+        void testRunningStatusOnlyIsNotAChange() {
+            ObjectId taskId = new ObjectId();
+            Map<String, List<TaskUpAndLoadDto>> payloads = Map.of(
+                    "MigrateTask.json", List.of(migrateTaskPayload(taskId.toHexString(), "task2")));
+
+            TaskDto running = new TaskDto();
+            running.setId(taskId);
+            running.setName("task2");
+            running.setStatus(TaskDto.STATUS_RUNNING);
+            running.setType("initial_sync+cdc");
+            running.setSyncType("migrate");
+
+            when(taskService.findAllDto(any(Query.class), any(UserDetail.class))).thenReturn(List.of(running));
+            when(taskService.findAll(any(Query.class), any(UserDetail.class)))
+                    .thenReturn(Collections.emptyList());
+
+            ResourceDiff diff = invoke(payloads);
+
+            assertTrue(diff.getAdd().isEmpty(), "运行状态差异不算变更");
+            assertTrue(diff.getUpdate().isEmpty(), "运行状态差异不算变更");
         }
     }
 

--- a/manager/tm/src/test/java/com/tapdata/tm/modules/service/ModulesServiceTest.java
+++ b/manager/tm/src/test/java/com/tapdata/tm/modules/service/ModulesServiceTest.java
@@ -3109,4 +3109,44 @@ class ModulesServiceTest {
 			service.analyzeApiServerKey(dataSourceConnectionDto, connection, parent);
 		}
 	}
+
+    @Nested
+    @DisplayName("导入时恢复目标环境已删除的 API")
+    class RestoreDeletedModuleOnImportTest {
+        private ModulesDto moduleDto;
+        private UserDetail user;
+        private ModulesRepository repository;
+
+        @BeforeEach
+        void setUp() {
+            modulesService = spy(new ModulesService(modulesRepository));
+            moduleDto = new ModulesDto();
+            moduleDto.setId(new ObjectId("662877df9179877be8b37075"));
+            moduleDto.setName("test_api");
+            // 目标环境这条记录已被 deleteLogicsById 置为 is_deleted:true
+            moduleDto.setIsDeleted(true);
+
+            user = mock(UserDetail.class);
+            repository = mock(ModulesRepository.class);
+            ReflectionTestUtils.setField(modulesService, "repository", repository);
+        }
+
+        /**
+         * ModulesEntity.isDeleted 是包装类型 Boolean：DTO 上为 null 时 buildUpdateSet 会跳过它，
+         * 目标环境里被删的同 _id 记录就会带着 is_deleted:true 留下来，导入报成功但 API 依然不可见。
+         * batchImport 目前靠入口处的 setIsDeleted(false) 兜住这一点——这条测试守住它，别被顺手删掉。
+         */
+        @Test
+        @DisplayName("batchImport 入口必须清除删除标记，被删的 API 才能恢复")
+        void testBatchImportClearsDeletedFlag() {
+            doNothing().when(modulesService).alignConnectionWithDataSource(any(ModulesDto.class));
+            doNothing().when(modulesService).handleGroupImportModuleMode(eq(moduleDto), eq(user), any());
+
+            modulesService.batchImport(Collections.singletonList(moduleDto), user,
+                    com.tapdata.tm.commons.task.dto.ImportModeEnum.GROUP_IMPORT, new HashMap<>(), new HashMap<>());
+
+            assertEquals(Boolean.FALSE, moduleDto.getIsDeleted(),
+                    "导入被删除的 API 时必须清除删除标记，否则它依然不可见");
+        }
+    }
 }

--- a/manager/tm/src/test/java/com/tapdata/tm/task/service/TaskServiceImplTest.java
+++ b/manager/tm/src/test/java/com/tapdata/tm/task/service/TaskServiceImplTest.java
@@ -7972,5 +7972,186 @@ class TaskServiceImplTest {
         }
     }
 
+    @Nested
+    @DisplayName("导入时恢复目标环境已删除的任务")
+    class RestoreDeletedTaskOnImportTest {
+
+        private TaskRepository repository;
+        private MongoTemplate mongoTemplate;
+        private ObjectId taskId;
+
+        @BeforeEach
+        void init() {
+            repository = mock(TaskRepository.class);
+            mongoTemplate = mock(MongoTemplate.class);
+            ReflectionTestUtils.setField(taskService, "repository", repository);
+            taskId = new ObjectId();
+        }
+
+        private TaskDto fileTask() {
+            TaskDto dto = new TaskDto();
+            dto.setId(taskId);
+            dto.setName("task3");
+            // 故意不是 edit，这样断言「恢复后状态是 edit」才能证明重置真的发生了
+            dto.setStatus(TaskDto.STATUS_RUNNING);
+            return dto;
+        }
+
+        private TaskDto existingTask(String status) {
+            TaskDto dto = new TaskDto();
+            dto.setId(taskId);
+            dto.setName("task3");
+            dto.setStatus(status);
+            return dto;
+        }
+
+        @Test
+        @DisplayName("checkTaskConfig：目标已删除时即使配置一致也算变更，且状态重置为 edit")
+        void testDeletedTargetIsAlwaysAChange() {
+            TaskDto taskDto = fileTask();
+            when(taskService.findOne(any(Query.class), any(UserDetail.class)))
+                    .thenReturn(existingTask(TaskDto.STATUS_DELETING));
+            doCallRealMethod().when(taskService).checkTaskConfig(any(TaskDto.class), any(UserDetail.class),
+                    any(ImportModeEnum.class), anyList(), anyMap(), anyBoolean());
+
+            boolean skipImport = taskService.checkTaskConfig(taskDto, user, ImportModeEnum.GROUP_IMPORT,
+                    new ArrayList<>(), new HashMap<>(), true);
+
+            assertFalse(skipImport, "目标环境已删除的任务必须算作有变更，不能跳过导入");
+            assertEquals(TaskDto.STATUS_EDIT, taskDto.getStatus(), "恢复时不能把 deleting 状态抄回来");
+        }
+
+        @Test
+        @DisplayName("回归：目标未删除且配置一致时仍然跳过导入")
+        void testUnchangedTaskIsStillSkipped() {
+            TaskDto taskDto = fileTask();
+            when(taskService.findOne(any(Query.class), any(UserDetail.class)))
+                    .thenReturn(existingTask(TaskDto.STATUS_EDIT));
+            doCallRealMethod().when(taskService).checkTaskConfig(any(TaskDto.class), any(UserDetail.class),
+                    any(ImportModeEnum.class), anyList(), anyMap(), anyBoolean());
+
+            boolean skipImport = taskService.checkTaskConfig(taskDto, user, ImportModeEnum.GROUP_IMPORT,
+                    new ArrayList<>(), new HashMap<>(), false);
+
+            assertTrue(skipImport, "配置一致的任务仍应跳过导入");
+        }
+
+        @Test
+        @DisplayName("回归：仅运行状态不同（导出时 running、目标是 stop）仍视为无变化")
+        void testRunningStatusDifferenceIsNotAChange() {
+            TaskDto taskDto = fileTask();
+            when(taskService.findOne(any(Query.class), any(UserDetail.class)))
+                    .thenReturn(existingTask(TaskDto.STATUS_STOP));
+            doCallRealMethod().when(taskService).checkTaskConfig(any(TaskDto.class), any(UserDetail.class),
+                    any(ImportModeEnum.class), anyList(), anyMap(), anyBoolean());
+
+            boolean skipImport = taskService.checkTaskConfig(taskDto, user, ImportModeEnum.GROUP_IMPORT,
+                    new ArrayList<>(), new HashMap<>(), false);
+
+            assertTrue(skipImport, "运行状态差异不算配置变更");
+        }
+
+        @Test
+        @DisplayName("reviveDeletedTask：清除 is_deleted 与 deleteName，并把状态拉回 edit")
+        void testReviveClearsDeletionMarkers() {
+            when(repository.getMongoOperations()).thenReturn(mongoTemplate);
+            doCallRealMethod().when(taskService).reviveDeletedTask(any(ObjectId.class));
+
+            taskService.reviveDeletedTask(taskId);
+
+            org.mockito.ArgumentCaptor<Update> updateCaptor = org.mockito.ArgumentCaptor.forClass(Update.class);
+            verify(mongoTemplate).updateFirst(any(Query.class), updateCaptor.capture(), eq(TaskEntity.class));
+            Document updateObject = updateCaptor.getValue().getUpdateObject();
+            Document set = (Document) updateObject.get("$set");
+            Document unset = (Document) updateObject.get("$unset");
+            assertEquals(false, set.get("is_deleted"), "必须显式清除删除标记");
+            assertEquals(TaskDto.STATUS_EDIT, set.get("status"), "必须把状态从 deleting 拉回 edit");
+            assertNotNull(unset, "必须清掉删除时写入的 deleteName");
+            assertTrue(unset.containsKey("deleteName"), "必须清掉删除时写入的 deleteName");
+        }
+
+        @Test
+        @DisplayName("isDeletedTask：is_deleted 已置位或停在 deleting/delete_failed 的记录都算删除态")
+        void testIsDeletedTaskQueriesBothDeletionStates() {
+            doCallRealMethod().when(taskService).isDeletedTask(any(ObjectId.class), any(UserDetail.class));
+            when(taskService.findAll(any(Query.class), any(UserDetail.class)))
+                    .thenReturn(Collections.singletonList(new TaskEntity()));
+
+            assertTrue(taskService.isDeletedTask(taskId, user));
+
+            org.mockito.ArgumentCaptor<Query> queryCaptor = org.mockito.ArgumentCaptor.forClass(Query.class);
+            verify(taskService).findAll(queryCaptor.capture(), any(UserDetail.class));
+            String queryJson = queryCaptor.getValue().getQueryObject().toJson();
+            assertTrue(queryJson.contains("is_deleted"), "查询要覆盖 is_deleted 已置位的记录");
+            assertTrue(queryJson.contains(TaskDto.STATUS_DELETING), "查询要覆盖仍停在 deleting 的记录");
+            assertTrue(queryJson.contains(TaskDto.STATUS_DELETE_FAILED), "查询要覆盖 delete_failed 的记录");
+        }
+
+        @Test
+        @DisplayName("isDeletedTask：查不到删除态记录时返回 false")
+        void testIsDeletedTaskReturnsFalseForLivingTask() {
+            doCallRealMethod().when(taskService).isDeletedTask(any(ObjectId.class), any(UserDetail.class));
+            when(taskService.findAll(any(Query.class), any(UserDetail.class))).thenReturn(Collections.emptyList());
+
+            assertFalse(taskService.isDeletedTask(taskId, user));
+        }
+
+        @Test
+        @DisplayName("batchImport：目标已删除时先复活再走覆盖导入")
+        void testBatchImportRevivesDeletedTaskBeforeImport() {
+            TaskDto taskDto = fileTask();
+            doReturn(true).when(taskService).isDeletedTask(any(ObjectId.class), any(UserDetail.class));
+            doReturn(false).when(taskService).checkTaskConfig(any(TaskDto.class), any(UserDetail.class),
+                    any(ImportModeEnum.class), anyList(), anyMap(), anyBoolean());
+            doNothing().when(taskService).reviveDeletedTask(any(ObjectId.class));
+            doNothing().when(taskService).handleGroupImportTaskMode(any(), any(), any(), any(), any(), any(), any());
+            doCallRealMethod().when(taskService).batchImport(anyList(), any(UserDetail.class),
+                    any(ImportModeEnum.class), anyList(), anyMap(), anyMap(), anyMap(), anyList());
+
+            taskService.batchImport(new ArrayList<>(Collections.singletonList(taskDto)), user,
+                    ImportModeEnum.GROUP_IMPORT, new ArrayList<>(), new HashMap<>(),
+                    new HashMap<>(), new HashMap<>(), new ArrayList<>());
+
+            verify(taskService, times(1)).reviveDeletedTask(taskId);
+            verify(taskService, times(1)).checkTaskConfig(eq(taskDto), any(UserDetail.class),
+                    any(ImportModeEnum.class), anyList(), anyMap(), eq(true));
+        }
+
+        @Test
+        @DisplayName("回归：导入副本 / 冲突即取消模式不做恢复，语义保持不变")
+        void testCopyAndCancelModesDoNotRestore() {
+            TaskDto taskDto = fileTask();
+            doReturn(false).when(taskService).checkTaskConfig(any(TaskDto.class), any(UserDetail.class),
+                    any(ImportModeEnum.class), anyList(), anyMap(), anyBoolean());
+            doNothing().when(taskService).handleImportAsCopyMode(any(), any(), any(), any(), any(), any());
+            doCallRealMethod().when(taskService).batchImport(anyList(), any(UserDetail.class),
+                    any(ImportModeEnum.class), anyList(), anyMap(), anyMap(), anyMap(), anyList());
+
+            taskService.batchImport(new ArrayList<>(Collections.singletonList(taskDto)), user,
+                    ImportModeEnum.IMPORT_AS_COPY, new ArrayList<>(), new HashMap<>(),
+                    new HashMap<>(), new HashMap<>(), new ArrayList<>());
+
+            verify(taskService, never()).isDeletedTask(any(ObjectId.class), any(UserDetail.class));
+            verify(taskService, never()).reviveDeletedTask(any(ObjectId.class));
+        }
+
+        @Test
+        @DisplayName("回归：目标未删除时不触发复活")
+        void testBatchImportDoesNotReviveLivingTask() {
+            TaskDto taskDto = fileTask();
+            doReturn(false).when(taskService).isDeletedTask(any(ObjectId.class), any(UserDetail.class));
+            doReturn(false).when(taskService).checkTaskConfig(any(TaskDto.class), any(UserDetail.class),
+                    any(ImportModeEnum.class), anyList(), anyMap(), anyBoolean());
+            doNothing().when(taskService).handleGroupImportTaskMode(any(), any(), any(), any(), any(), any(), any());
+            doCallRealMethod().when(taskService).batchImport(anyList(), any(UserDetail.class),
+                    any(ImportModeEnum.class), anyList(), anyMap(), anyMap(), anyMap(), anyList());
+
+            taskService.batchImport(new ArrayList<>(Collections.singletonList(taskDto)), user,
+                    ImportModeEnum.GROUP_IMPORT, new ArrayList<>(), new HashMap<>(),
+                    new HashMap<>(), new HashMap<>(), new ArrayList<>());
+
+            verify(taskService, never()).reviveDeletedTask(any(ObjectId.class));
+        }
+    }
 
 }


### PR DESCRIPTION
## 工单

[TAP-12433](https://tapdata.atlassian.net/browse/TAP-12433) — 删除任务后重新导入项目，任务没有在列表上显示

## 复现

创建 4 个任务 → 建项目并把任务加进去 → 导出项目 → 手动删除 2 个任务 → 重新导入。

期望被删的任务恢复，实际「显示没有更新所以不导入」，恢复不了。

## 根因（三处，缺一不可）

**1. 比对时把「半删除态」当成普通改名**

删除走 `TaskServiceImpl#remove`：先把 `name` 改成「原名_随机6位」、原名存进 `deleteName`、状态置 `deleting`，**等引擎确认后才**由 `afterRemove` 置 `is_deleted=true`。所以一条被删记录可能停在两种状态：

| | `is_deleted` | `status` | `name` |
|---|---|---|---|
| A. 引擎已确认 | `true` | `deleting` | `任务3_ab12cd` |
| B. 引擎未确认 | `false` | `deleting` | 同上 |

`buildTaskDiff` 与 `checkTaskConfig` 都只过滤 `is_deleted != true`：状态 A 查不到、归 add 桶（本来就对）；**状态 B 查得到**，于是进入配置比对，把删除时的改名当成一次普通的 `name` 变更——语义完全错，也不触发任何恢复。

**2. 状态保留把 `deleting` 抄回来**

`checkTaskConfig` 的 `enableStatusPreserve` 分支执行 `setStatus(existingTask.getStatus())`，而 `TaskRepository.buildUpdateSet` 又显式跳过 `status` 字段。结果导入跑完任务仍是 `deleting`——任务列表按 `status $nin [deleting, delete_failed]` 过滤，界面依然看不到，`TaskResetSchedule` 随后还会把它真删掉。

**3. 重建写入没清删除标记**

`deleteName` 不在 `TaskDto` 上，`buildUpdateSet` 覆盖不到，永远残留。

## 方案

**规则：目标环境该任务处于删除态本身就是一种变更，必须导入并显式复活；其余运行状态差异（`stop → running`）仍按无变化处理。**

`TaskConfigCompareUtil.CONFIG_FIELDS` **没动**——没有把 `status` 加进比对字段，有专门的回归测试守着。

- 新增 `TaskDeletionState`：删除态 = `is_deleted` 已置位 **或** `status` 停在 `deleting` / `delete_failed`
- `buildTaskDiff` 探测到删除态直接归 `add` 桶，不做配置比对
- `checkTaskConfig` 加 `restoreDeleted` 参数：不返回「无变化」，且强制重置状态
- 新增 `reviveDeletedTask`：原生 update 清 `is_deleted`、`$unset deleteName`、`status` 拉回 `edit`——这三个字段 `buildUpdateSet` / `filterStatus` 都覆盖不到
- 恢复**只在 `GROUP_IMPORT`（项目导入）下生效**：`REPLACE` / `IMPORT_AS_COPY` 走按 name 查重，复活后 DB 里仍是删除时改过的名字，查不到会另分配 `_id` 变成副本
- `ModulesService.batchImport` 入口已有 `setIsDeleted(false)`，API 侧本来就能恢复，补一条回归测试守住它（做过变异验证：注掉那行测试立刻红）

前端与 cicd-worker **零改动**——恢复项归入现有 `add` 桶，`ResourceDiff` 契约不变。

## 测试

TDD 走完红-绿。新增 17 个用例（8 个驱动修复 + 9 个回归守卫），其中包括：

- 半删除态（`deleting` / `delete_failed` + 已改名）→ 落 `add` 桶而不是 `name` 变更
- `is_deleted=true` → 落 `add` 桶
- **回归**：仅 `stop → running`、配置一致 → 既不 add 也不 update
- **回归**：未删除且配置一致 → 仍跳过导入
- **回归**：`IMPORT_AS_COPY` / `CANCEL_IMPORT` 不触发恢复

```
mvn -o test -pl manager/tm -Dtest='GroupInfoServiceTest,TaskServiceImplTest,ModulesServiceTest' -Dsurefire.failIfNoSpecifiedTests=false
→ 647 tests, 0 failures, 0 errors
```

## 待人工验证

单测覆盖不到真实 Mongo 写入，合并前建议按工单场景手工过一遍：导出 → 删任务 → 导入，确认任务恢复且 `status=edit`、`name` 是原名、`deleteName` 已清除，未删的任务 `last_updated` 不变。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TAP-12433]: https://tapdata.atlassian.net/browse/TAP-12433?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ