### PR TITLE
fix(group): 导出/导入 secret 分流——本地保真、GIT 强制脱敏、导入侧空值不覆盖

### DIFF
--- a/manager/tm/src/main/java/com/tapdata/tm/group/constant/GroupConstants.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/group/constant/GroupConstants.java
@@ -58,6 +58,22 @@ public final class GroupConstants {
      */
     public static final String VAULT_FILE = "vault.json";
 
+    /**
+     * 包清单文件名（根级 sidecar，[ADR-0034] D3）。
+     *
+     * 与 {@link #VAULT_FILE} 同一套机制：按文件名从 payload map 取用、不写进任何被导入的文档。
+     * ⚠ 这是**包格式的一部分**（对外兼容承诺）——改名等于让所有已导出的包变成「无标记的老包」。
+     */
+    public static final String PACKAGE_MANIFEST_FILE = "export-manifest.json";
+
+    /**
+     * 包清单里的「本包是否已脱敏」位（[ADR-0034] D3）。
+     *
+     * 导入侧唯一能区分「这个字段真的没配」和「这个字段被脱敏抹空了」的依据——
+     * 两者在包里长得一模一样，不可由内容推断。
+     */
+    public static final String MANIFEST_KEY_SECRETS_MASKED = "secretsMasked";
+
     // ==================== 敏感字段列表 ====================
 
     /**

--- a/manager/tm/src/main/java/com/tapdata/tm/group/handler/InspectResourceHandler.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/group/handler/InspectResourceHandler.java
@@ -52,7 +52,7 @@ public class InspectResourceHandler implements ResourceHandler {
     }
 
     @Override
-    public List<TaskUpAndLoadDto> buildExportPayload(List<?> resources, UserDetail user) {
+    public List<TaskUpAndLoadDto> buildExportPayload(List<?> resources, UserDetail user, boolean maskSecrets) {
         if (CollectionUtils.isEmpty(resources)) {
             return new ArrayList<>();
         }

--- a/manager/tm/src/main/java/com/tapdata/tm/group/handler/ModuleResourceHandler.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/group/handler/ModuleResourceHandler.java
@@ -202,8 +202,8 @@ public class ModuleResourceHandler implements ResourceHandler {
 
     @Override
     public void handleRelatedResources(Map<String, List<TaskUpAndLoadDto>> payloadsByType, List<?> resources,
-            UserDetail user,Set<ObjectId> tagIds) {
-        ResourceHandler.super.handleRelatedResources(payloadsByType, resources, user,tagIds);
+            UserDetail user,Set<ObjectId> tagIds, boolean maskSecrets) {
+        ResourceHandler.super.handleRelatedResources(payloadsByType, resources, user,tagIds, maskSecrets);
 
         List<ModulesDto> modules = (List<ModulesDto>) resources;
         for (ModulesDto modulesDto : modules) {

--- a/manager/tm/src/main/java/com/tapdata/tm/group/handler/ModuleResourceHandler.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/group/handler/ModuleResourceHandler.java
@@ -67,7 +67,7 @@ public class ModuleResourceHandler implements ResourceHandler {
     }
 
     @Override
-    public List<TaskUpAndLoadDto> buildExportPayload(List<?> resources, UserDetail user) {
+    public List<TaskUpAndLoadDto> buildExportPayload(List<?> resources, UserDetail user, boolean maskSecrets) {
         List<TaskUpAndLoadDto> payload = new ArrayList<>();
         if (CollectionUtils.isEmpty(resources)) {
             return payload;

--- a/manager/tm/src/main/java/com/tapdata/tm/group/handler/ResourceHandler.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/group/handler/ResourceHandler.java
@@ -17,6 +17,7 @@ import com.tapdata.tm.metadatadefinition.dto.MetadataDefinitionDto;
 import com.tapdata.tm.metadatainstance.service.MetadataInstancesService;
 import com.tapdata.tm.task.bean.TaskUpAndLoadDto;
 import com.tapdata.tm.commons.schema.MetadataInstancesDto;
+import com.tapdata.tm.commons.schema.bean.SourceDto;
 import com.tapdata.tm.utils.ExcelUtil;
 import com.tapdata.tm.utils.MongoUtils;
 import org.apache.commons.collections4.CollectionUtils;
@@ -176,8 +177,12 @@ public interface ResourceHandler {
                     .getBean(DataSourceDefinitionService.class);
             DataSourceDefinitionDto definition = dataSourceDefinitionService
                     .findByPdkHash(entity.getPdkHash(), Integer.MAX_VALUE, user);
-            if (maskSecrets && definition != null) {
-                maskSensitiveConfigFields(entity, definition);
+            if (maskSecrets) {
+                if (definition != null) {
+                    maskSensitiveConfigFields(entity, definition);
+                }
+                // config 之外还有一份顶层镜像，不抹等于没抹（[ADR-0034] D2）
+                maskMirroredSecretFields(entity);
             }
 
             // 收集元数据
@@ -195,6 +200,10 @@ public interface ResourceHandler {
                     Query.query(Criteria.where("qualified_name").is(databaseQualifiedName).and("is_deleted").ne(true)),
                     user);
             if (dataSourceMetadataInstance != null) {
+                if (maskSecrets) {
+                    // metadata 的 source 是连接的整份拷贝（DAGService 序列化而来），凭据的第三处存放点
+                    maskMirroredSecretFields(dataSourceMetadataInstance);
+                }
                 payload.add(new TaskUpAndLoadDto(GroupConstants.COLLECTION_METADATA_INSTANCES,
                         JsonUtil.toJsonUseJackson(dataSourceMetadataInstance)));
             }
@@ -448,6 +457,51 @@ public interface ResourceHandler {
      * 根据 DataSourceDefinitionDto 中的 apiServerKey 定义，找到 DataSourceEntity.config
      * 里对应的路径并清空值。只处理 SENSITIVE_API_KEYS 中声明的标准化 apiServerKey。
      */
+    /**
+     * 顶层凭据镜像字段：{@link #SENSITIVE_API_KEYS} 那一批 secret 在 {@code config} **之外**的第二处存放点。
+     *
+     * 连接实体、以及 {@code MetadataInstances.source}（连接的整份拷贝）都各有一份，字段名完全相同。
+     * 这不是「扩敏感字段集合」（[ADR-0034] 明确不改 {@code SENSITIVE_API_KEYS} 的成员），
+     * 而是把**既有的那一组 secret** 应用到之前被漏掉的载体上 —— 只抹 config 的话，
+     * 导出包里照样躺着明文 uri/password。
+     *
+     * {@code plain_password} / {@code database_password_1} 是同一个口令的别名；
+     * {@code database_name} / {@code database_type} 等不是凭据，不动。证书材料（{@code sslPass} 等）
+     * 属 ADR 划出的「扩敏感字段集合是另一件事」，不在此列。
+     */
+    List<String> MIRRORED_SECRET_FIELDS = List.of(
+            "database_host", "database_username", "database_port",
+            "database_uri", "database_password", "plain_password", "database_password_1");
+
+    /** 抹掉连接实体上的顶层凭据镜像（导出侧）。 */
+    static void maskMirroredSecretFields(DataSourceEntity conn) {
+        if (conn == null) {
+            return;
+        }
+        conn.setDatabase_host(null);
+        conn.setDatabase_username(null);
+        conn.setDatabase_port(null);
+        conn.setDatabase_uri(null);
+        conn.setDatabase_password(null);
+        conn.setPlain_password(null);
+        conn.setDatabase_password_1(null);
+    }
+
+    /** 抹掉 metadata 里那份连接拷贝上的顶层凭据镜像（导出侧）。 */
+    static void maskMirroredSecretFields(MetadataInstancesDto metadata) {
+        if (metadata == null || metadata.getSource() == null) {
+            return;
+        }
+        SourceDto source = metadata.getSource();
+        source.setDatabase_host(null);
+        source.setDatabase_username(null);
+        source.setDatabase_port(null);
+        source.setDatabase_uri(null);
+        source.setDatabase_password(null);
+        source.setPlain_password(null);
+        source.setDatabase_password_1(null);
+    }
+
     private static void maskSensitiveConfigFields(DataSourceEntity conn,
             DataSourceDefinitionDto definition) {
         Map<String, Object> config = conn.getConfig();
@@ -753,9 +807,30 @@ public interface ResourceHandler {
      * @return 被保留（即包内缺值、改用目标既有值）的 config path，供调用方汇报——D7 要求绝不静默。
      */
     static List<String> restoreMissingSecretsFromExisting(DataSourceConnectionDto incoming,
-            Map<String, Object> existingConfig, DataSourceDefinitionDto definition) {
+            DataSourceConnectionDto existing, DataSourceDefinitionDto definition) {
         List<String> preserved = new ArrayList<>();
-        if (incoming == null || MapUtils.isEmpty(existingConfig)) {
+        if (incoming == null || existing == null) {
+            return preserved;
+        }
+        // 顶层镜像与 config 同等对待：导出把两处一起抹了，导入就得把两处一起补回来，
+        // 否则 ES-2b 只是把「凭据被抹空」从 config 挪到了顶层
+        restoreMirroredField("database_host", incoming.getDatabase_host(), existing.getDatabase_host(),
+                incoming::setDatabase_host, preserved);
+        restoreMirroredField("database_username", incoming.getDatabase_username(), existing.getDatabase_username(),
+                incoming::setDatabase_username, preserved);
+        restoreMirroredField("database_port", incoming.getDatabase_port(), existing.getDatabase_port(),
+                incoming::setDatabase_port, preserved);
+        restoreMirroredField("database_uri", incoming.getDatabase_uri(), existing.getDatabase_uri(),
+                incoming::setDatabase_uri, preserved);
+        restoreMirroredField("database_password", incoming.getDatabase_password(), existing.getDatabase_password(),
+                incoming::setDatabase_password, preserved);
+        restoreMirroredField("plain_password", incoming.getPlain_password(), existing.getPlain_password(),
+                incoming::setPlain_password, preserved);
+        restoreMirroredField("database_password_1", incoming.getDatabase_password_1(),
+                existing.getDatabase_password_1(), incoming::setDatabase_password_1, preserved);
+
+        Map<String, Object> existingConfig = existing.getConfig();
+        if (MapUtils.isEmpty(existingConfig)) {
             return preserved;
         }
         Map<String, Object> config = incoming.getConfig();
@@ -780,6 +855,16 @@ public interface ResourceHandler {
     /** 空字符串与 null 同等对待：脱敏既可能删键，也可能留下空串。 */
     private static boolean isPresent(Object value) {
         return value != null && !(value instanceof CharSequence && ((CharSequence) value).length() == 0);
+    }
+
+    /** 顶层镜像字段的逐个补回：包里缺、目标有 ⇒ 用目标的，并记下字段名交给导入报告。 */
+    private static <V> void restoreMirroredField(String name, V incomingValue, V existingValue,
+            java.util.function.Consumer<V> setter, List<String> preserved) {
+        if (isPresent(incomingValue) || !isPresent(existingValue)) {
+            return;
+        }
+        setter.accept(existingValue);
+        preserved.add(name);
     }
 
     static Object getNestedValue(Map<String, Object> config, String path) {

--- a/manager/tm/src/main/java/com/tapdata/tm/group/handler/ResourceHandler.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/group/handler/ResourceHandler.java
@@ -92,11 +92,18 @@ public interface ResourceHandler {
     /**
      * 构建资源的导出数据
      *
-     * @param resources 资源列表
-     * @param user      用户信息
+     * @param resources   资源列表
+     * @param user        用户信息
+     * @param maskSecrets 是否移除包内凭据（[ADR-0034] D1/D2）。任务导出会把 DAG 各节点的
+     *                    {@link MetadataInstancesDto} 一并塞进包，其 {@code source} 是连接的
+     *                    整份拷贝、带顶层凭据镜像 —— 这是继连接文档、database 级与 table 级
+     *                    metadata 之后的**第四处载体**，2026-08-06 实机在真实包里抓到
+     *                    （老包同样在漏，故非回归）。
+     *                    <p>刻意不留带默认值的重载：一个能被静默取到的默认，就是下一次把明文
+     *                    凭据推上 GitHub 的入口。
      * @return 导出数据 payload 列表
      */
-    List<TaskUpAndLoadDto> buildExportPayload(List<?> resources, UserDetail user);
+    List<TaskUpAndLoadDto> buildExportPayload(List<?> resources, UserDetail user, boolean maskSecrets);
 
     /**
      * 从导入的 payload 中收集资源和元数据

--- a/manager/tm/src/main/java/com/tapdata/tm/group/handler/ResourceHandler.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/group/handler/ResourceHandler.java
@@ -734,6 +734,46 @@ public interface ResourceHandler {
     /**
      * 从 config map 中按点号分隔的路径读取值（支持嵌套路径，如 "ssl.password"）
      */
+    /**
+     * 导入侧：包内敏感字段缺失/为空时，保留目标环境已有的值（[ADR-0034] D5/D6）。
+     *
+     * 为什么需要它：导出会把敏感字段抹空，而 GROUP_IMPORT 的落库是整文档覆盖
+     * （{@code DataSourceServiceImpl.handleGroupImportConnection} → {@code importSave}），
+     * 于是「脱敏包 + 未提供 vault」会把目标环境已有的 uri/password 覆盖成空，导入还报成功。
+     * 包里那个空缺是脱敏流程的产物、不是用户配置的内容，因此**任何 importMode 下都不该覆盖**。
+     *
+     * @return 被保留（即包内缺值、改用目标既有值）的 config path，供调用方汇报——D7 要求绝不静默。
+     */
+    static List<String> restoreMissingSecretsFromExisting(DataSourceConnectionDto incoming,
+            Map<String, Object> existingConfig, DataSourceDefinitionDto definition) {
+        List<String> preserved = new ArrayList<>();
+        if (incoming == null || MapUtils.isEmpty(existingConfig)) {
+            return preserved;
+        }
+        Map<String, Object> config = incoming.getConfig();
+        if (config == null) {
+            config = new LinkedHashMap<>();
+            incoming.setConfig(config);
+        }
+        for (String path : getMaskedConfigPaths(definition)) {
+            if (isPresent(getNestedValue(config, path))) {
+                continue;
+            }
+            Object existingValue = getNestedValue(existingConfig, path);
+            if (!isPresent(existingValue)) {
+                continue;
+            }
+            setNestedValue(config, path, existingValue);
+            preserved.add(path);
+        }
+        return preserved;
+    }
+
+    /** 空字符串与 null 同等对待：脱敏既可能删键，也可能留下空串。 */
+    private static boolean isPresent(Object value) {
+        return value != null && !(value instanceof CharSequence && ((CharSequence) value).length() == 0);
+    }
+
     static Object getNestedValue(Map<String, Object> config, String path) {
         if (config == null || path == null) return null;
         String[] parts = path.split("\\.");

--- a/manager/tm/src/main/java/com/tapdata/tm/group/handler/ResourceHandler.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/group/handler/ResourceHandler.java
@@ -132,10 +132,14 @@ public interface ResourceHandler {
      */
     String resolveResourceName(String resourceId, Map<String, ?> resourceMap);
 
+    /**
+     * @param maskSecrets 是否抹掉连接凭据。**刻意不提供带默认值的重载**：调用方必须自己声明意图——
+     *                    一个能被静默取到的默认，就是将来把明文凭据推上 GitHub 的入口（[ADR-0034] D2）
+     */
     default void handleRelatedResources(Map<String, List<TaskUpAndLoadDto>> payloadsByType, List<?> resources,
-            UserDetail user,Set<ObjectId> tagIds) {
+            UserDetail user,Set<ObjectId> tagIds, boolean maskSecrets) {
         List<DataSourceEntity> connections = loadConnections(resources);
-        List<TaskUpAndLoadDto> connectionPayload = buildConnectionPayload(connections, user);
+        List<TaskUpAndLoadDto> connectionPayload = buildConnectionPayload(connections, user, maskSecrets);
         if (CollectionUtils.isNotEmpty(connections)) {
             connections.forEach(c -> {
                 if (CollectionUtils.isNotEmpty(c.getListtags())) {
@@ -149,8 +153,12 @@ public interface ResourceHandler {
 
     /**
      * 构建连接的导出payload（只收集连接和元数据，不生成Excel）
+     *
+     * @param maskSecrets 是否抹掉 config 里的敏感字段。FILE 默认保真、GIT 强制脱敏，
+     *                    口径由 {@code GroupInfoService.resolveMaskSecrets} 单点解析（[ADR-0034] D1/D2）
      */
-    default List<TaskUpAndLoadDto> buildConnectionPayload(List<DataSourceEntity> connections, UserDetail user) {
+    default List<TaskUpAndLoadDto> buildConnectionPayload(List<DataSourceEntity> connections, UserDetail user,
+            boolean maskSecrets) {
         List<TaskUpAndLoadDto> payload = new ArrayList<>();
         if (CollectionUtils.isEmpty(connections)) {
             return payload;
@@ -168,7 +176,7 @@ public interface ResourceHandler {
                     .getBean(DataSourceDefinitionService.class);
             DataSourceDefinitionDto definition = dataSourceDefinitionService
                     .findByPdkHash(entity.getPdkHash(), Integer.MAX_VALUE, user);
-            if (definition != null) {
+            if (maskSecrets && definition != null) {
                 maskSensitiveConfigFields(entity, definition);
             }
 

--- a/manager/tm/src/main/java/com/tapdata/tm/group/handler/TaskResourceHandler.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/group/handler/TaskResourceHandler.java
@@ -295,8 +295,8 @@ public class TaskResourceHandler implements ResourceHandler {
 
     @Override
     public void handleRelatedResources(Map<String, List<TaskUpAndLoadDto>> payloadsByType, List<?> resources,
-            UserDetail user,Set<ObjectId> tagIds) {
-        ResourceHandler.super.handleRelatedResources(payloadsByType, resources, user,tagIds);
+            UserDetail user,Set<ObjectId> tagIds, boolean maskSecrets) {
+        ResourceHandler.super.handleRelatedResources(payloadsByType, resources, user,tagIds, maskSecrets);
         List<TaskDto> tasks = (List<TaskDto>) resources;
         Set<String> shareCacheNames = new HashSet<>();
         for (TaskDto taskDto : tasks) {

--- a/manager/tm/src/main/java/com/tapdata/tm/group/handler/TaskResourceHandler.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/group/handler/TaskResourceHandler.java
@@ -115,7 +115,7 @@ public class TaskResourceHandler implements ResourceHandler {
     }
 
     @Override
-    public List<TaskUpAndLoadDto> buildExportPayload(List<?> resources, UserDetail user) {
+    public List<TaskUpAndLoadDto> buildExportPayload(List<?> resources, UserDetail user, boolean maskSecrets) {
         List<TaskUpAndLoadDto> payload = new ArrayList<>();
         if (CollectionUtils.isEmpty(resources)) {
             return payload;
@@ -177,6 +177,11 @@ public class TaskResourceHandler implements ResourceHandler {
                     for (MetadataInstancesDto metadataInstancesDto : metadataInstancesDtos) {
                         metadataInstancesDto.setCustomId(null);
                         metadataInstancesDto.setLastUpdBy(null);
+                        if (maskSecrets) {
+                            // metadata 的 source 是连接的整份拷贝，带顶层凭据镜像 —— 凭据的第四处载体
+                            // （[ADR-0034]；2026-08-06 实机在真实包的 Task/*.json 里抓到）
+                            ResourceHandler.maskMirroredSecretFields(metadataInstancesDto);
+                        }
                         payload.add(new TaskUpAndLoadDto(GroupConstants.COLLECTION_METADATA_INSTANCES,
                                 JsonUtil.toJsonUseJackson(metadataInstancesDto)));
                         metadataCount++;
@@ -316,7 +321,7 @@ public class TaskResourceHandler implements ResourceHandler {
             List<TaskDto> shareCacheTasks = taskService.findAllDto(
                     Query.query(Criteria.where("name").in(shareCacheNames).and("is_deleted").ne(true)),
                     user);
-            List<TaskUpAndLoadDto> payload = buildExportPayload(shareCacheTasks, user);
+            List<TaskUpAndLoadDto> payload = buildExportPayload(shareCacheTasks, user, maskSecrets);
             payloadsByType.computeIfAbsent(ResourceType.SHARE_CACHE.name(), k -> new ArrayList<>()).addAll(payload);
         }
 
@@ -328,7 +333,7 @@ public class TaskResourceHandler implements ResourceHandler {
                     tagIds.addAll(inspectDto.getListtags().stream().map(tag -> MongoUtils.toObjectId(tag.getId())).toList());
                 }
             });
-            List<TaskUpAndLoadDto> payload = inspectResourceHandler.buildExportPayload(inspectDtoList, user);
+            List<TaskUpAndLoadDto> payload = inspectResourceHandler.buildExportPayload(inspectDtoList, user, maskSecrets);
             payloadsByType.computeIfAbsent(ResourceType.INSPECT_TASK.name(), k -> new ArrayList<>()).addAll(payload);
         }
 

--- a/manager/tm/src/main/java/com/tapdata/tm/group/service/GroupInfoService.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/group/service/GroupInfoService.java
@@ -406,6 +406,38 @@ public class GroupInfoService extends BaseService<GroupInfoDto, GroupInfoEntity,
         }
     }
 
+    /** 导出记录里那句「已强制脱敏」——用户明确要保真却被覆盖时写上，绝不静默（[ADR-0034] D2）。 */
+    static final String MASK_FORCED_MESSAGE =
+            "Secrets were removed from the package: this transfer type always masks them and cannot be overridden.";
+
+    /**
+     * 本次导出是否脱敏（[ADR-0034] D1/D2）——**导出脱敏与否的唯一判据**，别处不许再算一遍。
+     *
+     * FILE 默认保真（本地包要能直接搬到另一个环境用），可显式要求移除敏感信息；
+     * GIT 一律脱敏，入参说什么都没用 —— 这是红线不是默认值：能被一个入参绕过，
+     * 就等于明文凭据可以被推上 GitHub，而 git 历史永久留存、可被 fork/缓存。
+     *
+     * 意图取不到时（请求或传输类型为 null）按最保守的来：脱敏。
+     */
+    static boolean resolveMaskSecrets(ExportGroupRequest request) {
+        if (request == null || request.getGroupTransferType() == null) {
+            return true;
+        }
+        return request.getGroupTransferType().isForceMaskSecrets()
+                || Boolean.TRUE.equals(request.getRemoveSensitiveData());
+    }
+
+    /**
+     * 用户**明确要求保真**、却被通路的强制脱敏覆盖了吗？只有这种情况才有「被吞掉的请求」需要回告；
+     * 压根没提要求的（{@code removeSensitiveData == null}）不算。
+     */
+    static boolean isMaskForciblyOverridden(ExportGroupRequest request) {
+        return request != null
+                && request.getGroupTransferType() != null
+                && request.getGroupTransferType().isForceMaskSecrets()
+                && Boolean.FALSE.equals(request.getRemoveSensitiveData());
+    }
+
     public void exportGroupInfos(HttpServletResponse response, ExportGroupRequest exportGroupRequest, UserDetail user) {
 		List<String> groupIds = exportGroupRequest.getGroupIds();
 		Map<String, List<String>> groupResetTask = exportGroupRequest.getGroupResetTask();
@@ -421,6 +453,13 @@ public class GroupInfoService extends BaseService<GroupInfoDto, GroupInfoEntity,
 		if (groupTransferType == GroupTransferType.GIT) {
 			checkExportingGroups(groupIds, user);
 		}
+
+        // 脱敏与否在这里一次定死，往下只传结果（[ADR-0034] D1/D2）
+        boolean maskSecrets = resolveMaskSecrets(exportGroupRequest);
+        if (isMaskForciblyOverridden(exportGroupRequest)) {
+            log.warn("Export via {} always masks secrets; the request asked to keep them and was overridden",
+                    groupTransferType);
+        }
 
         applyResetTaskList(groupInfos, groupResetTask);
 
@@ -442,7 +481,7 @@ public class GroupInfoService extends BaseService<GroupInfoDto, GroupInfoEntity,
         for (Map.Entry<ResourceType, List<?>> entry : resourcesByType.entrySet()) {
             ResourceHandler handler = resourceHandlerRegistry.getHandler(entry.getKey());
             if (handler != null) {
-                handler.handleRelatedResources(payloadsByType, entry.getValue(), user,new HashSet<>());
+                handler.handleRelatedResources(payloadsByType, entry.getValue(), user,new HashSet<>(), maskSecrets);
             }
         }
         for (Map.Entry<ResourceType, List<?>> entry : resourcesByType.entrySet()) {
@@ -484,6 +523,11 @@ public class GroupInfoService extends BaseService<GroupInfoDto, GroupInfoEntity,
         String name = buildGroupExportFileName(groupInfos, yyyymmdd);
         GroupInfoRecordDto recordDto = buildExportRecord(GroupInfoRecordDto.TYPE_EXPORT, user,
                 buildExportRecordDetails(groupInfos, resourcesByType), name, exportGroupRequest, groupInfos.get(0));
+        if (isMaskForciblyOverridden(exportGroupRequest)) {
+            // 用户明确要保真却被强制脱敏 —— 不能静默吞掉这个请求（[ADR-0034] D2）。
+            // 成功路径的 updateRecordStatus 传 message=null，不会覆盖这里写的内容。
+            recordDto.setMessage(MASK_FORCED_MESSAGE);
+        }
         recordDto = groupInfoRecordService.save(recordDto, user);
 
         // 构建导出文件内容

--- a/manager/tm/src/main/java/com/tapdata/tm/group/service/GroupInfoService.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/group/service/GroupInfoService.java
@@ -488,7 +488,7 @@ public class GroupInfoService extends BaseService<GroupInfoDto, GroupInfoEntity,
         for (Map.Entry<ResourceType, List<?>> entry : resourcesByType.entrySet()) {
             ResourceHandler handler = resourceHandlerRegistry.getHandler(entry.getKey());
             if (handler != null) {
-                List<TaskUpAndLoadDto> payload = handler.buildExportPayload(entry.getValue(), user);
+                List<TaskUpAndLoadDto> payload = handler.buildExportPayload(entry.getValue(), user, maskSecrets);
                 payloadsByType.put(entry.getKey().name(), payload);
             }
         }

--- a/manager/tm/src/main/java/com/tapdata/tm/group/service/GroupInfoService.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/group/service/GroupInfoService.java
@@ -87,6 +87,7 @@ import java.util.*;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.springframework.data.mongodb.core.query.Update;
 import com.tapdata.tm.roleMapping.dto.RoleMappingDto;
 import com.tapdata.tm.user.dto.UserDto;
@@ -502,7 +503,7 @@ public class GroupInfoService extends BaseService<GroupInfoDto, GroupInfoEntity,
             }
         }
         if (!exportConnectionIds.isEmpty()) {
-            List<TaskUpAndLoadDto> connMetadataPayload = buildConnectionMetadataPayload(exportConnectionIds, user);
+            List<TaskUpAndLoadDto> connMetadataPayload = buildConnectionMetadataPayload(exportConnectionIds, user, maskSecrets);
             if (!connMetadataPayload.isEmpty()) {
                 payloadsByType.computeIfAbsent(ResourceType.CONNECTION.name(), k -> new ArrayList<>())
                         .addAll(connMetadataPayload);
@@ -2709,14 +2710,16 @@ public class GroupInfoService extends BaseService<GroupInfoDto, GroupInfoEntity,
             if (conn == null || conn.getId() == null) {
                 continue;   // 新连接，目标环境没有可保留的既有值
             }
-            DataSourceConnectionDto existing = dataSourceService.findById(conn.getId(), "config");
-            if (existing == null || MapUtils.isEmpty(existing.getConfig())) {
+            // 投影必须同时带上 config 与顶层镜像字段——导出把两处一起抹了，这里就得能看见两处
+            String[] projection = Stream.concat(Stream.of("config"),
+                    ResourceHandler.MIRRORED_SECRET_FIELDS.stream()).toArray(String[]::new);
+            DataSourceConnectionDto existing = dataSourceService.findById(conn.getId(), projection);
+            if (existing == null) {
                 continue;
             }
             DataSourceDefinitionDto definition =
                     dataSourceDefinitionService.findByPdkHash(conn.getPdkHash(), Integer.MAX_VALUE, user);
-            List<String> paths = ResourceHandler.restoreMissingSecretsFromExisting(
-                    conn, existing.getConfig(), definition);
+            List<String> paths = ResourceHandler.restoreMissingSecretsFromExisting(conn, existing, definition);
             if (paths.isEmpty()) {
                 continue;
             }
@@ -2893,7 +2896,8 @@ public class GroupInfoService extends BaseService<GroupInfoDto, GroupInfoEntity,
      * 查询连接关联的模型元数据（database 级别 + table/collection 等级别），序列化为导出 payload。
      * taskId 为空的条目为连接原始模型，区别于任务节点派生的模型（后者由 TaskResourceHandler 导出）。
      */
-    private List<TaskUpAndLoadDto> buildConnectionMetadataPayload(Collection<String> connectionIds, UserDetail user) {
+    private List<TaskUpAndLoadDto> buildConnectionMetadataPayload(Collection<String> connectionIds, UserDetail user,
+            boolean maskSecrets) {
         List<TaskUpAndLoadDto> payload = new ArrayList<>();
         for (String connectionId : connectionIds) {
             try {
@@ -2910,6 +2914,10 @@ public class GroupInfoService extends BaseService<GroupInfoDto, GroupInfoEntity,
                     meta.setCustomId(null);
                     meta.setLastUpdBy(null);
                     meta.setUserId(null);
+                    if (maskSecrets) {
+                        // 表级 metadata 的 source 同样是连接的整份拷贝，凭据在这里也有一份
+                        ResourceHandler.maskMirroredSecretFields(meta);
+                    }
                     payload.add(new TaskUpAndLoadDto(GroupConstants.COLLECTION_METADATA_INSTANCES,
                             JsonUtil.toJsonUseJackson(meta)));
                 }

--- a/manager/tm/src/main/java/com/tapdata/tm/group/service/GroupInfoService.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/group/service/GroupInfoService.java
@@ -532,7 +532,8 @@ public class GroupInfoService extends BaseService<GroupInfoDto, GroupInfoEntity,
         recordDto = groupInfoRecordService.save(recordDto, user);
 
         // 构建导出文件内容
-        Map<String, byte[]> contents = buildExportContents(groupInfoPayload, payloadsByType, userExportContents);
+        Map<String, byte[]> contents = buildExportContents(groupInfoPayload, payloadsByType, userExportContents,
+                maskSecrets);
 
         log.info("Start exporting groups, groupCount={}, user={}", groupInfos.size(), user.getUsername());
 
@@ -891,7 +892,7 @@ public class GroupInfoService extends BaseService<GroupInfoDto, GroupInfoEntity,
             // （[ADR-0034] D5）。刻意放在 vaultSecrets 判空之外——最危险的正是「没带 vault」。
             // 这条路的 details 本来是空的，保留清单就是它唯一的内容（D7 不许只落日志）。
             List<GroupInfoRecordDetail> details = new ArrayList<>();
-            reportPreservedSecrets(details, preserveExistingSecrets(connections, user), connections);
+            reportPreservedSecrets(details, preserveExistingSecrets(payloads, connections, user), connections);
             refreshImportLastUpdate(connections.values(), connectionMetadata);
             Map<String, DataSourceConnectionDto> conMap = dataSourceService.batchImport(
                     new ArrayList<>(connections.values()), user, importMode);
@@ -2495,7 +2496,7 @@ public class GroupInfoService extends BaseService<GroupInfoDto, GroupInfoEntity,
             }
             // 同上：无条件保护，缺 vault 时才是真正会把目标凭据抹空的那条路（[ADR-0034] D5）；
             // 保留清单挂到 details 里已有的连接行上，随下一次 updateImportProgress 落库（D7）
-            reportPreservedSecrets(details, preserveExistingSecrets(connections, user), connections);
+            reportPreservedSecrets(details, preserveExistingSecrets(payloads, connections, user), connections);
             List<MetadataInstancesDto> connectionMetadata = metadataByType
                     .getOrDefault(ResourceType.CONNECTION, Collections.emptyList());
             refreshImportLastUpdate(connections.values(), connectionMetadata);
@@ -2690,6 +2691,37 @@ public class GroupInfoService extends BaseService<GroupInfoDto, GroupInfoEntity,
     }
 
     /**
+     * 本次导入的包是否已脱敏（[ADR-0034] D3/D4）——**导入侧是否信任包里空值的唯一判据**，别处不许再算一遍。
+     *
+     * 脱敏包里的空值是抹出来的洞，保真包里的空值是用户真实配置；两者在包里长得一模一样，
+     * 不可由内容推断（"真的没配 uri" 与 "uri 被抹空" 的连接文档完全相同），只能靠包自带的标记。
+     *
+     * 缺文件 / 空内容 / 读不懂 / 没有这一位，一律按**脱敏包**处理：历史包事实上都是脱敏的，
+     * 这个默认与真相一致，老包因此自动获得 D5 的保护；反过来把老包当保真包，就会信任包里的
+     * 空值——正好复现 ADR-0034 要修的那个 bug（实撞：uri is blank）。
+     */
+    boolean packageSecretsMasked(Map<String, List<TaskUpAndLoadDto>> payloads) {
+        if (payloads == null) {
+            return true;
+        }
+        List<TaskUpAndLoadDto> manifest = payloads.getOrDefault(
+                GroupConstants.PACKAGE_MANIFEST_FILE, Collections.emptyList());
+        if (CollectionUtils.isEmpty(manifest) || StringUtils.isBlank(manifest.get(0).getJson())) {
+            return true;
+        }
+        try {
+            Map<String, Object> parsed = JsonUtil.parseJsonUseJackson(
+                    manifest.get(0).getJson(), new TypeReference<Map<String, Object>>() {});
+            // 只有**显式** false 才算保真包：读到别的（缺这一位、类型不对）都退回保守的一侧
+            return parsed == null
+                    || !Boolean.FALSE.equals(parsed.get(GroupConstants.MANIFEST_KEY_SECRETS_MASKED));
+        } catch (Exception e) {
+            log.warn("Import: unreadable package manifest, treating the package as masked: {}", e.getMessage());
+            return true;
+        }
+    }
+
+    /**
      * 导入侧保护：包内敏感字段缺值时，改用目标环境已有的值（[ADR-0034] D5/D6）。
      *
      * 必须排在 {@link #injectVaultSecrets} **之后**——vault 提供了值就不算缺，那是用户
@@ -2701,9 +2733,15 @@ public class GroupInfoService extends BaseService<GroupInfoDto, GroupInfoEntity,
      *
      * @return 连接 id → 被保留的 config 路径；交给 {@link #reportPreservedSecrets} 写进导入报告——D7 要求绝不静默
      */
-    Map<String, List<String>> preserveExistingSecrets(Map<String, DataSourceConnectionDto> connections, UserDetail user) {
+    Map<String, List<String>> preserveExistingSecrets(Map<String, List<TaskUpAndLoadDto>> payloads,
+            Map<String, DataSourceConnectionDto> connections, UserDetail user) {
         Map<String, List<String>> preserved = new LinkedHashMap<>();
         if (connections == null || connections.isEmpty()) {
+            return preserved;
+        }
+        if (!packageSecretsMasked(payloads)) {
+            // 保真包：包里的空缺就是用户的真实配置，照写。拿目标旧值回填会让用户永远删不掉一个
+            // 配置项，而且同样是「以为更新了其实没有」——D7 要防的正是这个。
             return preserved;
         }
         for (DataSourceConnectionDto conn : connections.values()) {
@@ -3402,10 +3440,26 @@ public class GroupInfoService extends BaseService<GroupInfoDto, GroupInfoEntity,
         }
     }
 
+    /**
+     * 包清单（[ADR-0034] D3）：根级 sidecar，只记「本包是否已脱敏」这一位。
+     *
+     * 取值必须是**本次导出实际发生**的脱敏结果（{@link #resolveMaskSecrets} 的返回值），
+     * 不是入参要的那个——GIT 会强制覆盖入参，跟着入参写就等于骗导入侧「包里的空值可信」。
+     */
+    private byte[] buildPackageManifest(boolean maskSecrets) {
+        Map<String, Object> manifest = new LinkedHashMap<>();
+        manifest.put(GroupConstants.MANIFEST_KEY_SECRETS_MASKED, maskSecrets);
+        return JsonUtil.toJsonUseJackson(manifest).getBytes(StandardCharsets.UTF_8);
+    }
+
     private Map<String, byte[]> buildExportContents(List<TaskUpAndLoadDto> groupInfoPayload,
             Map<String, List<TaskUpAndLoadDto>> payloadsByType,
-            Map<String, byte[]> userExportContents) {
+            Map<String, byte[]> userExportContents,
+            boolean maskSecrets) {
         Map<String, byte[]> contents = new LinkedHashMap<>();
+
+        // export-manifest.json — 根级 sidecar，标记本包是否已脱敏（[ADR-0034] D3）
+        contents.put(GroupConstants.PACKAGE_MANIFEST_FILE, buildPackageManifest(maskSecrets));
 
         // GroupInfo.json — 根目录，无子目录
         contents.put("GroupInfo.json", toJsonBytes(groupInfoPayload));

--- a/manager/tm/src/main/java/com/tapdata/tm/group/service/GroupInfoService.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/group/service/GroupInfoService.java
@@ -844,13 +844,15 @@ public class GroupInfoService extends BaseService<GroupInfoDto, GroupInfoEntity,
             }
             // 在 vault 注入之后、落库之前：包里仍缺的敏感字段改用目标既有值，绝不写空
             // （[ADR-0034] D5）。刻意放在 vaultSecrets 判空之外——最危险的正是「没带 vault」。
-            preserveExistingSecrets(connections, user);
+            // 这条路的 details 本来是空的，保留清单就是它唯一的内容（D7 不许只落日志）。
+            List<GroupInfoRecordDetail> details = new ArrayList<>();
+            reportPreservedSecrets(details, preserveExistingSecrets(connections, user), connections);
             refreshImportLastUpdate(connections.values(), connectionMetadata);
             Map<String, DataSourceConnectionDto> conMap = dataSourceService.batchImport(
                     new ArrayList<>(connections.values()), user, importMode);
             metadataInstancesService.batchImport(connectionMetadata, user, conMap, new HashMap<>(), new HashMap<>());
             log.info("Async import connections completed, recordId={}, count={}", recordId, connections.size());
-            updateRecordStatus(recordId, GroupInfoRecordDto.STATUS_COMPLETED, null, new ArrayList<>(), user);
+            updateRecordStatus(recordId, GroupInfoRecordDto.STATUS_COMPLETED, null, details, user);
         } catch (Exception e) {
             log.error("Async import connections failed, recordId={}, error={}",
                     recordId, ThrowableUtils.getStackTraceByPn(e));
@@ -2446,8 +2448,9 @@ public class GroupInfoService extends BaseService<GroupInfoDto, GroupInfoEntity,
                 log.info("Vault secrets found, injecting into {} connections", connections.size());
                 injectVaultSecrets(connections, vaultSecrets, user);
             }
-            // 同上：无条件保护，缺 vault 时才是真正会把目标凭据抹空的那条路（[ADR-0034] D5）
-            preserveExistingSecrets(connections, user);
+            // 同上：无条件保护，缺 vault 时才是真正会把目标凭据抹空的那条路（[ADR-0034] D5）；
+            // 保留清单挂到 details 里已有的连接行上，随下一次 updateImportProgress 落库（D7）
+            reportPreservedSecrets(details, preserveExistingSecrets(connections, user), connections);
             List<MetadataInstancesDto> connectionMetadata = metadataByType
                     .getOrDefault(ResourceType.CONNECTION, Collections.emptyList());
             refreshImportLastUpdate(connections.values(), connectionMetadata);
@@ -2651,10 +2654,10 @@ public class GroupInfoService extends BaseService<GroupInfoDto, GroupInfoEntity,
      *
      * 与 importMode 无关：REPLACE 要替换的是用户配置的内容，不是脱敏留下的空洞。
      *
-     * @return 被保留的字段清单（{@code 连接名.字段路径}），交给导入报告汇报——D7 要求绝不静默
+     * @return 连接 id → 被保留的 config 路径；交给 {@link #reportPreservedSecrets} 写进导入报告——D7 要求绝不静默
      */
-    List<String> preserveExistingSecrets(Map<String, DataSourceConnectionDto> connections, UserDetail user) {
-        List<String> preserved = new ArrayList<>();
+    Map<String, List<String>> preserveExistingSecrets(Map<String, DataSourceConnectionDto> connections, UserDetail user) {
+        Map<String, List<String>> preserved = new LinkedHashMap<>();
         if (connections == null || connections.isEmpty()) {
             return preserved;
         }
@@ -2673,11 +2676,85 @@ public class GroupInfoService extends BaseService<GroupInfoDto, GroupInfoEntity,
             if (paths.isEmpty()) {
                 continue;
             }
-            paths.forEach(path -> preserved.add(conn.getName() + "." + path));
+            preserved.put(conn.getId().toHexString(), paths);
             log.warn("Import: package omits secret field(s) for connection '{}', kept the target environment's existing value(s): {}",
                     conn.getName(), paths);
         }
         return preserved;
+    }
+
+    /** 导入报告里那句「这些字段沿用了目标既有值」的正文——单点定义，两条导入路径同一措辞。 */
+    static String preservedSecretsMessage(List<String> paths) {
+        return "Kept the target environment's existing value for secret field(s) missing in the package: "
+                + String.join(", ", paths);
+    }
+
+    /**
+     * 把 {@link #preserveExistingSecrets} 的结果写进导入报告（[ADR-0034] D7「绝不静默」）。
+     *
+     * 只落在 WARN 日志上不算显形——用户翻不到日志，就分不清「凭据已更新」和「沿用了旧的」，
+     * 于是修好了数据破坏、换来一个更隐蔽的「以为更新了其实没有」。
+     *
+     * 报告里已有该连接的行就直接挂消息（整组导入这条路），一行都没有就补一行
+     * （拆分导入 {@code executeImportConnectionsAsync} 整份 details 本来就是空的）。
+     * 不改写 {@code action}：连接确实导入了，只是部分字段沿用旧值，改成 SKIPPED 会是误报。
+     */
+    void reportPreservedSecrets(List<GroupInfoRecordDetail> details,
+            Map<String, List<String>> preservedByConnectionId,
+            Map<String, DataSourceConnectionDto> connections) {
+        if (details == null || MapUtils.isEmpty(preservedByConnectionId)) {
+            return;
+        }
+        Set<String> attached = new HashSet<>();
+        for (GroupInfoRecordDetail detail : details) {
+            if (detail == null || CollectionUtils.isEmpty(detail.getRecordDetails())) {
+                continue;
+            }
+            for (GroupInfoRecordDetail.RecordDetail row : detail.getRecordDetails()) {
+                if (row == null || ResourceType.CONNECTION != row.getResourceType()) {
+                    continue;
+                }
+                List<String> paths = preservedByConnectionId.get(row.getResourceId());
+                if (CollectionUtils.isEmpty(paths)) {
+                    continue;
+                }
+                String message = preservedSecretsMessage(paths);
+                row.setMessage(StringUtils.isBlank(row.getMessage()) ? message : row.getMessage() + " | " + message);
+                attached.add(row.getResourceId());
+            }
+        }
+        List<GroupInfoRecordDetail.RecordDetail> added = new ArrayList<>();
+        for (Map.Entry<String, List<String>> entry : preservedByConnectionId.entrySet()) {
+            if (attached.contains(entry.getKey())) {
+                continue;
+            }
+            GroupInfoRecordDetail.RecordDetail row = new GroupInfoRecordDetail.RecordDetail();
+            row.setResourceType(ResourceType.CONNECTION);
+            row.setResourceId(entry.getKey());
+            row.setResourceName(resolveConnectionName(connections, entry.getKey()));
+            row.setAction(GroupInfoRecordDetail.RecordAction.IMPORTED);
+            row.setMessage(preservedSecretsMessage(entry.getValue()));
+            added.add(row);
+        }
+        if (!added.isEmpty()) {
+            GroupInfoRecordDetail detail = new GroupInfoRecordDetail();
+            detail.setMessage("Some secret fields were kept from the target environment");
+            detail.getRecordDetails().addAll(added);
+            details.add(detail);
+        }
+    }
+
+    /** 按 id 取连接名——报告行给人看的是名字，不是 ObjectId。 */
+    private static String resolveConnectionName(Map<String, DataSourceConnectionDto> connections, String connectionId) {
+        if (connections == null) {
+            return null;
+        }
+        for (DataSourceConnectionDto conn : connections.values()) {
+            if (conn != null && conn.getId() != null && conn.getId().toHexString().equals(connectionId)) {
+                return conn.getName();
+            }
+        }
+        return null;
     }
 
     /**

--- a/manager/tm/src/main/java/com/tapdata/tm/group/service/GroupInfoService.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/group/service/GroupInfoService.java
@@ -842,6 +842,9 @@ public class GroupInfoService extends BaseService<GroupInfoDto, GroupInfoEntity,
                 log.info("Vault secrets found, injecting into {} connections", connections.size());
                 injectVaultSecrets(connections, vaultSecrets, user);
             }
+            // 在 vault 注入之后、落库之前：包里仍缺的敏感字段改用目标既有值，绝不写空
+            // （[ADR-0034] D5）。刻意放在 vaultSecrets 判空之外——最危险的正是「没带 vault」。
+            preserveExistingSecrets(connections, user);
             refreshImportLastUpdate(connections.values(), connectionMetadata);
             Map<String, DataSourceConnectionDto> conMap = dataSourceService.batchImport(
                     new ArrayList<>(connections.values()), user, importMode);
@@ -2443,6 +2446,8 @@ public class GroupInfoService extends BaseService<GroupInfoDto, GroupInfoEntity,
                 log.info("Vault secrets found, injecting into {} connections", connections.size());
                 injectVaultSecrets(connections, vaultSecrets, user);
             }
+            // 同上：无条件保护，缺 vault 时才是真正会把目标凭据抹空的那条路（[ADR-0034] D5）
+            preserveExistingSecrets(connections, user);
             List<MetadataInstancesDto> connectionMetadata = metadataByType
                     .getOrDefault(ResourceType.CONNECTION, Collections.emptyList());
             refreshImportLastUpdate(connections.values(), connectionMetadata);
@@ -2634,6 +2639,45 @@ public class GroupInfoService extends BaseService<GroupInfoDto, GroupInfoEntity,
         }
         Map<String, String> secrets = JsonUtil.parseJsonUseJackson(json, new TypeReference<Map<String, String>>() {});
         return secrets != null ? secrets : Collections.emptyMap();
+    }
+
+    /**
+     * 导入侧保护：包内敏感字段缺值时，改用目标环境已有的值（[ADR-0034] D5/D6）。
+     *
+     * 必须排在 {@link #injectVaultSecrets} **之后**——vault 提供了值就不算缺，那是用户
+     * 明确要写入的新凭据。到这一步仍为空的，只可能是脱敏抹出来的洞：导出会无条件清空
+     * 敏感字段，而 GROUP_IMPORT 落库是整文档覆盖，两者叠加就把目标环境已有的
+     * uri/password 覆盖成空，且导入照常报成功（实撞：uri is blank）。
+     *
+     * 与 importMode 无关：REPLACE 要替换的是用户配置的内容，不是脱敏留下的空洞。
+     *
+     * @return 被保留的字段清单（{@code 连接名.字段路径}），交给导入报告汇报——D7 要求绝不静默
+     */
+    List<String> preserveExistingSecrets(Map<String, DataSourceConnectionDto> connections, UserDetail user) {
+        List<String> preserved = new ArrayList<>();
+        if (connections == null || connections.isEmpty()) {
+            return preserved;
+        }
+        for (DataSourceConnectionDto conn : connections.values()) {
+            if (conn == null || conn.getId() == null) {
+                continue;   // 新连接，目标环境没有可保留的既有值
+            }
+            DataSourceConnectionDto existing = dataSourceService.findById(conn.getId(), "config");
+            if (existing == null || MapUtils.isEmpty(existing.getConfig())) {
+                continue;
+            }
+            DataSourceDefinitionDto definition =
+                    dataSourceDefinitionService.findByPdkHash(conn.getPdkHash(), Integer.MAX_VALUE, user);
+            List<String> paths = ResourceHandler.restoreMissingSecretsFromExisting(
+                    conn, existing.getConfig(), definition);
+            if (paths.isEmpty()) {
+                continue;
+            }
+            paths.forEach(path -> preserved.add(conn.getName() + "." + path));
+            log.warn("Import: package omits secret field(s) for connection '{}', kept the target environment's existing value(s): {}",
+                    conn.getName(), paths);
+        }
+        return preserved;
     }
 
     /**

--- a/manager/tm/src/main/java/com/tapdata/tm/group/service/transfer/FileGroupTransferStrategy.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/group/service/transfer/FileGroupTransferStrategy.java
@@ -139,6 +139,13 @@ public class FileGroupTransferStrategy implements GroupTransferStrategy {
                         list.add(new TaskUpAndLoadDto(GroupConstants.VAULT_FILE,
                                 new String(bytes, StandardCharsets.UTF_8)));
                         payloads.put(GroupConstants.VAULT_FILE, list);
+                    } else if (GroupConstants.PACKAGE_MANIFEST_FILE.equalsIgnoreCase(baseName)) {
+                        // 包清单同 vault：它是包的元信息不是资源，走通用解析会被当成资源列表、
+                        // 失败后静默变成空列表，标记就此消失（[ADR-0034] D3）
+                        List<TaskUpAndLoadDto> list = new ArrayList<>();
+                        list.add(new TaskUpAndLoadDto(GroupConstants.PACKAGE_MANIFEST_FILE,
+                                new String(bytes, StandardCharsets.UTF_8)));
+                        payloads.put(GroupConstants.PACKAGE_MANIFEST_FILE, list);
                     } else {
                         // JSON文件：按文件名映射到对应的资源类型 key，支持新旧格式
                         List<TaskUpAndLoadDto> list = parseTaskUpAndLoadList(bytes);

--- a/manager/tm/src/main/java/com/tapdata/tm/group/service/transfer/GroupTransferType.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/group/service/transfer/GroupTransferType.java
@@ -11,14 +11,23 @@ public enum GroupTransferType {
     /**
      * 文件传输（tar 包）
      */
-    FILE(false),
-	GIT(true)
+    FILE(false, false),
+	GIT(true, true)
 	;
 
 	private final boolean async;
 
-	GroupTransferType(boolean async) {
+	/**
+	 * 该通路是否**强制**脱敏，且不可被入参绕过（[ADR-0034] D2）。
+	 *
+	 * GIT 为 true：包会进 git 历史，而 git 历史永久留存、可被 fork/缓存 —— 明文凭据一旦推上去
+	 * 就收不回来。新增任何「把包送出本平台」的通路时，这一位必须显式想清楚再填。
+	 */
+	private final boolean forceMaskSecrets;
+
+	GroupTransferType(boolean async, boolean forceMaskSecrets) {
 		this.async = async;
+		this.forceMaskSecrets = forceMaskSecrets;
 	}
 
 }

--- a/manager/tm/src/main/java/com/tapdata/tm/group/vo/ExportGroupRequest.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/group/vo/ExportGroupRequest.java
@@ -16,6 +16,14 @@ import java.util.Map;
 public class ExportGroupRequest {
 	private List<String> groupIds;
 	private GroupTransferType groupTransferType = GroupTransferType.FILE;
+	/**
+	 * 是否移除包内的敏感信息（连接凭据）。三态：
+	 * {@code null} = 未指定（FILE 按保真、GIT 按脱敏）、{@code TRUE} = 要求脱敏、{@code FALSE} = 要求保真。
+	 *
+	 * 用 Boolean 而非 boolean，是为了把「显式要求保真」和「压根没提」分开 —— GIT 强制脱敏时
+	 * 只有前者才需要回告「你的请求被覆盖了」（[ADR-0034] D2 不静默）。GIT 下本字段一律不生效。
+	 */
+	private Boolean removeSensitiveData;
 	private Map<String, List<String>> groupResetTask;
 	private String gitTag;
 	private String gitBranchName;

--- a/manager/tm/src/test/java/com/tapdata/tm/group/handler/ModuleResourceHandlerTest.java
+++ b/manager/tm/src/test/java/com/tapdata/tm/group/handler/ModuleResourceHandlerTest.java
@@ -122,14 +122,14 @@ public class ModuleResourceHandlerTest {
         @Test
         @DisplayName("Should return empty list when resources is null")
         void testBuildExportPayloadNullResources() {
-            List<TaskUpAndLoadDto> result = moduleResourceHandler.buildExportPayload(null, user);
+            List<TaskUpAndLoadDto> result = moduleResourceHandler.buildExportPayload(null, user, false);
             assertTrue(result.isEmpty());
         }
 
         @Test
         @DisplayName("Should return empty list when resources is empty")
         void testBuildExportPayloadEmptyResources() {
-            List<TaskUpAndLoadDto> result = moduleResourceHandler.buildExportPayload(new ArrayList<>(), user);
+            List<TaskUpAndLoadDto> result = moduleResourceHandler.buildExportPayload(new ArrayList<>(), user, false);
             assertTrue(result.isEmpty());
         }
 
@@ -143,7 +143,7 @@ public class ModuleResourceHandlerTest {
             module.setLastUpdBy("lastUpdBy");
             module.setStatus("active");
 
-            List<TaskUpAndLoadDto> result = moduleResourceHandler.buildExportPayload(Arrays.asList(module), user);
+            List<TaskUpAndLoadDto> result = moduleResourceHandler.buildExportPayload(Arrays.asList(module), user, false);
 
             assertEquals(1, result.size());
             assertEquals(GroupConstants.COLLECTION_MODULES, result.get(0).getCollectionName());
@@ -161,7 +161,7 @@ public class ModuleResourceHandlerTest {
             module.setId(new ObjectId());
             module.setName("Test Module");
 
-            List<TaskUpAndLoadDto> result = moduleResourceHandler.buildExportPayload(Arrays.asList(module), user);
+            List<TaskUpAndLoadDto> result = moduleResourceHandler.buildExportPayload(Arrays.asList(module), user, false);
 
             assertEquals(GroupConstants.COLLECTION_MODULES, result.get(0).getCollectionName());
         }

--- a/manager/tm/src/test/java/com/tapdata/tm/group/handler/ResourceHandlerExportMaskTest.java
+++ b/manager/tm/src/test/java/com/tapdata/tm/group/handler/ResourceHandlerExportMaskTest.java
@@ -1,0 +1,116 @@
+package com.tapdata.tm.group.handler;
+
+import cn.hutool.extra.spring.SpringUtil;
+import com.tapdata.tm.commons.schema.DataSourceDefinitionDto;
+import com.tapdata.tm.config.security.UserDetail;
+import com.tapdata.tm.ds.entity.DataSourceEntity;
+import com.tapdata.tm.ds.service.impl.DataSourceDefinitionService;
+import com.tapdata.tm.metadatainstance.service.MetadataInstancesService;
+import com.tapdata.tm.task.bean.TaskUpAndLoadDto;
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
+/**
+ * ES-2：导出脱敏开关是否真的透到 payload（[ADR-0034] D1/D2）。
+ *
+ * 光有「策略解析对了」不够——ES-4 刚撞过「方法有测试、接线没有」。这里钉的是最后一段：
+ * 开关为「保真」时包里必须留有真实凭据，为「脱敏」时必须抹掉。
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("buildConnectionPayload 的脱敏开关")
+public class ResourceHandlerExportMaskTest {
+
+    private static final String REAL_URI = "mongodb://real-host:27017/dmp";
+
+    @Mock
+    private UserDetail user;
+
+    private DataSourceDefinitionDto definitionWithUri() {
+        Map<String, Object> uriMeta = new LinkedHashMap<>();
+        uriMeta.put("apiServerKey", "database_uri");
+        Map<String, Object> connProps = new LinkedHashMap<>();
+        connProps.put("uri", uriMeta);
+        Map<String, Object> connection = new LinkedHashMap<>();
+        connection.put("properties", connProps);
+        LinkedHashMap<String, Object> properties = new LinkedHashMap<>();
+        properties.put("connection", connection);
+        DataSourceDefinitionDto def = new DataSourceDefinitionDto();
+        def.setProperties(properties);
+        return def;
+    }
+
+    private DataSourceEntity connectionWithRealUri() {
+        DataSourceEntity entity = new DataSourceEntity();
+        entity.setId(new ObjectId());
+        entity.setName("MDM_CUSTOMER");
+        entity.setPdkHash("pdkhash-mongodb");
+        Map<String, Object> config = new LinkedHashMap<>();
+        config.put("isUri", true);
+        config.put("uri", REAL_URI);
+        entity.setConfig(config);
+        return entity;
+    }
+
+    /** 跑一次导出 payload 构建，返回连接文档的 JSON */
+    private String exportedConnectionJson(DataSourceEntity entity, boolean maskSecrets) {
+        DataSourceDefinitionService definitionService = mock(DataSourceDefinitionService.class);
+        when(definitionService.findByPdkHash(any(), anyInt(), any())).thenReturn(definitionWithUri());
+        MetadataInstancesService metadataInstancesService = mock(MetadataInstancesService.class);
+        ResourceHandler handler = mock(ResourceHandler.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
+
+        try (MockedStatic<SpringUtil> springUtil = mockStatic(SpringUtil.class)) {
+            springUtil.when(() -> SpringUtil.getBean(DataSourceDefinitionService.class)).thenReturn(definitionService);
+            springUtil.when(() -> SpringUtil.getBean(MetadataInstancesService.class)).thenReturn(metadataInstancesService);
+
+            List<TaskUpAndLoadDto> payload = handler.buildConnectionPayload(List.of(entity), user, maskSecrets);
+            assertEquals(1, payload.size(), "一条连接应当产出一份连接文档（本例无元数据）");
+            return payload.get(0).getJson();
+        }
+    }
+
+    @Test
+    @DisplayName("保真：包里留着真实 uri —— 本地导出的包要能直接用")
+    void keepsSecretsWhenMaskDisabled() {
+        String json = exportedConnectionJson(connectionWithRealUri(), false);
+        assertTrue(json.contains(REAL_URI),
+                "本地导出默认保真（ADR-0034 D1），凭据被抹掉的包搬到另一个环境就是不可用的：" + json);
+    }
+
+    @Test
+    @DisplayName("脱敏：包里没有 uri")
+    void masksSecretsWhenMaskEnabled() {
+        String json = exportedConnectionJson(connectionWithRealUri(), true);
+        assertFalse(json.contains(REAL_URI), "要求脱敏时凭据不得出现在包里：" + json);
+    }
+
+    @Test
+    @DisplayName("脱敏不改动调用方传进来的其它 config 项")
+    void masksOnlySensitivePaths() {
+        DataSourceEntity entity = connectionWithRealUri();
+        String json = exportedConnectionJson(entity, true);
+        assertTrue(json.contains("isUri"), "只抹敏感路径，非敏感项照常导出：" + json);
+    }
+}

--- a/manager/tm/src/test/java/com/tapdata/tm/group/handler/ResourceHandlerImportPreserveTest.java
+++ b/manager/tm/src/test/java/com/tapdata/tm/group/handler/ResourceHandlerImportPreserveTest.java
@@ -1,0 +1,63 @@
+package com.tapdata.tm.group.handler;
+
+import com.tapdata.tm.commons.schema.DataSourceConnectionDto;
+import com.tapdata.tm.commons.schema.DataSourceDefinitionDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * 导入侧：包里缺敏感字段时，绝不用空值覆盖目标环境已有的配置（ADR-0034 D5/D6/D7）。
+ *
+ * 反面教材就是这条链路今天的行为：导出无条件脱敏 → 包里 uri 被抹空 → GROUP_IMPORT 走
+ * handleGroupImportConnection → importSave 整文档覆盖 → 目标连接的 uri 变成空，
+ * 导入还报成功。实撞记录：`Create MongoDB client failed, error: uri is blank`。
+ */
+@DisplayName("ResourceHandler import-side secret preservation")
+public class ResourceHandlerImportPreserveTest {
+
+    /** definition.properties.connection.properties.{uri -> apiServerKey=database_uri} */
+    private DataSourceDefinitionDto definitionWithUri() {
+        Map<String, Object> uriMeta = new LinkedHashMap<>();
+        uriMeta.put("apiServerKey", "database_uri");
+        Map<String, Object> connProps = new LinkedHashMap<>();
+        connProps.put("uri", uriMeta);
+        Map<String, Object> connection = new LinkedHashMap<>();
+        connection.put("properties", connProps);
+        LinkedHashMap<String, Object> properties = new LinkedHashMap<>();
+        properties.put("connection", connection);
+
+        DataSourceDefinitionDto definition = new DataSourceDefinitionDto();
+        definition.setProperties(properties);
+        return definition;
+    }
+
+    private DataSourceConnectionDto connection(Map<String, Object> config) {
+        DataSourceConnectionDto conn = new DataSourceConnectionDto();
+        conn.setName("MDM_CUSTOMER");
+        conn.setConfig(config);
+        return conn;
+    }
+
+    @Test
+    @DisplayName("包里 uri 缺失时保留目标既有 uri，并报告该字段")
+    void missingSensitiveField_keepsExistingValueAndReportsIt() {
+        DataSourceConnectionDto incoming = connection(new LinkedHashMap<>(Map.of("isUri", true)));
+        Map<String, Object> existingConfig = new LinkedHashMap<>(Map.of(
+                "isUri", true,
+                "uri", "mongodb://real-host:27017/dmp"));
+
+        List<String> preserved = ResourceHandler.restoreMissingSecretsFromExisting(
+                incoming, existingConfig, definitionWithUri());
+
+        assertEquals("mongodb://real-host:27017/dmp", incoming.getConfig().get("uri"),
+                "目标既有 uri 必须被保留——包里那个空缺是脱敏的产物，不是用户的配置");
+        assertEquals(List.of("uri"), preserved,
+                "被保留的字段必须报出来，否则就是静默（ADR-0034 D7）");
+    }
+}

--- a/manager/tm/src/test/java/com/tapdata/tm/group/handler/ResourceHandlerImportPreserveTest.java
+++ b/manager/tm/src/test/java/com/tapdata/tm/group/handler/ResourceHandlerImportPreserveTest.java
@@ -48,16 +48,55 @@ public class ResourceHandlerImportPreserveTest {
     @DisplayName("包里 uri 缺失时保留目标既有 uri，并报告该字段")
     void missingSensitiveField_keepsExistingValueAndReportsIt() {
         DataSourceConnectionDto incoming = connection(new LinkedHashMap<>(Map.of("isUri", true)));
-        Map<String, Object> existingConfig = new LinkedHashMap<>(Map.of(
+        DataSourceConnectionDto existing = connection(new LinkedHashMap<>(Map.of(
                 "isUri", true,
-                "uri", "mongodb://real-host:27017/dmp"));
+                "uri", "mongodb://real-host:27017/dmp")));
 
         List<String> preserved = ResourceHandler.restoreMissingSecretsFromExisting(
-                incoming, existingConfig, definitionWithUri());
+                incoming, existing, definitionWithUri());
 
         assertEquals("mongodb://real-host:27017/dmp", incoming.getConfig().get("uri"),
                 "目标既有 uri 必须被保留——包里那个空缺是脱敏的产物，不是用户的配置");
         assertEquals(List.of("uri"), preserved,
                 "被保留的字段必须报出来，否则就是静默（ADR-0034 D7）");
+    }
+
+    /**
+     * ES-2b：导出把 config 与顶层镜像**两处**一起抹了，导入就必须两处一起补回来——
+     * 只补 config 的话，等于把「凭据被抹空」从 config 挪到了顶层，坑还在。
+     */
+    @Test
+    @DisplayName("顶层镜像字段（database_uri / password 等）同样保留目标既有值并报出来")
+    void missingMirroredFields_keepExistingValuesAndAreReported() {
+        DataSourceConnectionDto incoming = connection(new LinkedHashMap<>(Map.of("isUri", true)));
+        DataSourceConnectionDto existing = connection(new LinkedHashMap<>(Map.of("isUri", true)));
+        existing.setDatabase_uri("mongodb://real-host:27017/dmp");
+        existing.setDatabase_password("s3cr3t");
+        existing.setDatabase_port(27017);
+
+        List<String> preserved = ResourceHandler.restoreMissingSecretsFromExisting(
+                incoming, existing, definitionWithUri());
+
+        assertEquals("mongodb://real-host:27017/dmp", incoming.getDatabase_uri());
+        assertEquals("s3cr3t", incoming.getDatabase_password());
+        assertEquals(27017, incoming.getDatabase_port());
+        assertTrue(preserved.containsAll(List.of("database_uri", "database_password", "database_port")),
+                "三个被保留的顶层字段都要报出来，实际：" + preserved);
+    }
+
+    @Test
+    @DisplayName("包里带了值就不动它——那是用户要写入的新凭据，不是脱敏留下的洞")
+    void presentValuesAreNotOverwritten() {
+        DataSourceConnectionDto incoming = connection(new LinkedHashMap<>(Map.of("isUri", true)));
+        incoming.setDatabase_uri("mongodb://new-host:27017/dmp");
+        DataSourceConnectionDto existing = connection(new LinkedHashMap<>(Map.of("isUri", true)));
+        existing.setDatabase_uri("mongodb://real-host:27017/dmp");
+
+        List<String> preserved = ResourceHandler.restoreMissingSecretsFromExisting(
+                incoming, existing, definitionWithUri());
+
+        assertEquals("mongodb://new-host:27017/dmp", incoming.getDatabase_uri(),
+                "包里给了值就是用户的意图，保护不能反过来把新凭据顶掉");
+        assertTrue(preserved.isEmpty(), "什么都没保留就不该报，否则报告全是噪声：" + preserved);
     }
 }

--- a/manager/tm/src/test/java/com/tapdata/tm/group/handler/TaskResourceHandlerTest.java
+++ b/manager/tm/src/test/java/com/tapdata/tm/group/handler/TaskResourceHandlerTest.java
@@ -552,7 +552,7 @@ public class TaskResourceHandlerTest {
             when(taskService.findAllDto(any(Query.class), eq(user))).thenReturn(new ArrayList<>());
             when(inspectService.findByTaskIdList(anyList())).thenReturn(new ArrayList<>());
 
-            taskResourceHandler.handleRelatedResources(payloadsByType, Arrays.asList(task), user,new HashSet<>());
+            taskResourceHandler.handleRelatedResources(payloadsByType, Arrays.asList(task), user,new HashSet<>(), true);
 
             verify(taskService).findAllDto(any(Query.class), eq(user));
         }
@@ -577,7 +577,7 @@ public class TaskResourceHandlerTest {
             inspectPayload.setJson(JsonUtil.toJsonUseJackson(inspect));
             when(inspectResourceHandler.buildExportPayload(anyList(), eq(user))).thenReturn(Arrays.asList(inspectPayload));
 
-            taskResourceHandler.handleRelatedResources(payloadsByType, Arrays.asList(task), user, new HashSet<>());
+            taskResourceHandler.handleRelatedResources(payloadsByType, Arrays.asList(task), user, new HashSet<>(), true);
 
             assertTrue(payloadsByType.containsKey(ResourceType.INSPECT_TASK.name()));
         }

--- a/manager/tm/src/test/java/com/tapdata/tm/group/handler/TaskResourceHandlerTest.java
+++ b/manager/tm/src/test/java/com/tapdata/tm/group/handler/TaskResourceHandlerTest.java
@@ -5,6 +5,7 @@ import com.tapdata.tm.commons.dag.Node;
 import com.tapdata.tm.commons.dag.nodes.DataParentNode;
 import com.tapdata.tm.commons.dag.nodes.DatabaseNode;
 import com.tapdata.tm.commons.schema.MetadataInstancesDto;
+import com.tapdata.tm.commons.schema.bean.SourceDto;
 import com.tapdata.tm.commons.task.dto.TaskDto;
 import com.tapdata.tm.commons.util.JsonUtil;
 import com.tapdata.tm.config.security.SimpleGrantedAuthority;
@@ -37,8 +38,10 @@ import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.*;
 
 
@@ -196,14 +199,14 @@ public class TaskResourceHandlerTest {
         @Test
         @DisplayName("Should return empty list when resources is null")
         void testBuildExportPayloadNullResources() {
-            List<TaskUpAndLoadDto> result = taskResourceHandler.buildExportPayload(null, user);
+            List<TaskUpAndLoadDto> result = taskResourceHandler.buildExportPayload(null, user, false);
             assertTrue(result.isEmpty());
         }
 
         @Test
         @DisplayName("Should return empty list when resources is empty")
         void testBuildExportPayloadEmptyResources() {
-            List<TaskUpAndLoadDto> result = taskResourceHandler.buildExportPayload(new ArrayList<>(), user);
+            List<TaskUpAndLoadDto> result = taskResourceHandler.buildExportPayload(new ArrayList<>(), user, false);
             assertTrue(result.isEmpty());
         }
 
@@ -219,7 +222,7 @@ public class TaskResourceHandlerTest {
             task.setUserId("userId");
             task.setAgentId("agentId");
 
-            List<TaskUpAndLoadDto> result = taskResourceHandler.buildExportPayload(Arrays.asList(task), user);
+            List<TaskUpAndLoadDto> result = taskResourceHandler.buildExportPayload(Arrays.asList(task), user, false);
 
             assertEquals(0, result.size());
 //            assertEquals(GroupConstants.COLLECTION_TASK, result.get(0).getCollectionName());
@@ -239,7 +242,7 @@ public class TaskResourceHandlerTest {
             task.setName("Test Task");
             task.setStatus(TaskDto.STATUS_RUNNING);
 
-            taskResourceHandler.buildExportPayload(Arrays.asList(task), user);
+            taskResourceHandler.buildExportPayload(Arrays.asList(task), user, false);
 
             assertEquals(TaskDto.STATUS_EDIT, task.getStatus());
         }
@@ -252,9 +255,62 @@ public class TaskResourceHandlerTest {
             task.setName("Test Task");
             task.setDag(null);
 
-            List<TaskUpAndLoadDto> result = taskResourceHandler.buildExportPayload(Arrays.asList(task), user);
+            List<TaskUpAndLoadDto> result = taskResourceHandler.buildExportPayload(Arrays.asList(task), user, false);
 
             assertEquals(0, result.size());
+        }
+
+        /**
+         * 任务导出会把 DAG 每个节点的 MetadataInstances 一并塞进包，而它的 source 是连接的整份
+         * 拷贝、带顶层凭据镜像 —— 这是继连接文档、database 级与 table 级 metadata 之后的**第四处
+         * 载体**。2026-08-06 实机在真实导出包里抓到（`Task/*.json` 的 `[].json.source.database_uri`），
+         * 老包同样在漏，故非回归。ES-2b 的整包红线测试之所以没抓到，正是因为它的 fixture 里
+         * 只有 Module 一条腿、压根没有任务自带的 metadata。
+         */
+        private String exportedPackageText(String secretUri, boolean maskSecrets) {
+            TaskDto task = new TaskDto();
+            task.setId(new ObjectId());
+            task.setName("Task Carrying Metadata");
+
+            DAG dag = mock(DAG.class);
+            task.setDag(dag);
+            DatabaseNode node = mock(DatabaseNode.class);
+            lenient().when(node.getId()).thenReturn("node-1");
+            when(dag.getNodes()).thenReturn(Arrays.asList(node));
+
+            MetadataInstancesDto metadata = new MetadataInstancesDto();
+            SourceDto source = new SourceDto();
+            source.setDatabase_uri(secretUri);
+            metadata.setSource(source);
+            when(metadataInstancesService.findByNodeId(eq("node-1"), isNull(), eq(user), eq(task)))
+                    .thenReturn(new ArrayList<>(Arrays.asList(metadata)));
+
+            List<TaskUpAndLoadDto> payload =
+                    taskResourceHandler.buildExportPayload(Arrays.asList(task), user, maskSecrets);
+            StringBuilder sb = new StringBuilder();
+            payload.forEach(p -> sb.append(p.getJson()));
+            return sb.toString();
+        }
+
+        @Test
+        @DisplayName("红线：脱敏导出时，任务自带 metadata 里那份连接拷贝的顶层凭据也必须抹掉")
+        void taskBorneMetadataSecretIsMasked() {
+            String secretUri = "mongodb://real-host:27017/from-task-metadata";
+
+            assertFalse(exportedPackageText(secretUri, true).contains(secretUri),
+                    "任务自带的 MetadataInstances.source 是凭据的第四处载体；漏了它，"
+                            + "「GIT 包里永远没有明文凭据」（ADR-0034）就仍是假的 —— "
+                            + "而 git 历史永久留存、可被 fork/缓存");
+        }
+
+        @Test
+        @DisplayName("对照：保真导出时这份凭据必须还在（否则上一条测的是「压根没导出」）")
+        void taskBorneMetadataSecretSurvivesFaithfulExport() {
+            String secretUri = "mongodb://real-host:27017/from-task-metadata";
+
+            assertTrue(exportedPackageText(secretUri, false).contains(secretUri),
+                    "没有这条对照，上一条断言可以靠「metadata 根本没进包」而假绿 —— "
+                            + "ES-2b 那次就是这么被骗过一次的");
         }
     }
 
@@ -575,7 +631,7 @@ public class TaskResourceHandlerTest {
             TaskUpAndLoadDto inspectPayload = new TaskUpAndLoadDto();
             inspectPayload.setCollectionName(GroupConstants.COLLECTION_INSPECT);
             inspectPayload.setJson(JsonUtil.toJsonUseJackson(inspect));
-            when(inspectResourceHandler.buildExportPayload(anyList(), eq(user))).thenReturn(Arrays.asList(inspectPayload));
+            when(inspectResourceHandler.buildExportPayload(anyList(), eq(user), anyBoolean())).thenReturn(Arrays.asList(inspectPayload));
 
             taskResourceHandler.handleRelatedResources(payloadsByType, Arrays.asList(task), user, new HashSet<>(), true);
 

--- a/manager/tm/src/test/java/com/tapdata/tm/group/service/GroupInfoServiceTest.java
+++ b/manager/tm/src/test/java/com/tapdata/tm/group/service/GroupInfoServiceTest.java
@@ -3036,6 +3036,151 @@ public class GroupInfoServiceTest {
     }
 
     /**
+     * ES-2 导出脱敏分流（[ADR-0034] D1/D2）：FILE 默认保真、可显式要求脱敏；
+     * GIT **强制脱敏且不可被入参绕过**——这是红线不是默认值，git 历史是永久的。
+     */
+    @Nested
+    @DisplayName("导出脱敏分流")
+    class ExportMaskPolicyTest {
+
+        private ExportGroupRequest request(GroupTransferType type, Boolean removeSensitiveData) {
+            ExportGroupRequest request = new ExportGroupRequest();
+            request.setGroupTransferType(type);
+            request.setRemoveSensitiveData(removeSensitiveData);
+            return request;
+        }
+
+        @Test
+        @DisplayName("FILE 未指定 ⇒ 保真（本地包要能直接用）")
+        void fileDefaultsToFaithful() {
+            assertFalse(GroupInfoService.resolveMaskSecrets(request(GroupTransferType.FILE, null)));
+        }
+
+        @Test
+        @DisplayName("FILE 显式要求移除敏感信息 ⇒ 脱敏")
+        void fileHonoursExplicitRemoval() {
+            assertTrue(GroupInfoService.resolveMaskSecrets(request(GroupTransferType.FILE, true)));
+        }
+
+        @Test
+        @DisplayName("FILE 显式要求保真 ⇒ 保真")
+        void fileHonoursExplicitFaithful() {
+            assertFalse(GroupInfoService.resolveMaskSecrets(request(GroupTransferType.FILE, false)));
+        }
+
+        @Test
+        @DisplayName("GIT 未指定 ⇒ 脱敏")
+        void gitDefaultsToMasked() {
+            assertTrue(GroupInfoService.resolveMaskSecrets(request(GroupTransferType.GIT, null)));
+        }
+
+        @Test
+        @DisplayName("红线：GIT + 入参显式要求保真 ⇒ 仍然脱敏")
+        void gitCannotBeTalkedOutOfMasking() {
+            assertTrue(GroupInfoService.resolveMaskSecrets(request(GroupTransferType.GIT, false)),
+                    "GIT 强制脱敏是红线不是默认值——能被一个入参绕过，就等于明文凭据可以被推上 GitHub，"
+                            + "而 git 历史永久留存、可被 fork/缓存（ADR-0034 D2）");
+        }
+
+        @Test
+        @DisplayName("传输类型缺失 / 整个请求缺失 ⇒ 按最保守的来（脱敏）")
+        void unknownIntentFallsBackToMasking() {
+            assertTrue(GroupInfoService.resolveMaskSecrets(request(null, false)));
+            assertTrue(GroupInfoService.resolveMaskSecrets(null));
+        }
+
+        @Test
+        @DisplayName("GIT 吞掉了「要保真」这个请求时必须告知，不静默")
+        void gitOverrideIsAnnounced() {
+            assertTrue(GroupInfoService.isMaskForciblyOverridden(request(GroupTransferType.GIT, false)),
+                    "用户明确要保真却被强制脱敏，这件事必须显形（ADR-0034 D2）");
+            assertFalse(GroupInfoService.isMaskForciblyOverridden(request(GroupTransferType.GIT, null)),
+                    "用户压根没提要求，就没有「被吞掉的请求」可告知");
+            assertFalse(GroupInfoService.isMaskForciblyOverridden(request(GroupTransferType.FILE, false)),
+                    "FILE 本来就给保真，没有覆盖发生");
+        }
+    }
+
+    /**
+     * ES-2 接线：exportGroupInfos 必须把**解析后**的开关传下去，并在被强制覆盖时留下记录。
+     * 光验策略函数不够——ES-4 刚撞过「方法有测试、接线没有」。
+     */
+    @Nested
+    @DisplayName("导出脱敏开关接线")
+    class ExportMaskWiringTest {
+
+        private ResourceHandler registerModuleHandler() {
+            ResourceHandler handler = mock(ResourceHandler.class);
+            when(handler.getResourceType()).thenReturn(ResourceType.MODULE);
+            doReturn(List.of(new ModulesDto())).when(handler).loadResources(anyList(), any(UserDetail.class));
+            when(handler.buildExportPayload(anyList(), any(UserDetail.class))).thenReturn(new ArrayList<>());
+            when(handler.loadConnections(anyList())).thenReturn(new ArrayList<>());
+            ResourceHandlerRegistry registry = new ResourceHandlerRegistry();
+            ReflectionTestUtils.setField(registry, "handlers", List.of(handler));
+            registry.init();
+            ReflectionTestUtils.setField(groupInfoService, "resourceHandlerRegistry", registry);
+            return handler;
+        }
+
+        private ExportGroupRequest exportRequest(GroupTransferType type, Boolean removeSensitiveData) {
+            ExportGroupRequest request = new ExportGroupRequest();
+            request.setGroupIds(List.of(new ObjectId().toHexString()));
+            request.setGroupTransferType(type);
+            request.setRemoveSensitiveData(removeSensitiveData);
+            request.setGroupResetTask(new HashMap<>());
+            return request;
+        }
+
+        private GroupInfoRecordDto runExport(ExportGroupRequest request) {
+            GroupInfoDto groupInfo = new GroupInfoDto();
+            groupInfo.setId(new ObjectId());
+            groupInfo.setName("Test Group");
+            ResourceItem item = new ResourceItem();
+            item.setId(new ObjectId().toHexString());
+            item.setType(ResourceType.MODULE);
+            groupInfo.setResourceItemList(new ArrayList<>(List.of(item)));
+            // GIT 导出的记录会读 gitInfo，与本用例无关但不能为 null
+            com.tapdata.tm.group.dto.GroupGitInfoDto gitInfo = new com.tapdata.tm.group.dto.GroupGitInfoDto();
+            gitInfo.setRepoUrl("https://example.invalid/repo.git");
+            groupInfo.setGitInfo(gitInfo);
+            doReturn(List.of(groupInfo)).when(groupInfoService).findAllDto(any(Query.class), any(UserDetail.class));
+
+            GroupInfoRecordDto savedRecord = new GroupInfoRecordDto();
+            savedRecord.setId(new ObjectId());
+            ArgumentCaptor<GroupInfoRecordDto> built = ArgumentCaptor.forClass(GroupInfoRecordDto.class);
+            when(groupInfoRecordService.save(built.capture(), any(UserDetail.class))).thenReturn(savedRecord);
+            doNothing().when(groupInfoService).updateRecordStatus(any(), any(), any(), any(), any());
+            lenient().when(transferStrategyRegistry.getStrategy(any())).thenReturn(groupTransferStrategy);
+
+            // GIT 是异步通路，doExport 会去 Spring 容器里取自己；单测里把它指回这个 spy
+            try (MockedStatic<SpringContextHelper> springContext = Mockito.mockStatic(SpringContextHelper.class)) {
+                springContext.when(() -> SpringContextHelper.getBean(GroupInfoService.class))
+                        .thenReturn(groupInfoService);
+                groupInfoService.exportGroupInfos(mock(HttpServletResponse.class), request, user);
+            }
+            return built.getValue();
+        }
+
+        @Test
+        @DisplayName("FILE 未指定：传给 handler 的是「保真」")
+        void fileExportPassesFaithfulDown() {
+            ResourceHandler handler = registerModuleHandler();
+            runExport(exportRequest(GroupTransferType.FILE, null));
+            verify(handler).handleRelatedResources(any(), anyList(), eq(user), anySet(), eq(false));
+        }
+
+        @Test
+        @DisplayName("红线接线：GIT + 显式要求保真，传给 handler 的仍是「脱敏」，且导出记录里说明已强制脱敏")
+        void gitExportForcesMaskDownAndAnnouncesIt() {
+            ResourceHandler handler = registerModuleHandler();
+            GroupInfoRecordDto record = runExport(exportRequest(GroupTransferType.GIT, false));
+
+            verify(handler).handleRelatedResources(any(), anyList(), eq(user), anySet(), eq(true));
+            assertNotNull(record.getMessage(), "被强制脱敏这件事必须留在导出记录里，不能静默吞掉用户的请求");
+        }
+    }
+
+    /**
      * 导入侧保护（ADR-0034 D5/D6/D7）：脱敏包未带 vault 时，绝不用空值覆盖目标环境
      * 已有的连接凭据。实撞过一次——Create MongoDB client failed, error: uri is blank。
      */

--- a/manager/tm/src/test/java/com/tapdata/tm/group/service/GroupInfoServiceTest.java
+++ b/manager/tm/src/test/java/com/tapdata/tm/group/service/GroupInfoServiceTest.java
@@ -1,5 +1,6 @@
 package com.tapdata.tm.group.service;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.tapdata.tm.base.dto.Filter;
 import com.tapdata.tm.base.dto.Page;
 import com.tapdata.tm.base.exception.BizException;
@@ -3246,6 +3247,42 @@ public class GroupInfoServiceTest {
             return def;
         }
 
+        /** 整包的文件清单——manifest 是根级 sidecar，得按文件名取，不能像凭据那样整包搜字符串 */
+        private Map<String, byte[]> packageFiles(ExportGroupRequest request) {
+            registerModuleHandler();
+            runExport(request);
+            ArgumentCaptor<GroupExportRequest> exported = ArgumentCaptor.forClass(GroupExportRequest.class);
+            verify(groupTransferStrategy).exportGroups(exported.capture());
+            return exported.getValue().getContents();
+        }
+
+        private Map<String, Object> manifestOf(ExportGroupRequest request) {
+            byte[] manifest = packageFiles(request).get(GroupConstants.PACKAGE_MANIFEST_FILE);
+            assertNotNull(manifest, "包里必须带 " + GroupConstants.PACKAGE_MANIFEST_FILE
+                    + "——导入侧只能靠它区分「这个字段真的没配」和「这个字段被脱敏抹空了」（ADR-0034 D3）");
+            return JsonUtil.parseJsonUseJackson(new String(manifest, StandardCharsets.UTF_8),
+                    new TypeReference<Map<String, Object>>() {});
+        }
+
+        @Test
+        @DisplayName("包标记：FILE 保真包标 secretsMasked=false")
+        void faithfulPackageIsMarkedUnmasked() {
+            assertEquals(Boolean.FALSE,
+                    manifestOf(exportRequest(GroupTransferType.FILE, null))
+                            .get(GroupConstants.MANIFEST_KEY_SECRETS_MASKED),
+                    "保真包里的空值是用户真实配置，导入侧要照写；标记错成 true 会让它被当成脱敏留下的洞");
+        }
+
+        @Test
+        @DisplayName("包标记：GIT 被强制脱敏时标 secretsMasked=true——按**实际发生**的写，不是按入参")
+        void forciblyMaskedPackageIsMarkedMasked() {
+            assertEquals(Boolean.TRUE,
+                    manifestOf(exportRequest(GroupTransferType.GIT, false))
+                            .get(GroupConstants.MANIFEST_KEY_SECRETS_MASKED),
+                    "入参说要保真、通路强制脱敏了，标记必须跟着实际结果走："
+                            + "标成 false 等于告诉导入侧「包里的空值可信」，正好把目标环境的凭据抹空");
+        }
+
         @Test
         @DisplayName("对照组：FILE 保真时整包里确实找得到凭据（否则红线用例是空断言）")
         void faithfulPackageActuallyContainsTheSecret() {
@@ -3335,12 +3372,116 @@ public class GroupInfoServiceTest {
             Map<String, DataSourceConnectionDto> connections = new LinkedHashMap<>();
             connections.put("MDM_CUSTOMER", incoming);
 
-            Map<String, List<String>> report = groupInfoService.preserveExistingSecrets(connections, user);
+            Map<String, List<String>> report = groupInfoService.preserveExistingSecrets(
+                    Collections.emptyMap(), connections, user);
 
             assertEquals("mongodb://real-host:27017/dmp", incoming.getConfig().get("uri"),
                     "目标既有 uri 必须留下——包里那个空缺是脱敏产物，不是用户的配置");
             assertEquals(Map.of(connId.toHexString(), List.of("uri")), report,
                     "保留了哪些字段必须按连接报出来，否则用户分不清『凭据已更新』和『沿用了旧的』");
+        }
+    }
+
+    /**
+     * ES-3：包自带脱敏标记（[ADR-0034] D3/D4）——导入侧**是否信任包里的空值**由它决定。
+     *
+     * 脱敏包里的空值是抹出来的洞（保留目标既有值），保真包里的空值是用户真实配置（照写）。
+     * 两者在包里长得一模一样，不可由内容推断，只能靠标记；标记缺失 ⇒ 老包 ⇒ 按脱敏包（D4）。
+     */
+    @Nested
+    @DisplayName("包脱敏标记决定导入侧是否保留既有凭据")
+    class PackageSecretsMarkTest {
+
+        private static final String REAL_URI = "mongodb://real-host:27017/dmp";
+
+        private DataSourceDefinitionDto definitionWithUri() {
+            Map<String, Object> uriMeta = new LinkedHashMap<>();
+            uriMeta.put("apiServerKey", "database_uri");
+            Map<String, Object> connProps = new LinkedHashMap<>();
+            connProps.put("uri", uriMeta);
+            Map<String, Object> connection = new LinkedHashMap<>();
+            connection.put("properties", connProps);
+            LinkedHashMap<String, Object> properties = new LinkedHashMap<>();
+            properties.put("connection", connection);
+            DataSourceDefinitionDto def = new DataSourceDefinitionDto();
+            def.setProperties(properties);
+            return def;
+        }
+
+        private Map<String, List<TaskUpAndLoadDto>> payloadsWithManifest(String manifestJson) {
+            Map<String, List<TaskUpAndLoadDto>> payloads = new HashMap<>();
+            if (manifestJson != null) {
+                payloads.put(GroupConstants.PACKAGE_MANIFEST_FILE,
+                        List.of(new TaskUpAndLoadDto(GroupConstants.PACKAGE_MANIFEST_FILE, manifestJson)));
+            }
+            return payloads;
+        }
+
+        /** 包里 uri 缺失的那条连接；目标环境同 id 的连接凭据齐全 */
+        private DataSourceConnectionDto incomingWithBlankUri(ObjectId connId) {
+            DataSourceConnectionDto incoming = new DataSourceConnectionDto();
+            incoming.setId(connId);
+            incoming.setName("MDM_CUSTOMER");
+            incoming.setPdkHash("pdkhash-mongodb");
+            incoming.setConfig(new LinkedHashMap<>(Map.of("isUri", true)));
+            return incoming;
+        }
+
+        private void stubTargetHasRealUri(ObjectId connId) {
+            DataSourceConnectionDto existing = new DataSourceConnectionDto();
+            existing.setId(connId);
+            existing.setConfig(new LinkedHashMap<>(Map.of("isUri", true, "uri", REAL_URI)));
+            lenient().when(dataSourceService.findById(eq(connId), any(String[].class))).thenReturn(existing);
+            lenient().when(dataSourceDefinitionService.findByPdkHash(eq("pdkhash-mongodb"), anyInt(), any(UserDetail.class)))
+                    .thenReturn(definitionWithUri());
+        }
+
+        /** @return 包里那条连接落库前的 uri（null = 没被回填） */
+        private Object uriAfterPreserve(String manifestJson) {
+            ObjectId connId = new ObjectId();
+            DataSourceConnectionDto incoming = incomingWithBlankUri(connId);
+            stubTargetHasRealUri(connId);
+            Map<String, DataSourceConnectionDto> connections = new LinkedHashMap<>();
+            connections.put("MDM_CUSTOMER", incoming);
+
+            groupInfoService.preserveExistingSecrets(payloadsWithManifest(manifestJson), connections, user);
+            return incoming.getConfig().get("uri");
+        }
+
+        @Test
+        @DisplayName("保真包（secretsMasked=false）：包里的空值是用户真实配置，照写，不拿目标旧值回填")
+        void faithfulPackage_trustsBlankValue() {
+            assertNull(uriAfterPreserve("{\"secretsMasked\":false}"),
+                    "保真包里没有 uri，就是这个连接真的没配 uri；"
+                            + "拿目标旧值回填等于让用户永远删不掉一个配置项，且「以为更新了其实没有」");
+        }
+
+        @Test
+        @DisplayName("脱敏包（secretsMasked=true）：空值是抹出来的洞，保留目标既有值")
+        void maskedPackage_keepsTargetValue() {
+            assertEquals(REAL_URI, uriAfterPreserve("{\"secretsMasked\":true}"),
+                    "脱敏包里的空缺不是用户配置，写下去就把目标环境的连接打死了");
+        }
+
+        @Test
+        @DisplayName("老包（无标记文件）：按脱敏包处理——历史包事实上都是脱敏的（D4）")
+        void oldPackageWithoutManifest_keepsTargetValue() {
+            assertEquals(REAL_URI, uriAfterPreserve(null),
+                    "把老包当保真包，就会信任包里的空值——正是 ADR-0034 要修的那个 bug");
+        }
+
+        @Test
+        @DisplayName("标记文件在、但没有这一位：按脱敏包处理——别把「没写」当成「写了 false」")
+        void manifestWithoutTheBit_keepsTargetValue() {
+            assertEquals(REAL_URI, uriAfterPreserve("{\"someFutureField\":1}"),
+                    "将来包格式若改名/漏写这一位，必须退回保守的一侧，不能静默变成「信任空值」");
+        }
+
+        @Test
+        @DisplayName("标记读不懂时按脱敏包处理——不确定就别信任空值")
+        void unreadableManifest_keepsTargetValue() {
+            assertEquals(REAL_URI, uriAfterPreserve("not-json-at-all"),
+                    "解析不了就退回最保守的一侧：错判成保真包的代价是抹掉目标凭据，反过来只是少更新一个字段");
         }
     }
 
@@ -3440,6 +3581,36 @@ public class GroupInfoServiceTest {
             assertReportsPreservedField(details.getValue(), "MDM_CUSTOMER", "uri");
         }
 
+        /**
+         * ES-3 接线：包标记必须真的传到 preserveExistingSecrets——判据只在那儿算一次，
+         * 但读得到 payloads 的是调用点。把 payloads 忘在调用点上，保真包就会被当老包处理。
+         */
+        @Test
+        @DisplayName("拆分导入 + 保真包：包里的空 uri 照写，不拿目标旧值回填")
+        void connectionsImportPath_faithfulPackageWritesBlankThrough() {
+            ObjectId connId = new ObjectId();
+            ObjectId recordId = new ObjectId();
+            Map<String, List<TaskUpAndLoadDto>> payloads = new HashMap<>();
+            payloads.put("Connection.json", List.of(maskedConnectionPayload(connId, "MDM_CUSTOMER")));
+            payloads.put(GroupConstants.PACKAGE_MANIFEST_FILE, List.of(new TaskUpAndLoadDto(
+                    GroupConstants.PACKAGE_MANIFEST_FILE, "{\"secretsMasked\":false}")));
+
+            // 目标环境确实有真 uri：不 stub 的话，这条用例在「漏传 payloads」时也会绿（findById 返回 null 而已）
+            lenient().when(dataSourceService.findById(eq(connId), any(String[].class)))
+                    .thenReturn(existingWithRealUri(connId));
+            lenient().when(dataSourceDefinitionService.findByPdkHash(eq("pdkhash-mongodb"), anyInt(), any(UserDetail.class)))
+                    .thenReturn(definitionWithUri());
+            when(dataSourceService.batchImport(anyList(), any(), any())).thenReturn(new HashMap<>());
+            doNothing().when(batchUpChecker).checkDataSourceConnection(any(), any(), any());
+            doNothing().when(groupInfoService).updateRecordStatus(any(), any(), any(), any(), any());
+
+            groupInfoService.executeImportConnectionsAsync(payloads, ImportModeEnum.GROUP_IMPORT, user, recordId,
+                    Collections.emptyMap());
+
+            assertNull(captureBatchImported().get(0).getConfig().get("uri"),
+                    "保真包说这个连接就是没配 uri，导入侧不该拿目标旧值把它填回去");
+        }
+
         @Test
         @DisplayName("整组导入（executeImportAsync）：同样保留目标既有 uri，并在导入记录里报出来")
         @SuppressWarnings("unchecked")
@@ -3472,6 +3643,40 @@ public class GroupInfoServiceTest {
             verify(groupInfoService).updateRecordStatus(eq(recordId), eq(GroupInfoRecordDto.STATUS_COMPLETED),
                     isNull(), details.capture(), eq(user));
             assertReportsPreservedField(details.getValue(), "MDM_CUSTOMER", "uri");
+        }
+
+        @Test
+        @DisplayName("整组导入 + 保真包：包里的空 uri 同样照写——两条调用点都得把 payloads 传下去")
+        void groupImportPath_faithfulPackageWritesBlankThrough() {
+            ObjectId connId = new ObjectId();
+            ObjectId recordId = new ObjectId();
+            Map<String, List<TaskUpAndLoadDto>> payloads = new HashMap<>();
+            payloads.put("GroupInfo.json", new ArrayList<>());
+            payloads.put(GroupConstants.PACKAGE_MANIFEST_FILE, List.of(new TaskUpAndLoadDto(
+                    GroupConstants.PACKAGE_MANIFEST_FILE, "{\"secretsMasked\":false}")));
+
+            DataSourceConnectionDto incoming = new DataSourceConnectionDto();
+            incoming.setId(connId);
+            incoming.setName("MDM_CUSTOMER");
+            incoming.setPdkHash("pdkhash-mongodb");
+            incoming.setConfig(new LinkedHashMap<>(Map.of("isUri", true)));
+            registerConnectionHandler(connId, incoming);
+
+            // 同上：目标环境确实有真 uri，漏传 payloads 时才会被这条用例抓住
+            lenient().when(dataSourceService.findById(eq(connId), any(String[].class)))
+                    .thenReturn(existingWithRealUri(connId));
+            lenient().when(dataSourceDefinitionService.findByPdkHash(eq("pdkhash-mongodb"), anyInt(), any(UserDetail.class)))
+                    .thenReturn(definitionWithUri());
+            when(dataSourceService.batchImport(anyList(), any(), any())).thenReturn(new HashMap<>());
+            when(metadataDefinitionService.batchImport(any(), any())).thenReturn(new HashMap<>());
+            doNothing().when(batchUpChecker).checkDataSourceConnection(any(), any(), any());
+            doNothing().when(groupInfoService).updateImportProgress(any(), anyInt(), any(), any());
+            doNothing().when(groupInfoService).updateRecordStatus(any(), any(), any(), any(), any());
+
+            groupInfoService.executeImportAsync(payloads, user, ImportModeEnum.GROUP_IMPORT, "test.tar", recordId);
+
+            assertNull(captureBatchImported().get(0).getConfig().get("uri"),
+                    "整组导入这条路也必须读包标记——只在拆分导入那条路接上，等于一半的入口还在拿旧值回填");
         }
 
         /** 让 executeImportAsync 的资源收集环节吐出这条连接（生产上由 Task/Module handler 的关联收集完成） */

--- a/manager/tm/src/test/java/com/tapdata/tm/group/service/GroupInfoServiceTest.java
+++ b/manager/tm/src/test/java/com/tapdata/tm/group/service/GroupInfoServiceTest.java
@@ -49,6 +49,11 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import com.tapdata.tm.ds.entity.DataSourceEntity;
+import com.tapdata.tm.ds.service.impl.DataSourceDefinitionService;
+import com.tapdata.tm.group.service.transfer.GroupExportRequest;
+import com.tapdata.tm.commons.schema.MetadataInstancesDto;
+import com.tapdata.tm.commons.schema.bean.SourceDto;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -3109,12 +3114,20 @@ public class GroupInfoServiceTest {
     @DisplayName("导出脱敏开关接线")
     class ExportMaskWiringTest {
 
+        private static final String SECRET_URI = "mongodb://real-host:27017/dmp";
+        private static final String SECRET_PASSWORD = "s3cr3t-p4ssw0rd";
+        /** 凭据在包里共三处载体，各给一个可区分的值——否则某一处漏抹了也测不出来 */
+        private static final String SECRET_IN_DB_META = "mongodb://real-host:27017/from-database-metadata";
+        private static final String SECRET_IN_TABLE_META = "mongodb://real-host:27017/from-table-metadata";
+
         private ResourceHandler registerModuleHandler() {
-            ResourceHandler handler = mock(ResourceHandler.class);
-            when(handler.getResourceType()).thenReturn(ResourceType.MODULE);
-            doReturn(List.of(new ModulesDto())).when(handler).loadResources(anyList(), any(UserDetail.class));
-            when(handler.buildExportPayload(anyList(), any(UserDetail.class))).thenReturn(new ArrayList<>());
-            when(handler.loadConnections(anyList())).thenReturn(new ArrayList<>());
+            // defaultAnswer=CALLS_REAL_METHODS：handleRelatedResources / buildConnectionPayload 正是被测的
+            // default 方法，普通 mock 会把它们一并空转掉，连接就永远进不了包（这套用例也就白测了）
+            ResourceHandler handler = mock(ResourceHandler.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
+            lenient().when(handler.getResourceType()).thenReturn(ResourceType.MODULE);
+            lenient().doReturn(List.of(new ModulesDto())).when(handler).loadResources(anyList(), any(UserDetail.class));
+            lenient().when(handler.buildExportPayload(anyList(), any(UserDetail.class))).thenReturn(new ArrayList<>());
+            lenient().when(handler.loadConnections(anyList())).thenReturn(new ArrayList<>());
             ResourceHandlerRegistry registry = new ResourceHandlerRegistry();
             ReflectionTestUtils.setField(registry, "handlers", List.of(handler));
             registry.init();
@@ -3159,6 +3172,101 @@ public class GroupInfoServiceTest {
                 groupInfoService.exportGroupInfos(mock(HttpServletResponse.class), request, user);
             }
             return built.getValue();
+        }
+
+        /**
+         * ES-2b：凭据在包里有**两份**拷贝——Connection 文档，以及 MetadataInstances.source
+         * （SourceDto 带 config 与 database_uri/password，由 DAGService 整份序列化连接而来）。
+         * 所以红线的判据必须是「**整包**搜不到明文凭据」，只看连接文档会漏掉第二条腿。
+         */
+        private String wholePackage(ExportGroupRequest request) {
+            ResourceHandler handler = registerModuleHandler();
+            DataSourceEntity connection = new DataSourceEntity();
+            connection.setId(new ObjectId());
+            connection.setName("MDM_CUSTOMER");
+            connection.setPdkHash("pdkhash-mongodb");
+            connection.setConfig(new LinkedHashMap<>(Map.of("isUri", true, "uri", SECRET_URI)));
+            // 同一批 secret 在实体顶层还有一份镜像（线上确有：08-01 那次事故里 config.uri 被抹空、顶层 database_uri 仍在）
+            connection.setDatabase_uri(SECRET_URI);
+            connection.setDatabase_password(SECRET_PASSWORD);
+            connection.setPlain_password(SECRET_PASSWORD);
+            doReturn(List.of(connection)).when(handler).loadConnections(anyList());
+
+            DataSourceDefinitionService definitionService = mock(DataSourceDefinitionService.class);
+            lenient().when(definitionService.findByPdkHash(any(), anyInt(), any())).thenReturn(definitionWithUri());
+            String connId = connection.getId().toHexString();
+            lenient().when(metadataInstancesService.findOne(any(Query.class), any(UserDetail.class)))
+                    .thenReturn(metadataCarryingSecrets(connId, SECRET_IN_DB_META));
+            lenient().when(metadataInstancesService.findAllDto(any(Query.class), any(UserDetail.class)))
+                    .thenReturn(new ArrayList<>(List.of(metadataCarryingSecrets(connId, SECRET_IN_TABLE_META))));
+
+            ArgumentCaptor<GroupExportRequest> exported = ArgumentCaptor.forClass(GroupExportRequest.class);
+            try (MockedStatic<cn.hutool.extra.spring.SpringUtil> springUtil =
+                         Mockito.mockStatic(cn.hutool.extra.spring.SpringUtil.class)) {
+                springUtil.when(() -> cn.hutool.extra.spring.SpringUtil.getBean(DataSourceDefinitionService.class))
+                        .thenReturn(definitionService);
+                springUtil.when(() -> cn.hutool.extra.spring.SpringUtil.getBean(
+                                com.tapdata.tm.metadatainstance.service.MetadataInstancesService.class))
+                        .thenReturn(metadataInstancesService);
+                runExport(request);
+            }
+            verify(groupTransferStrategy).exportGroups(exported.capture());
+            StringBuilder all = new StringBuilder();
+            exported.getValue().getContents().forEach((k, v) -> all.append(new String(v, StandardCharsets.UTF_8)));
+            return all.toString();
+        }
+
+        /** metadata 里那份连接拷贝——线上由 DAGService:419 整份序列化连接得来，这里照那个形状造 */
+        private MetadataInstancesDto metadataCarryingSecrets(String connectionId, String uri) {
+            MetadataInstancesDto meta = new MetadataInstancesDto();
+            meta.setId(new ObjectId());
+            SourceDto source = new SourceDto();
+            source.setName("MDM_CUSTOMER");
+            // source._id 必须是所属连接的 id：buildConnectionFileContents 靠它把元数据归到连接名下，
+            // 不设就整份被丢掉，这套用例也就测不到 metadata 这条腿
+            source.set_id(connectionId);
+            source.setDatabase_uri(uri);
+            source.setDatabase_password(SECRET_PASSWORD);
+            source.setPlain_password(SECRET_PASSWORD);
+            meta.setSource(source);
+            return meta;
+        }
+
+        private DataSourceDefinitionDto definitionWithUri() {
+            Map<String, Object> uriMeta = new LinkedHashMap<>();
+            uriMeta.put("apiServerKey", "database_uri");
+            Map<String, Object> connProps = new LinkedHashMap<>();
+            connProps.put("uri", uriMeta);
+            Map<String, Object> connection = new LinkedHashMap<>();
+            connection.put("properties", connProps);
+            LinkedHashMap<String, Object> properties = new LinkedHashMap<>();
+            properties.put("connection", connection);
+            DataSourceDefinitionDto def = new DataSourceDefinitionDto();
+            def.setProperties(properties);
+            return def;
+        }
+
+        @Test
+        @DisplayName("对照组：FILE 保真时整包里确实找得到凭据（否则红线用例是空断言）")
+        void faithfulPackageActuallyContainsTheSecret() {
+            String pkg = wholePackage(exportRequest(GroupTransferType.FILE, null));
+            assertTrue(pkg.contains(SECRET_URI), "连接文档那份凭据没进包，红线用例就白测了");
+            assertTrue(pkg.contains(SECRET_IN_DB_META), "database 级 metadata 那份没进包，红线用例覆盖不到这条腿");
+            assertTrue(pkg.contains(SECRET_IN_TABLE_META), "table 级 metadata 那份没进包，红线用例覆盖不到这条腿");
+        }
+
+        @Test
+        @DisplayName("红线（整包）：GIT + 显式要求保真，整个包里搜不到明文凭据")
+        void gitPackageNeverCarriesPlaintextSecrets() {
+            String pkg = wholePackage(exportRequest(GroupTransferType.GIT, false));
+            assertFalse(pkg.contains(SECRET_URI),
+                    "GIT 包会进 git 历史、永久留存且可被 fork/缓存——明文凭据一处都不能有。"
+                            + "凭据在包里有两份拷贝（Connection 文档 + MetadataInstances.source），"
+                            + "只抹前者等于没抹（ADR-0034 D2）");
+            assertFalse(pkg.contains(SECRET_IN_DB_META), "database 级 metadata 里那份连接拷贝同样不能留");
+            assertFalse(pkg.contains(SECRET_IN_TABLE_META), "table 级 metadata 里那份连接拷贝同样不能留");
+            assertFalse(pkg.contains(SECRET_PASSWORD),
+                    "顶层 database_password / plain_password 是同一个 secret 的另一处存放点，同样不能留");
         }
 
         @Test

--- a/manager/tm/src/test/java/com/tapdata/tm/group/service/GroupInfoServiceTest.java
+++ b/manager/tm/src/test/java/com/tapdata/tm/group/service/GroupInfoServiceTest.java
@@ -44,6 +44,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
@@ -3081,12 +3082,191 @@ public class GroupInfoServiceTest {
             Map<String, DataSourceConnectionDto> connections = new LinkedHashMap<>();
             connections.put("MDM_CUSTOMER", incoming);
 
-            List<String> report = groupInfoService.preserveExistingSecrets(connections, user);
+            Map<String, List<String>> report = groupInfoService.preserveExistingSecrets(connections, user);
 
             assertEquals("mongodb://real-host:27017/dmp", incoming.getConfig().get("uri"),
                     "目标既有 uri 必须留下——包里那个空缺是脱敏产物，不是用户的配置");
-            assertEquals(List.of("MDM_CUSTOMER.uri"), report,
-                    "保留了哪些字段必须报出来，否则用户分不清『凭据已更新』和『沿用了旧的』");
+            assertEquals(Map.of(connId.toHexString(), List.of("uri")), report,
+                    "保留了哪些字段必须按连接报出来，否则用户分不清『凭据已更新』和『沿用了旧的』");
+        }
+    }
+
+    /**
+     * ES-4b：① 两处调用点的接线覆盖 ② 保留清单接进导入报告（ADR-0034 D7 的「显形」）。
+     *
+     * 断言刻意走行为面而不是 verify(调用发生过)：落库那份 config 必须已带目标既有 uri、
+     * 导入记录里必须报出「哪个连接的哪个字段沿用了旧值」。摘掉任一调用点即转红。
+     */
+    @Nested
+    @DisplayName("preserveExistingSecrets 接线 + 导入报告显形")
+    class PreserveExistingSecretsWiringTest {
+
+        private static final String REAL_URI = "mongodb://real-host:27017/dmp";
+
+        private DataSourceDefinitionDto definitionWithUri() {
+            Map<String, Object> uriMeta = new LinkedHashMap<>();
+            uriMeta.put("apiServerKey", "database_uri");
+            Map<String, Object> connProps = new LinkedHashMap<>();
+            connProps.put("uri", uriMeta);
+            Map<String, Object> connection = new LinkedHashMap<>();
+            connection.put("properties", connProps);
+            LinkedHashMap<String, Object> properties = new LinkedHashMap<>();
+            properties.put("connection", connection);
+            DataSourceDefinitionDto def = new DataSourceDefinitionDto();
+            def.setProperties(properties);
+            return def;
+        }
+
+        /** 包里的连接：uri 已被导出脱敏抹掉，只剩非敏感项 */
+        private TaskUpAndLoadDto maskedConnectionPayload(ObjectId connId, String name) {
+            Map<String, Object> json = new LinkedHashMap<>();
+            json.put("id", connId.toHexString());
+            json.put("name", name);
+            json.put("pdkHash", "pdkhash-mongodb");
+            json.put("config", new LinkedHashMap<>(Map.of("isUri", true)));
+            return new TaskUpAndLoadDto(GroupConstants.COLLECTION_CONNECTION, JsonUtil.toJsonUseJackson(json));
+        }
+
+        /** 目标环境里那条连接：凭据齐全 */
+        private DataSourceConnectionDto existingWithRealUri(ObjectId connId) {
+            DataSourceConnectionDto existing = new DataSourceConnectionDto();
+            existing.setId(connId);
+            existing.setConfig(new LinkedHashMap<>(Map.of("isUri", true, "uri", REAL_URI)));
+            return existing;
+        }
+
+        private void stubTargetLookup(ObjectId connId) {
+            when(dataSourceService.findById(eq(connId), any(String[].class)))
+                    .thenReturn(existingWithRealUri(connId));
+            when(dataSourceDefinitionService.findByPdkHash(eq("pdkhash-mongodb"), anyInt(), any(UserDetail.class)))
+                    .thenReturn(definitionWithUri());
+        }
+
+        @SuppressWarnings("unchecked")
+        private List<DataSourceConnectionDto> captureBatchImported() {
+            ArgumentCaptor<List<DataSourceConnectionDto>> captor = ArgumentCaptor.forClass(List.class);
+            verify(dataSourceService).batchImport(captor.capture(), eq(user), any());
+            return captor.getValue();
+        }
+
+        private void assertReportsPreservedField(List<GroupInfoRecordDetail> details, String connName, String field) {
+            assertNotNull(details, "导入报告不能为 null——D7 要求保留旧凭据这件事必须显形");
+            String messages = details.stream()
+                    .flatMap(d -> d.getRecordDetails().stream())
+                    .filter(rd -> connName.equals(rd.getResourceName()))
+                    .map(GroupInfoRecordDetail.RecordDetail::getMessage)
+                    .filter(java.util.Objects::nonNull)
+                    .reduce("", (a, b) -> a + " " + b);
+            assertTrue(messages.contains(field),
+                    "导入报告里必须能看到 " + connName + " 的 " + field + " 沿用了目标既有值，实际报告：" + messages);
+        }
+
+        @Test
+        @DisplayName("拆分导入（executeImportConnectionsAsync）：落库前保留目标既有 uri，并在导入记录里报出来")
+        @SuppressWarnings("unchecked")
+        void connectionsImportPath_preservesAndReports() {
+            ObjectId connId = new ObjectId();
+            ObjectId recordId = new ObjectId();
+            Map<String, List<TaskUpAndLoadDto>> payloads = new HashMap<>();
+            payloads.put("Connection.json", List.of(maskedConnectionPayload(connId, "MDM_CUSTOMER")));
+
+            stubTargetLookup(connId);
+            when(dataSourceService.batchImport(anyList(), any(), any())).thenReturn(new HashMap<>());
+            doNothing().when(batchUpChecker).checkDataSourceConnection(any(), any(), any());
+            doNothing().when(groupInfoService).updateRecordStatus(any(), any(), any(), any(), any());
+
+            groupInfoService.executeImportConnectionsAsync(payloads, ImportModeEnum.GROUP_IMPORT, user, recordId,
+                    Collections.emptyMap());
+
+            assertEquals(REAL_URI, captureBatchImported().get(0).getConfig().get("uri"),
+                    "落库的那份 config 必须已经带上目标既有 uri——否则空值会把目标环境的凭据抹掉");
+
+            ArgumentCaptor<List<GroupInfoRecordDetail>> details = ArgumentCaptor.forClass(List.class);
+            verify(groupInfoService).updateRecordStatus(eq(recordId), eq(GroupInfoRecordDto.STATUS_COMPLETED),
+                    isNull(), details.capture(), eq(user));
+            assertReportsPreservedField(details.getValue(), "MDM_CUSTOMER", "uri");
+        }
+
+        @Test
+        @DisplayName("整组导入（executeImportAsync）：同样保留目标既有 uri，并在导入记录里报出来")
+        @SuppressWarnings("unchecked")
+        void groupImportPath_preservesAndReports() {
+            ObjectId connId = new ObjectId();
+            ObjectId recordId = new ObjectId();
+            Map<String, List<TaskUpAndLoadDto>> payloads = new HashMap<>();
+            payloads.put("GroupInfo.json", new ArrayList<>());
+
+            DataSourceConnectionDto incoming = new DataSourceConnectionDto();
+            incoming.setId(connId);
+            incoming.setName("MDM_CUSTOMER");
+            incoming.setPdkHash("pdkhash-mongodb");
+            incoming.setConfig(new LinkedHashMap<>(Map.of("isUri", true)));
+            registerConnectionHandler(connId, incoming);
+
+            stubTargetLookup(connId);
+            when(dataSourceService.batchImport(anyList(), any(), any())).thenReturn(new HashMap<>());
+            when(metadataDefinitionService.batchImport(any(), any())).thenReturn(new HashMap<>());
+            doNothing().when(batchUpChecker).checkDataSourceConnection(any(), any(), any());
+            doNothing().when(groupInfoService).updateImportProgress(any(), anyInt(), any(), any());
+            doNothing().when(groupInfoService).updateRecordStatus(any(), any(), any(), any(), any());
+
+            groupInfoService.executeImportAsync(payloads, user, ImportModeEnum.GROUP_IMPORT, "test.tar", recordId);
+
+            assertEquals(REAL_URI, captureBatchImported().get(0).getConfig().get("uri"),
+                    "整组导入这条路同样会整文档覆盖，缺了保护一样会抹空目标凭据");
+
+            ArgumentCaptor<List<GroupInfoRecordDetail>> details = ArgumentCaptor.forClass(List.class);
+            verify(groupInfoService).updateRecordStatus(eq(recordId), eq(GroupInfoRecordDto.STATUS_COMPLETED),
+                    isNull(), details.capture(), eq(user));
+            assertReportsPreservedField(details.getValue(), "MDM_CUSTOMER", "uri");
+        }
+
+        /** 让 executeImportAsync 的资源收集环节吐出这条连接（生产上由 Task/Module handler 的关联收集完成） */
+        @SuppressWarnings("unchecked")
+        private void registerConnectionHandler(ObjectId connId, DataSourceConnectionDto incoming) {
+            ResourceHandler connectionHandler = mock(ResourceHandler.class);
+            when(connectionHandler.getResourceType()).thenReturn(ResourceType.CONNECTION);
+            doAnswer(invocation -> {
+                ((Map<String, Object>) invocation.getArgument(1)).put(connId.toHexString(), incoming);
+                return null;
+            }).when(connectionHandler).collectPayload(any(), any(), any());
+            ResourceHandlerRegistry registry = new ResourceHandlerRegistry();
+            ReflectionTestUtils.setField(registry, "handlers", List.of(connectionHandler));
+            registry.init();
+            ReflectionTestUtils.setField(groupInfoService, "resourceHandlerRegistry", registry);
+        }
+
+        @Test
+        @DisplayName("报告显形：已有的连接行直接挂上消息，不另起一行")
+        void reportAttachesToExistingConnectionRow() {
+            ObjectId connId = new ObjectId();
+            GroupInfoRecordDetail detail = new GroupInfoRecordDetail();
+            detail.setGroupName("MDM");
+            GroupInfoRecordDetail.RecordDetail row = new GroupInfoRecordDetail.RecordDetail();
+            row.setResourceType(ResourceType.CONNECTION);
+            row.setResourceId(connId.toHexString());
+            row.setResourceName("MDM_CUSTOMER");
+            row.setAction(GroupInfoRecordDetail.RecordAction.IMPORTING);
+            detail.getRecordDetails().add(row);
+            List<GroupInfoRecordDetail> details = new ArrayList<>(List.of(detail));
+
+            DataSourceConnectionDto conn = new DataSourceConnectionDto();
+            conn.setId(connId);
+            conn.setName("MDM_CUSTOMER");
+
+            groupInfoService.reportPreservedSecrets(details,
+                    Map.of(connId.toHexString(), List.of("uri", "ssl.password")),
+                    Map.of(connId.toHexString(), conn));
+
+            assertEquals(1, details.size(), "已有行能挂上就不该另起一个分组");
+            assertEquals(1, details.get(0).getRecordDetails().size(), "同一个连接不该出现两行");
+            String message = details.get(0).getRecordDetails().get(0).getMessage();
+            assertNotNull(message);
+            assertTrue(message.contains("uri") && message.contains("ssl.password"),
+                    "两个被保留的字段都要报出来，实际：" + message);
+            assertEquals(GroupInfoRecordDetail.RecordAction.IMPORTING,
+                    details.get(0).getRecordDetails().get(0).getAction(),
+                    "连接确实导入了，只是部分字段沿用旧值——不该改写 action 误报成跳过");
         }
     }
 

--- a/manager/tm/src/test/java/com/tapdata/tm/group/service/GroupInfoServiceTest.java
+++ b/manager/tm/src/test/java/com/tapdata/tm/group/service/GroupInfoServiceTest.java
@@ -3127,7 +3127,7 @@ public class GroupInfoServiceTest {
             ResourceHandler handler = mock(ResourceHandler.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
             lenient().when(handler.getResourceType()).thenReturn(ResourceType.MODULE);
             lenient().doReturn(List.of(new ModulesDto())).when(handler).loadResources(anyList(), any(UserDetail.class));
-            lenient().when(handler.buildExportPayload(anyList(), any(UserDetail.class))).thenReturn(new ArrayList<>());
+            lenient().when(handler.buildExportPayload(anyList(), any(UserDetail.class), anyBoolean())).thenReturn(new ArrayList<>());
             lenient().when(handler.loadConnections(anyList())).thenReturn(new ArrayList<>());
             ResourceHandlerRegistry registry = new ResourceHandlerRegistry();
             ReflectionTestUtils.setField(registry, "handlers", List.of(handler));

--- a/manager/tm/src/test/java/com/tapdata/tm/group/service/GroupInfoServiceTest.java
+++ b/manager/tm/src/test/java/com/tapdata/tm/group/service/GroupInfoServiceTest.java
@@ -3034,4 +3034,60 @@ public class GroupInfoServiceTest {
         }
     }
 
+    /**
+     * 导入侧保护（ADR-0034 D5/D6/D7）：脱敏包未带 vault 时，绝不用空值覆盖目标环境
+     * 已有的连接凭据。实撞过一次——Create MongoDB client failed, error: uri is blank。
+     */
+    @Nested
+    @DisplayName("preserveExistingSecrets")
+    class PreserveExistingSecretsTest {
+
+        private com.tapdata.tm.commons.schema.DataSourceDefinitionDto definitionWithUri() {
+            Map<String, Object> uriMeta = new LinkedHashMap<>();
+            uriMeta.put("apiServerKey", "database_uri");
+            Map<String, Object> connProps = new LinkedHashMap<>();
+            connProps.put("uri", uriMeta);
+            Map<String, Object> connection = new LinkedHashMap<>();
+            connection.put("properties", connProps);
+            LinkedHashMap<String, Object> properties = new LinkedHashMap<>();
+            properties.put("connection", connection);
+            com.tapdata.tm.commons.schema.DataSourceDefinitionDto def =
+                    new com.tapdata.tm.commons.schema.DataSourceDefinitionDto();
+            def.setProperties(properties);
+            return def;
+        }
+
+        @Test
+        @DisplayName("包里 uri 被脱敏抹空时，改用目标既有 uri，并把该字段报出来")
+        void maskedPackage_keepsTargetSecretAndReportsIt() {
+            ObjectId connId = new ObjectId();
+
+            DataSourceConnectionDto incoming = new DataSourceConnectionDto();
+            incoming.setId(connId);
+            incoming.setName("MDM_CUSTOMER");
+            incoming.setPdkHash("pdkhash-mongodb");
+            incoming.setConfig(new LinkedHashMap<>(Map.of("isUri", true)));
+
+            DataSourceConnectionDto existing = new DataSourceConnectionDto();
+            existing.setId(connId);
+            existing.setConfig(new LinkedHashMap<>(Map.of(
+                    "isUri", true,
+                    "uri", "mongodb://real-host:27017/dmp")));
+
+            when(dataSourceService.findById(eq(connId), any(String[].class))).thenReturn(existing);
+            when(dataSourceDefinitionService.findByPdkHash(eq("pdkhash-mongodb"), anyInt(), any(UserDetail.class)))
+                    .thenReturn(definitionWithUri());
+
+            Map<String, DataSourceConnectionDto> connections = new LinkedHashMap<>();
+            connections.put("MDM_CUSTOMER", incoming);
+
+            List<String> report = groupInfoService.preserveExistingSecrets(connections, user);
+
+            assertEquals("mongodb://real-host:27017/dmp", incoming.getConfig().get("uri"),
+                    "目标既有 uri 必须留下——包里那个空缺是脱敏产物，不是用户的配置");
+            assertEquals(List.of("MDM_CUSTOMER.uri"), report,
+                    "保留了哪些字段必须报出来，否则用户分不清『凭据已更新』和『沿用了旧的』");
+        }
+    }
+
 }

--- a/manager/tm/src/test/java/com/tapdata/tm/group/service/transfer/FileGroupTransferStrategyTest.java
+++ b/manager/tm/src/test/java/com/tapdata/tm/group/service/transfer/FileGroupTransferStrategyTest.java
@@ -1,0 +1,90 @@
+package com.tapdata.tm.group.service.transfer;
+
+import com.tapdata.tm.group.constant.GroupConstants;
+import com.tapdata.tm.task.bean.TaskUpAndLoadDto;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * ES-3：包自带的脱敏标记（[ADR-0034] D3）是根级 sidecar，必须像 vault.json 一样**按原样**读回。
+ *
+ * 走通用 JSON 分支的话，{@code parseTaskUpAndLoadList} 会拿它当资源列表解析、失败后静默返回空列表——
+ * 标记就此消失，导入侧只能退回「按老包处理」，D4 的兼容口径也就永远命中，等于 ES-3 没做。
+ */
+class FileGroupTransferStrategyTest {
+
+    private final FileGroupTransferStrategy strategy = new FileGroupTransferStrategy();
+
+    private MockMultipartFile tarOf(Map<String, String> entries) throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (TarArchiveOutputStream taos = new TarArchiveOutputStream(baos)) {
+            for (Map.Entry<String, String> entry : entries.entrySet()) {
+                byte[] bytes = entry.getValue().getBytes(StandardCharsets.UTF_8);
+                TarArchiveEntry tarEntry = new TarArchiveEntry(entry.getKey());
+                tarEntry.setSize(bytes.length);
+                taos.putArchiveEntry(tarEntry);
+                taos.write(bytes);
+                taos.closeArchiveEntry();
+            }
+            taos.finish();
+        }
+        return new MockMultipartFile("file", "group.tar", null, baos.toByteArray());
+    }
+
+    @Nested
+    @DisplayName("包脱敏标记的读回")
+    class PackageManifestTest {
+
+        private static final String MANIFEST_JSON = "{\"secretsMasked\":false}";
+
+        @Test
+        @DisplayName("标记文件按原样读回，不被当成资源列表解析掉")
+        void manifestIsReadBackVerbatim() throws Exception {
+            Map<String, List<TaskUpAndLoadDto>> payloads = strategy.parseImportPayloads(
+                    tarOf(Map.of(GroupConstants.PACKAGE_MANIFEST_FILE, MANIFEST_JSON)));
+
+            List<TaskUpAndLoadDto> items = payloads.get(GroupConstants.PACKAGE_MANIFEST_FILE);
+            assertNotNull(items, "标记文件必须能按自己的文件名取到——导入侧靠它区分「真的没配」和「被抹空」");
+            assertEquals(1, items.size());
+            assertEquals(MANIFEST_JSON, items.get(0).getJson(),
+                    "必须是原始 JSON：走通用分支会被解析成空的资源列表，标记静默消失");
+        }
+
+        @Test
+        @DisplayName("标记文件不混进资源 payload——它不是要被导入的文档")
+        void manifestIsNotTreatedAsAResource() throws Exception {
+            Map<String, List<TaskUpAndLoadDto>> payloads = strategy.parseImportPayloads(
+                    tarOf(new LinkedHashMap<>(Map.of(
+                            GroupConstants.PACKAGE_MANIFEST_FILE, MANIFEST_JSON,
+                            "GroupInfo.json", "[]"))));
+
+            assertFalse(payloads.getOrDefault("GroupInfo.json", List.of()).stream()
+                            .anyMatch(item -> MANIFEST_JSON.equals(item.getJson())),
+                    "标记是包的元信息，不能被当作资源导进库（D3：不写进任何被导入的文档）");
+        }
+
+        @Test
+        @DisplayName("老包没有标记文件：payloads 里就没有这个 key，读侧自行按兼容口径处理")
+        void oldPackageHasNoManifestKey() throws Exception {
+            Map<String, List<TaskUpAndLoadDto>> payloads = strategy.parseImportPayloads(
+                    tarOf(Map.of("GroupInfo.json", "[]")));
+
+            assertFalse(payloads.containsKey(GroupConstants.PACKAGE_MANIFEST_FILE),
+                    "老包本来就没有这个文件，读侧不该凭空造一个 key 出来");
+        }
+    }
+}


### PR DESCRIPTION
## 问题

分组导出对 secret 是**一刀切脱敏**：`ResourceHandler` 在 `buildConnectionPayload` 里无条件调 `maskSensitiveConfigFields`，`GroupTransferType`（FILE / GIT）只决定字节送去哪、不影响 payload。由此造成两个方向的实际损害：

1. **导入侧数据破坏**：脱敏后的空 `config` 被 `handleGroupImportConnection` 整文档覆盖写回目标环境，把目标连接已有的 `uri` / `password` 抹空（`injectVaultSecretsToConnection` 在无 vault 时直接 return，不兜底）。实撞现场：2026-08-01 导入后 load 报 `Create MongoDB client failed, error: uri is blank`。
2. **「脱敏」名不副实**：`maskSensitiveConfigFields` 只清 `config` 里按 definition 解析出的路径，而同一批凭据在包内还有**三处镜像**从未被清理 —— ① 连接实体顶层（`database_uri` / `database_password` / `plain_password` / `database_password_1` …）；② database 级与 table 级 `MetadataInstances.source`（`SourceDto` 带同一批顶层字段，由 `DAGService` 整份序列化连接而来）；③ 任务导出时为 DAG **每个节点**另发的一批 `MetadataInstances`（`Task/*.json` 的 `[].json.source.database_uri`）。⇒ **推上 GitHub 的包里一直带着明文凭据**：实测一个真实老包整包命中 16 处明文 URI。

## 改了什么

**导出侧 —— 按用途分流，GIT 强制脱敏**
- `ExportGroupRequest` 新增 `removeSensitiveData`（三态：不传 = 按用途取默认）；FILE 默认**保真**，GIT **一律脱敏且不可被入参绕过**。
- 脱敏动作从「只清 `config`」扩到上述三处镜像载体：`maskMirroredSecretFields` 覆盖连接文档顶层 + 两级 `MetadataInstances.source`；`ResourceHandler.buildExportPayload` 增加 `maskSecrets` 参数（接口 + 3 实现 + 3 调用点，**不留带默认值的重载**），把任务自带的 metadata 也纳入。
- 敏感字段集合**未扩**，仍是既有的 `SENSITIVE_API_KEYS`（host/port/username/password/uri）及其别名 —— 本 PR 做的是把**既有那组 secret** 应用到被漏掉的载体上。证书材料（`sslKey`/`sslPass`/…）仍会明文进包，另行决策。

**包格式 —— 自带脱敏标记**
- 包根新增 sidecar `export-manifest.json`，键 `secretsMasked`，按**本次实际发生**的脱敏结果写（不是按入参意图）。
- 这是导入侧「包里的空值是脱敏留的，还是本来就空」的唯一判据。**无 manifest 的历史包 = 不信任其空值**，行为与今日一致。

**导入侧 —— 缺 secret 绝不用空值覆盖（本 PR 的根治项）**
- 在 `handleGroupImportConnection` 之前加一层合并（纯函数 `preserveExistingSecrets`）：包内敏感字段为空/缺失、且 vault 未提供时，**保留目标既有值**，绝不写空；覆盖 `config` 内路径与顶层镜像两批。
- 保留清单接进**导入报告**（不止 WARN 日志）：每条连接给出结构化告警 `Kept the target environment's existing value for secret field(s) missing in the package: <字段>` —— 连接、字段、原因三要素齐全，用户能分清「凭据已更新」与「沿用了旧的」。

## 测试

`com.tapdata.tm.group.**` 全量 **298 测 0 失败 0 错误**。关键几条是**红线**而非默认值验证：

- `gitPackageNeverCarriesPlaintextSecrets` —— 判据是**整包**搜不到明文凭据（不是只看连接文档），且钉死「GIT + 入参显式要求保真」仍脱敏。
- `taskBorneMetadataSecretIsMasked` —— 带**对照用例**（保真导出时该凭据必须还在），否则「metadata 压根没进包」就能让断言假绿。
- `preserveExistingSecrets` 的两处**调用点**各有接线测试，摘掉调用即转红（方法有测试 ≠ 接线被确认）。

## 实机验证（本地 TM + 真实分组）

| 项 | 结果 |
|---|---|
| 脱敏包整包明文命中 | 老包 **16** → 修镜像前 **6** → 修后 **0** |
| 保真包 | 仍 **6** 处命中 —— 不是无脑全抹 |
| manifest 两态 | `{"secretsMasked":false}` / `{"secretsMasked":true}`，按实际结果写 |
| 脱敏包 + 无 vault 导入 | 目标凭据指纹**零差异**，导入报告出两条结构化告警 |

**未做实机的一项**：无 manifest 老包的导入回归（怕在测试环境再触发一次空值覆盖），由单测覆盖其判定分支 —— 残余风险已知并接受。

## 兼容性

- 包格式**只增不改**：新增根级 sidecar，老包无此文件时按「不信任空值」处理，导入行为与今日一致。
- 本地导出的默认行为**变了**：从「总是脱敏」变成「默认保真」。代价是本地包从此默认含明文凭据 —— 前端 PR 用告警色文案让这件事在导出弹窗上看得见。

前端配套 PR：tapdata/tapdata-web#620