### PR TITLE
Fix(build): TAP-12452 inject app type into image launcher

### DIFF
--- a/build/image/docker-entrypoint.sh
+++ b/build/image/docker-entrypoint.sh
@@ -132,12 +132,13 @@ get_env() {
     export engineMem=${engineMem:-"1G"} # engine memory
     export managerMem=${managerMem:-"1G"} # manager memory
     export tm_port=${tm_port:-"3030"} # manager port
+    export app_type="${app_type:-DAAS}" # application type
     export ACCESS_CODE=${ACCESS_CODE:-"3324cfdf-7d3e-4792-bd32-571638d4562f"}  # access code
     export LAUNCH_SUPERVISOR=${LAUNCH_SUPERVISOR:-"false"}  # launch supervisor
     export REPORT_DATA_OSS=true # report data oss
 
     # Export env
-    export MONGO_URI dbMem engineMem managerMem tm_port ACCESS_CODE LAUNCH_SUPERVISOR REPORT_DATA_OSS
+    export MONGO_URI dbMem engineMem managerMem tm_port app_type ACCESS_CODE LAUNCH_SUPERVISOR REPORT_DATA_OSS
 
 cat <<EOF
 MONGO_URI         : $MONGO_URI
@@ -145,6 +146,7 @@ dbMem             : $dbMem
 engineMem         : $engineMem
 managerMem        : $managerMem
 tm_port           : $tm_port
+app_type          : $app_type
 ACCESS_CODE       : $ACCESS_CODE
 LAUNCH_SUPERVISOR : $LAUNCH_SUPERVISOR
 REPORT_DATA_OSS   : $REPORT_DATA_OSS
@@ -271,7 +273,6 @@ start_iengine() {
         supervisorctl -c supervisor/supervisord.conf start iengine
     else
         mkdir -p logs/iengine/ && touch logs/iengine/tapdata-agent.jar.log
-        export app_type="DAAS"
         export backend_url="http://127.0.0.1:$tm_port/api/"
         export TAPDATA_MONGO_URI=$MONGO_URI
         nohup java $JVM_OPTS -Xmx$engineMem -jar components/tapdata-agent.jar &> logs/iengine/tapdata-agent.jar.log &

--- a/build/image/supervisor/conf.d/manager.conf
+++ b/build/image/supervisor/conf.d/manager.conf
@@ -1,5 +1,6 @@
 [program:manager]
 command = java -Xmx%(ENV_managerMem)s -jar -Dserver.port=%(ENV_tm_port)s -server components/tm.jar --spring.config.additional-location=file:etc/ --logging.config=file:etc/logback.xml --spring.data.mongodb.default.uri=%(ENV_MONGO_URI)s --spring.data.mongodb.obs.uri=%(ENV_MONGO_URI)s --spring.data.mongodb.log.uri=%(ENV_MONGO_URI)s
+environment = app_type="%(ENV_app_type)s"
 directory = %(here)s/../../
 autostart = false
 autoresart = false


### PR DESCRIPTION
Initialize app_type in the shared image startup environment so the TM process receives DAAS by default in normal launcher mode. Pass the same value to the supervisor-managed manager process to cover both image startup paths and prevent login failures caused by a blank application type.

Refs: TAP-12452