### PR TITLE
fix(TAP-12466): [to 4.21] Do not enable the dynamic adjustment batch count thre…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,5 +137,3 @@ sybase-poc-temp/
 .tmStartMsg.json
 
 run-resources
-data/
-ll

--- a/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/node/hazelcast/data/batch/AdjustBatchSizeFactory.java
+++ b/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/node/hazelcast/data/batch/AdjustBatchSizeFactory.java
@@ -4,11 +4,11 @@ import io.tapdata.flow.engine.V2.node.hazelcast.data.batch.rule.IncreaseRuleInst
 import io.tapdata.observable.logging.ObsLogger;
 import io.tapdata.pdk.core.async.ThreadPoolExecutorEx;
 import org.apache.commons.lang3.StringUtils;
-import org.ehcache.impl.internal.concurrent.ConcurrentHashMap;
 
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
@@ -29,6 +29,7 @@ public final class AdjustBatchSizeFactory {
     private final Map<String, AdjustManager> adjustInstanceMap = new ConcurrentHashMap<>(16);
     private final ScheduledExecutorService scheduledExecutor = new ScheduledThreadPoolExecutor(20);
     private final Map<String, ScheduledFuture<?>> adjustTaskFutureMap = new ConcurrentHashMap<>(16);
+    private final Object lifecycleLock = new Object();
 
     private AdjustBatchSizeFactory() {
 
@@ -47,82 +48,90 @@ public final class AdjustBatchSizeFactory {
             return;
         }
         final AdjustBatchSizeFactory instance = getInstance();
-        instance.adjustInstanceMap.computeIfAbsent(
-                taskId,
-                key -> new AdjustManager(instance.adjustTaskMap.computeIfAbsent(taskId, k -> new AtomicBoolean(true)), DEFAULT_CHECK_INTERVAL_MS)
-        ).append(taskId, stage, sourceRunner);
+        synchronized (instance.lifecycleLock) {
+            instance.adjustInstanceMap.computeIfAbsent(
+                    taskId,
+                    key -> new AdjustManager(instance.adjustTaskMap.computeIfAbsent(taskId, k -> new AtomicBoolean(true)), DEFAULT_CHECK_INTERVAL_MS)
+            ).append(taskId, stage, sourceRunner);
+        }
     }
 
     public static void start(String taskId, ObsLogger obsLogger) {
-        getInstance().adjustTaskMap.put(taskId, new AtomicBoolean(true));
-        getInstance().taskLoggerMap.put(taskId, obsLogger);
-        AdjustBatchSizeFactory.stopTaskIfNeed(taskId);
-        final ScheduledFuture<?> scheduledFuture = getInstance().scheduledExecutor.scheduleWithFixedDelay(
-                () -> {
-                    try {
-                        foreach(taskId, IncreaseRuleInstance::checkOnce);
-                    } catch (Exception e) {
-                        Optional.ofNullable(getInstance().taskLoggerMap.get(taskId)).ifPresent(log -> log.debug("Check adjust batch size failed, error message: {}", e.getMessage()));
-                    }
-                },
-                DEFAULT_CHECK_INTERVAL_MS,
-                DEFAULT_CHECK_INTERVAL_MS,
-                TimeUnit.MILLISECONDS
-        );
-        getInstance().adjustTaskFutureMap.put(taskId, scheduledFuture);
-        obsLogger.info("Adjust batch size task started");
+        if (StringUtils.isBlank(taskId)) {
+            return;
+        }
+        final AdjustBatchSizeFactory instance = getInstance();
+        synchronized (instance.lifecycleLock) {
+            instance.adjustTaskMap.computeIfAbsent(taskId, key -> new AtomicBoolean(true)).set(true);
+            if (null == obsLogger) {
+                instance.taskLoggerMap.remove(taskId);
+            } else {
+                instance.taskLoggerMap.put(taskId, obsLogger);
+            }
+            AdjustBatchSizeFactory.stopTaskIfNeed(taskId);
+            final ScheduledFuture<?> scheduledFuture = instance.scheduledExecutor.scheduleWithFixedDelay(
+                    () -> {
+                        try {
+                            foreach(taskId, IncreaseRuleInstance::checkOnce);
+                        } catch (Exception e) {
+                            Optional.ofNullable(getInstance().taskLoggerMap.get(taskId)).ifPresent(log -> log.debug("Check adjust batch size failed, error message: {}", e.getMessage()));
+                        }
+                    },
+                    DEFAULT_CHECK_INTERVAL_MS,
+                    DEFAULT_CHECK_INTERVAL_MS,
+                    TimeUnit.MILLISECONDS
+            );
+            instance.adjustTaskFutureMap.put(taskId, scheduledFuture);
+        }
+        Optional.ofNullable(obsLogger).ifPresent(log -> log.info("Adjust batch size task started"));
     }
 
     static final String MSG = "Stop adjust batch size task failed, error message: {}";
 
     static void stopTaskIfNeed(String taskId) {
+        if (StringUtils.isBlank(taskId)) {
+            return;
+        }
         final AdjustBatchSizeFactory instance = getInstance();
-        Optional.ofNullable(instance.adjustTaskFutureMap.get(taskId)).ifPresent(feature -> {
-            try {
-                feature.cancel(true);
-            } catch (Exception e) {
-                Optional.ofNullable(instance.taskLoggerMap.get(taskId)).ifPresent(log -> log.warn(MSG, e.getMessage()));
-            }
-        });
-        try {
-            instance.adjustTaskFutureMap.remove(taskId);
-        } catch (Exception e) {
-            Optional.ofNullable(instance.taskLoggerMap.get(taskId)).ifPresent(log -> log.warn(MSG, e.getMessage()));
+        synchronized (instance.lifecycleLock) {
+            Optional.ofNullable(instance.adjustTaskFutureMap.remove(taskId)).ifPresent(feature -> {
+                try {
+                    feature.cancel(true);
+                } catch (Exception e) {
+                    Optional.ofNullable(instance.taskLoggerMap.get(taskId)).ifPresent(log -> log.warn(MSG, e.getMessage()));
+                }
+            });
         }
     }
 
     public static void stop(String taskId) {
+        if (StringUtils.isBlank(taskId)) {
+            return;
+        }
         final AdjustBatchSizeFactory instance = getInstance();
-        try {
-            Optional.ofNullable(instance.adjustTaskMap.get(taskId))
-                    .ifPresent(e -> e.set(false));
-        } catch (Exception e) {
-            Optional.ofNullable(instance.taskLoggerMap.get(taskId)).ifPresent(log -> log.warn(MSG, e.getMessage()));
-        }
-        try {
-            instance.adjustTaskMap.remove(taskId);
-        } catch (Exception e) {
-            Optional.ofNullable(instance.taskLoggerMap.get(taskId)).ifPresent(log -> log.warn(MSG, e.getMessage()));
-        }
-        AdjustBatchSizeFactory.stopTaskIfNeed(taskId);
-        try {
+        synchronized (instance.lifecycleLock) {
+            try {
+                Optional.ofNullable(instance.adjustTaskMap.get(taskId))
+                        .ifPresent(e -> e.set(false));
+            } catch (Exception e) {
+                Optional.ofNullable(instance.taskLoggerMap.get(taskId)).ifPresent(log -> log.warn(MSG, e.getMessage()));
+            }
+            try {
+                instance.adjustTaskMap.remove(taskId);
+            } catch (Exception e) {
+                Optional.ofNullable(instance.taskLoggerMap.get(taskId)).ifPresent(log -> log.warn(MSG, e.getMessage()));
+            }
+            AdjustBatchSizeFactory.stopTaskIfNeed(taskId);
             instance.adjustInstanceMap.remove(taskId);
-        } catch (Exception e) {
-            Optional.ofNullable(instance.taskLoggerMap.get(taskId)).ifPresent(log -> log.warn(MSG, e.getMessage()));
+            instance.taskLoggerMap.remove(taskId);
         }
-        instance.taskLoggerMap.remove(taskId);
     }
 
     public static void unregister(String taskId) {
         if (StringUtils.isBlank(taskId)) {
             return;
         }
-        final AdjustBatchSizeFactory instance = getInstance();
-        try {
-            instance.adjustInstanceMap.remove(taskId);
-        } finally {
-            AdjustBatchSizeFactory.stop(taskId);
-        }
+        AdjustBatchSizeFactory.stop(taskId);
     }
 
     static void foreach(String taskId, Consumer<IncreaseRuleInstance> consumer) {
@@ -134,21 +143,27 @@ public final class AdjustBatchSizeFactory {
                 .ifPresent(list -> list.foreach(consumer));
     }
 
-    record AdjustManager(AtomicBoolean isAlive, long checkIntervalMs) {
+    public static class AdjustManager {
+        final Map<String, IncreaseRuleInstance> nodeList = new ConcurrentHashMap<>(4);
+        final AtomicBoolean isAlive;
+        final long checkIntervalMs;
 
-        static final Map<String, IncreaseRuleInstance> NODE_LIST = new ConcurrentHashMap<>(4);
-
-            void foreach(Consumer<IncreaseRuleInstance> consumer) {
-                NODE_LIST.values().stream().filter(Objects::nonNull).forEach(consumer);
-            }
-
-            void append(String taskId, AdjustStage stage, ThreadPoolExecutorEx sourceRunner) {
-                if (null == stage) {
-                    return;
-                }
-                NODE_LIST.put(stage.getNodeId(), new IncreaseRuleInstance(isAlive, taskId, checkIntervalMs, stage).sourceRunner(sourceRunner));
-            }
+        public AdjustManager(AtomicBoolean isAlive, long checkIntervalMs) {
+            this.isAlive = isAlive;
+            this.checkIntervalMs = checkIntervalMs;
         }
+
+        void foreach(Consumer<IncreaseRuleInstance> consumer) {
+            nodeList.values().stream().filter(Objects::nonNull).forEach(consumer);
+        }
+
+        void append(String taskId, AdjustStage stage, ThreadPoolExecutorEx sourceRunner) {
+            if (null == stage) {
+                return;
+            }
+            nodeList.put(stage.getNodeId(), new IncreaseRuleInstance(isAlive, taskId, checkIntervalMs, stage).sourceRunner(sourceRunner));
+        }
+    }
 
     public static void debug(String taskId, String msg, Object... params) {
         Optional.ofNullable(getInstance().taskLoggerMap.get(taskId)).ifPresent(log -> log.debug(msg, params));

--- a/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/node/hazelcast/data/batch/rule/IncreaseRuleInstance.java
+++ b/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/node/hazelcast/data/batch/rule/IncreaseRuleInstance.java
@@ -150,7 +150,7 @@ public final class IncreaseRuleInstance {
     }
 
     boolean exit() {
-        return queue.isEmpty() || isAlive == null;
+        return queue.isEmpty() || isAlive == null || !isAlive.get();
     }
 
     void collect(List<AdjustInfo> adjustInfos, long now) {

--- a/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/node/hazelcast/data/batch/utils/CapabilityChecker.java
+++ b/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/node/hazelcast/data/batch/utils/CapabilityChecker.java
@@ -1,0 +1,94 @@
+package io.tapdata.flow.engine.V2.node.hazelcast.data.batch.utils;
+
+import com.tapdata.constant.ConnectionUtil;
+import com.tapdata.entity.Connections;
+import com.tapdata.entity.DatabaseTypeEnum;
+import com.tapdata.mongo.ClientMongoOperator;
+import com.tapdata.tm.commons.dag.Edge;
+import com.tapdata.tm.commons.dag.Node;
+import com.tapdata.tm.commons.dag.nodes.DataParentNode;
+import com.tapdata.tm.commons.task.dto.TaskDto;
+import io.tapdata.pdk.apis.entity.Capability;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * @author <a href="2749984520@qq.com">Gavin'Xiao</a>
+ * @author <a href="https://github.com/11000100111010101100111">Gavin'Xiao</a>
+ * @version v1.0 2026/8/11 11:03 Create
+ * @description
+ */
+public final class CapabilityChecker {
+    private static final String STREAM_READ_ONE_BY_ONE_FUNCTION = "stream_read_one_by_one_function";
+
+    private CapabilityChecker() {
+
+    }
+
+    public static boolean hasAutoIncrementalBatchSizeNode(TaskDto taskDto, Function<String, Connections> getConnection, ClientMongoOperator clientMongoOperator) {
+        if (null == taskDto || null == taskDto.getDag()) {
+            return false;
+        }
+        final com.tapdata.tm.commons.dag.DAG dag = taskDto.getDag();
+        final List<Node> nodes = dag.getNodes();
+        if (CollectionUtils.isEmpty(nodes)) {
+            return false;
+        }
+        final List<Edge> edges = dag.getEdges();
+        final Set<String> incomingNodeIds = CollectionUtils.isEmpty(edges)
+                ? Collections.emptySet()
+                : edges.stream()
+                .filter(Objects::nonNull)
+                .map(Edge::getTarget)
+                .filter(StringUtils::isNotBlank)
+                .collect(Collectors.toSet());
+        final Set<String> outgoingNodeIds = CollectionUtils.isEmpty(edges)
+                ? Collections.emptySet()
+                : edges.stream()
+                .filter(Objects::nonNull)
+                .map(Edge::getSource)
+                .filter(StringUtils::isNotBlank)
+                .collect(Collectors.toSet());
+        return nodes.stream()
+                .filter(Objects::nonNull)
+                .filter(node -> isAutoIncrementalBatchSizeCandidate(node, incomingNodeIds, outgoingNodeIds))
+                .anyMatch(e -> CapabilityChecker.hasStreamReadOneByOneCapability(e, getConnection, clientMongoOperator));
+    }
+
+    static boolean isAutoIncrementalBatchSizeCandidate(Node<?> node, Set<String> incomingNodeIds, Set<String> outgoingNodeIds) {
+        return node instanceof DataParentNode
+                && StringUtils.isNotBlank(node.getId())
+                && !incomingNodeIds.contains(node.getId())
+                && outgoingNodeIds.contains(node.getId());
+    }
+
+    static boolean hasStreamReadOneByOneCapability(Node<?> node, Function<String, Connections> getConnection, ClientMongoOperator clientMongoOperator) {
+        Connections connection = getConnection.apply(((DataParentNode<?>) node).getConnectionId());
+        if (null == connection || !"pdk".equals(connection.getPdkType())) {
+            return false;
+        }
+        if (hasStreamOneByOneCapability(connection.getCapabilities())) {
+            return true;
+        }
+        if (StringUtils.isBlank(connection.getPdkHash())) {
+            return false;
+        }
+        DatabaseTypeEnum.DatabaseType databaseType = ConnectionUtil.getDatabaseType(clientMongoOperator, connection.getPdkHash());
+        return null != databaseType && hasStreamOneByOneCapability(databaseType.getCapabilities());
+    }
+
+    static boolean hasStreamOneByOneCapability(List<Capability> capabilities) {
+        return CollectionUtils.isNotEmpty(capabilities)
+                && capabilities.stream()
+                .filter(Objects::nonNull)
+                .map(Capability::getId)
+                .anyMatch(STREAM_READ_ONE_BY_ONE_FUNCTION::equals);
+    }
+}

--- a/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/node/hazelcast/data/pdk/HazelcastSourcePdkDataNode.java
+++ b/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/node/hazelcast/data/pdk/HazelcastSourcePdkDataNode.java
@@ -234,7 +234,6 @@ public class HazelcastSourcePdkDataNode extends HazelcastSourcePdkBaseNode imple
 	@Override
 	protected void doInitWithDisableNode(@NotNull Context context) throws TapCodeException {
 		super.doInitWithDisableNode(context);
-		registerAdjustStageIfNeed();
 		if (getNode().disabledNode() && isRunning()) {
 			Map<String, Object> taskGlobalVariable = TaskGlobalVariable.INSTANCE.getTaskGlobalVariable(dataProcessorContext.getTaskDto().getId().toHexString());
 			Object obj = taskGlobalVariable.get(TaskGlobalVariable.SOURCE_INITIAL_COUNTER_KEY);

--- a/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/task/impl/HazelcastTaskService.java
+++ b/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/task/impl/HazelcastTaskService.java
@@ -26,7 +26,6 @@ import com.tapdata.entity.Connections;
 import com.tapdata.entity.DatabaseTypeEnum;
 import com.tapdata.entity.JetDag;
 import com.tapdata.entity.RelateDataBaseTable;
-import com.tapdata.entity.Setting;
 import com.tapdata.entity.task.config.TaskConfig;
 import com.tapdata.entity.task.config.TaskGlobalVariable;
 import com.tapdata.entity.task.config.TaskRetryConfig;
@@ -51,7 +50,6 @@ import com.tapdata.tm.commons.dag.vo.ReadPartitionOptions;
 import com.tapdata.tm.commons.externalStorage.ExternalStorageDto;
 import com.tapdata.tm.commons.schema.TransformerWsMessageDto;
 import com.tapdata.tm.commons.task.dto.*;
-import com.tapdata.tm.commons.util.ProcessorNodeType;
 import com.tapdata.tm.utils.MergeTablePropertiesUtil;
 import io.tapdata.aspect.TaskStartAspect;
 import io.tapdata.aspect.TaskStopAspect;
@@ -81,6 +79,7 @@ import io.tapdata.flow.engine.V2.node.hazelcast.controller.SnapshotOrderControll
 import io.tapdata.flow.engine.V2.node.hazelcast.controller.SnapshotOrderService;
 import io.tapdata.flow.engine.V2.node.hazelcast.data.*;
 import io.tapdata.flow.engine.V2.node.hazelcast.data.batch.AdjustBatchSizeFactory;
+import io.tapdata.flow.engine.V2.node.hazelcast.data.batch.util.CapabilityChecker;
 import io.tapdata.flow.engine.V2.node.hazelcast.data.pdk.*;
 import io.tapdata.flow.engine.V2.node.hazelcast.processor.*;
 import io.tapdata.flow.engine.V2.node.hazelcast.processor.join.HazelcastJoinProcessor;
@@ -255,7 +254,7 @@ public class 	HazelcastTaskService implements TaskService<TaskDto> {
 			Job job = startJetJob(taskDto, obsLogger, jet, jobConfig, hazelcastTaskClient, open);
 			hazelcastTaskClient.setJob(job);
 			obsLogger.info("Task started");
-			if (open) {
+			if (open && CapabilityChecker.hasAutoIncrementalBatchSizeNode(taskDto, this::getConnection, clientMongoOperator)) {
 				AdjustBatchSizeFactory.start(taskDto.getId().toHexString(), obsLogger);
 				obsLogger.info("Task supports automatic adjustment of incremental batch times and the automatic adjustment of batch times switch has been turned on. After the current node enters incremental mode, batch times will be adjusted based on real-time data");
 			}

--- a/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/task/impl/HazelcastTaskService.java
+++ b/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/task/impl/HazelcastTaskService.java
@@ -254,9 +254,13 @@ public class 	HazelcastTaskService implements TaskService<TaskDto> {
 			Job job = startJetJob(taskDto, obsLogger, jet, jobConfig, hazelcastTaskClient, open);
 			hazelcastTaskClient.setJob(job);
 			obsLogger.info("Task started");
-			if (open && CapabilityChecker.hasAutoIncrementalBatchSizeNode(taskDto, this::getConnection, clientMongoOperator)) {
-				AdjustBatchSizeFactory.start(taskDto.getId().toHexString(), obsLogger);
-				obsLogger.info("Task supports automatic adjustment of incremental batch times and the automatic adjustment of batch times switch has been turned on. After the current node enters incremental mode, batch times will be adjusted based on real-time data");
+			try {
+				if (open && CapabilityChecker.hasAutoIncrementalBatchSizeNode(taskDto, this::getConnection, clientMongoOperator)) {
+					AdjustBatchSizeFactory.start(taskDto.getId().toHexString(), obsLogger);
+					obsLogger.info("Task supports automatic adjustment of incremental batch size and the automatic adjustment of batch size switch has been turned on. After the current node enters incremental mode, batch times will be adjusted based on real-time data");
+				}
+			} catch (Exception e) {
+				obsLogger.warn("When checking whether automatic adjustment of batch size is required, an exception occurs: {}. This exception does not affect the actual operation of the task.", e.getMessage(), e);
 			}
 			return hazelcastTaskClient;
 		} catch (Throwable throwable) {

--- a/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/task/impl/HazelcastTaskService.java
+++ b/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/task/impl/HazelcastTaskService.java
@@ -79,7 +79,7 @@ import io.tapdata.flow.engine.V2.node.hazelcast.controller.SnapshotOrderControll
 import io.tapdata.flow.engine.V2.node.hazelcast.controller.SnapshotOrderService;
 import io.tapdata.flow.engine.V2.node.hazelcast.data.*;
 import io.tapdata.flow.engine.V2.node.hazelcast.data.batch.AdjustBatchSizeFactory;
-import io.tapdata.flow.engine.V2.node.hazelcast.data.batch.util.CapabilityChecker;
+import io.tapdata.flow.engine.V2.node.hazelcast.data.batch.utils.CapabilityChecker;
 import io.tapdata.flow.engine.V2.node.hazelcast.data.pdk.*;
 import io.tapdata.flow.engine.V2.node.hazelcast.processor.*;
 import io.tapdata.flow.engine.V2.node.hazelcast.processor.join.HazelcastJoinProcessor;

--- a/iengine/iengine-app/src/test/java/io/tapdata/flow/engine/V2/node/hazelcast/data/batch/AdjustBatchSizeFactoryTest.java
+++ b/iengine/iengine-app/src/test/java/io/tapdata/flow/engine/V2/node/hazelcast/data/batch/AdjustBatchSizeFactoryTest.java
@@ -9,8 +9,15 @@ import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
@@ -60,6 +67,130 @@ class AdjustBatchSizeFactoryTest {
             ObsLogger logger = mock(ObsLogger.class);
             AdjustBatchSizeFactory.start("taskStart", logger);
             AdjustBatchSizeFactory.stop("taskStart");
+        }
+
+        @Test
+        void testStartIgnoresBlankTaskId() {
+            AdjustBatchSizeFactory instance = AdjustBatchSizeFactory.getInstance();
+            ScheduledExecutorService oldScheduledExecutor =
+                    (ScheduledExecutorService) getField(instance, "scheduledExecutor");
+            ScheduledExecutorService scheduledExecutor = mock(ScheduledExecutorService.class);
+            ObsLogger logger = mock(ObsLogger.class);
+            setField(instance, "scheduledExecutor", scheduledExecutor);
+            try {
+                AdjustBatchSizeFactory.start(" ", logger);
+
+                verify(scheduledExecutor, never())
+                        .scheduleWithFixedDelay(any(Runnable.class), anyLong(), anyLong(), any(TimeUnit.class));
+                verify(logger, never()).info(anyString());
+            } finally {
+                AdjustBatchSizeFactory.stop(" ");
+                setField(instance, "scheduledExecutor", oldScheduledExecutor);
+            }
+        }
+
+        @Test
+        void testStartAllowsMissingLogger() {
+            AdjustBatchSizeFactory instance = AdjustBatchSizeFactory.getInstance();
+            ScheduledExecutorService oldScheduledExecutor =
+                    (ScheduledExecutorService) getField(instance, "scheduledExecutor");
+            ScheduledExecutorService scheduledExecutor = mock(ScheduledExecutorService.class);
+            ScheduledFuture<?> future = mock(ScheduledFuture.class);
+            doReturn(future).when(scheduledExecutor)
+                    .scheduleWithFixedDelay(any(Runnable.class), anyLong(), anyLong(), any(TimeUnit.class));
+            setField(instance, "scheduledExecutor", scheduledExecutor);
+            try {
+                Assertions.assertDoesNotThrow(() -> AdjustBatchSizeFactory.start("task-null-logger", null));
+
+                verify(scheduledExecutor, times(1))
+                        .scheduleWithFixedDelay(any(Runnable.class), anyLong(), anyLong(), any(TimeUnit.class));
+            } finally {
+                AdjustBatchSizeFactory.stop("task-null-logger");
+                setField(instance, "scheduledExecutor", oldScheduledExecutor);
+            }
+        }
+
+        @Test
+        void testStopMarksRegisteredManagerNotAliveAfterStart() {
+            AdjustBatchSizeFactory instance = AdjustBatchSizeFactory.getInstance();
+            ScheduledExecutorService oldScheduledExecutor =
+                    (ScheduledExecutorService) getField(instance, "scheduledExecutor");
+            ScheduledExecutorService scheduledExecutor = mock(ScheduledExecutorService.class);
+            ScheduledFuture<?> future = mock(ScheduledFuture.class);
+            doReturn(future).when(scheduledExecutor)
+                    .scheduleWithFixedDelay(any(Runnable.class), anyLong(), anyLong(), any(TimeUnit.class));
+            setField(instance, "scheduledExecutor", scheduledExecutor);
+
+            String taskId = "task-reuse-alive";
+            AdjustStage stage = mock(AdjustStage.class);
+            when(stage.getNodeId()).thenReturn("node-reuse-alive");
+            try {
+                AdjustBatchSizeFactory.register(taskId, stage, mock(ThreadPoolExecutorEx.class));
+
+                @SuppressWarnings("unchecked")
+                Map<String, AdjustBatchSizeFactory.AdjustManager> managerMap =
+                        (Map<String, AdjustBatchSizeFactory.AdjustManager>) getField(instance, "adjustInstanceMap");
+                AdjustBatchSizeFactory.AdjustManager manager = managerMap.get(taskId);
+                Assertions.assertNotNull(manager);
+
+                AdjustBatchSizeFactory.start(taskId, mock(ObsLogger.class));
+                AdjustBatchSizeFactory.stop(taskId);
+
+                Assertions.assertFalse(manager.isAlive.get());
+            } finally {
+                AdjustBatchSizeFactory.unregister(taskId);
+                setField(instance, "scheduledExecutor", oldScheduledExecutor);
+            }
+        }
+
+        @Test
+        void testConcurrentStartCancelsSupersededFuture() throws Exception {
+            AdjustBatchSizeFactory instance = AdjustBatchSizeFactory.getInstance();
+            ScheduledExecutorService oldScheduledExecutor =
+                    (ScheduledExecutorService) getField(instance, "scheduledExecutor");
+            ScheduledExecutorService scheduledExecutor = mock(ScheduledExecutorService.class);
+            ScheduledFuture<?> firstFuture = mock(ScheduledFuture.class);
+            ScheduledFuture<?> secondFuture = mock(ScheduledFuture.class);
+            AtomicInteger scheduleCount = new AtomicInteger();
+            CyclicBarrier scheduleBarrier = new CyclicBarrier(2);
+            when(scheduledExecutor.scheduleWithFixedDelay(any(Runnable.class), anyLong(), anyLong(), any(TimeUnit.class)))
+                    .thenAnswer(invocation -> {
+                        int index = scheduleCount.getAndIncrement();
+                        try {
+                            scheduleBarrier.await(500L, TimeUnit.MILLISECONDS);
+                        } catch (Exception ignored) {
+                            // The synchronized implementation schedules one task at a time.
+                        }
+                        return index == 0 ? firstFuture : secondFuture;
+                    });
+            setField(instance, "scheduledExecutor", scheduledExecutor);
+
+            String taskId = "task-concurrent-start";
+            ObsLogger logger = mock(ObsLogger.class);
+            ExecutorService executorService = Executors.newFixedThreadPool(2);
+            CountDownLatch startLatch = new CountDownLatch(2);
+            try {
+                Runnable startTask = () -> {
+                    startLatch.countDown();
+                    try {
+                        startLatch.await();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                    AdjustBatchSizeFactory.start(taskId, logger);
+                };
+
+                Future<?> first = executorService.submit(startTask);
+                Future<?> second = executorService.submit(startTask);
+                first.get(2L, TimeUnit.SECONDS);
+                second.get(2L, TimeUnit.SECONDS);
+
+                verify(firstFuture, times(1)).cancel(true);
+            } finally {
+                executorService.shutdownNow();
+                AdjustBatchSizeFactory.stop(taskId);
+                setField(instance, "scheduledExecutor", oldScheduledExecutor);
+            }
         }
 
         @Test
@@ -174,7 +305,7 @@ class AdjustBatchSizeFactoryTest {
             map.put("task-foreach", manager);
 
             IncreaseRuleInstance ruleInstance = mock(IncreaseRuleInstance.class);
-            AdjustBatchSizeFactory.AdjustManager.NODE_LIST.put("node", ruleInstance);
+            manager.nodeList.put("node", ruleInstance);
             @SuppressWarnings("unchecked")
             Consumer<IncreaseRuleInstance> consumer = mock(Consumer.class);
 
@@ -249,4 +380,3 @@ class AdjustBatchSizeFactoryTest {
         }
     }
 }
-

--- a/iengine/iengine-app/src/test/java/io/tapdata/flow/engine/V2/node/hazelcast/data/batch/rule/IncreaseRuleInstanceTest.java
+++ b/iengine/iengine-app/src/test/java/io/tapdata/flow/engine/V2/node/hazelcast/data/batch/rule/IncreaseRuleInstanceTest.java
@@ -204,6 +204,15 @@ class IncreaseRuleInstanceTest {
         }
 
         @Test
+        void testExitWhenNotAliveEvenWithQueuedInfo() {
+            AdjustStage stage = mock(AdjustStage.class);
+            IncreaseRuleInstance instance = new IncreaseRuleInstance(new AtomicBoolean(false), "task1", 5000L, stage);
+            instance.queue.offer(new AdjustInfo("task1"));
+
+            Assertions.assertTrue(instance.exit());
+        }
+
+        @Test
         void testCheckOnceWithQueueIsNotEmpty() {
             ObjectId taskId = new ObjectId();
             AdjustStage stage = mock(AdjustStage.class);
@@ -416,4 +425,3 @@ class IncreaseRuleInstanceTest {
         }
     }
 }
-

--- a/iengine/iengine-app/src/test/java/io/tapdata/flow/engine/V2/task/impl/HazelcastTaskServiceTest.java
+++ b/iengine/iengine-app/src/test/java/io/tapdata/flow/engine/V2/task/impl/HazelcastTaskServiceTest.java
@@ -66,6 +66,8 @@ import io.tapdata.entity.schema.type.TapString;
 import io.tapdata.entity.utils.InstanceFactory;
 import io.tapdata.entity.utils.JsonParser;
 import io.tapdata.exception.TapCodeException;
+import io.tapdata.entity.logger.Log;
+import io.tapdata.flow.engine.V2.log.LogFactory;
 import io.tapdata.flow.engine.V2.node.hazelcast.HazelcastBaseNode;
 import io.tapdata.flow.engine.V2.node.hazelcast.data.HazelcastBlank;
 import io.tapdata.flow.engine.V2.node.hazelcast.data.HazelcastCacheTarget;
@@ -73,6 +75,7 @@ import io.tapdata.flow.engine.V2.node.hazelcast.data.HazelcastTaskSource;
 import io.tapdata.flow.engine.V2.node.hazelcast.data.HazelcastTaskSourceAndTarget;
 import io.tapdata.flow.engine.V2.node.hazelcast.data.HazelcastTaskTarget;
 import io.tapdata.flow.engine.V2.node.hazelcast.data.HazelcastVirtualTargetNode;
+import io.tapdata.flow.engine.V2.node.hazelcast.data.batch.AdjustBatchSizeFactory;
 import io.tapdata.flow.engine.V2.node.hazelcast.data.pdk.HazelcastPdkSourceAndTargetTableNode;
 import io.tapdata.flow.engine.V2.node.hazelcast.data.pdk.HazelcastSourceConcurrentReadDataNode;
 import io.tapdata.flow.engine.V2.node.hazelcast.data.pdk.HazelcastSourcePartitionReadDataNode;
@@ -94,6 +97,7 @@ import io.tapdata.flow.engine.V2.node.hazelcast.processor.HazelcastRenameTablePr
 import io.tapdata.flow.engine.V2.node.hazelcast.processor.HazelcastTypeFilterProcessorNode;
 import io.tapdata.flow.engine.V2.node.hazelcast.processor.HazelcastUnwindProcessNode;
 import io.tapdata.flow.engine.V2.node.hazelcast.processor.join.HazelcastJoinProcessor;
+import io.tapdata.flow.engine.V2.schedule.CpuMemoryScheduler;
 import io.tapdata.flow.engine.V2.task.TaskClient;
 import io.tapdata.flow.engine.V2.task.preview.TaskPreviewInstance;
 import io.tapdata.flow.engine.V2.task.preview.TaskPreviewService;
@@ -103,6 +107,7 @@ import io.tapdata.flow.engine.util.TaskDtoUtil;
 import io.tapdata.observable.logging.ObsLogger;
 import io.tapdata.observable.logging.ObsLoggerFactory;
 import io.tapdata.pdk.apis.context.TapConnectorContext;
+import io.tapdata.pdk.apis.entity.Capability;
 import io.tapdata.pdk.core.api.impl.JsonParserImpl;
 import io.tapdata.pdk.core.executor.ThreadFactory;
 import io.tapdata.schema.TapTableMap;
@@ -2180,6 +2185,111 @@ public class HazelcastTaskServiceTest {
                         eq(ConstructType.IMAP),
                         anyString()
                 );
+            }
+        }
+    }
+
+    @Nested
+    class StartTaskAutoIncrementalBatchSizeTest {
+        private static final String STREAM_READ_ONE_BY_ONE_FUNCTION = "stream_read_one_by_one_function";
+
+        private ClientMongoOperator clientMongoOperator;
+        private ConfigurationCenter configurationCenter;
+        private HazelcastInstance hazelcastInstance;
+        private JetService jetService;
+        private CpuMemoryScheduler cpuMemoryScheduler;
+        private HazelcastTaskService hazelcastTaskService;
+
+        @BeforeEach
+        void setUp() {
+            clientMongoOperator = mock(ClientMongoOperator.class);
+            configurationCenter = mock(ConfigurationCenter.class);
+            hazelcastInstance = mock(HazelcastInstance.class);
+            jetService = mock(JetService.class);
+            cpuMemoryScheduler = mock(CpuMemoryScheduler.class);
+            hazelcastTaskService = spy(new HazelcastTaskService(clientMongoOperator, clientMongoOperator));
+            ReflectionTestUtils.setField(hazelcastTaskService, "configurationCenter", configurationCenter);
+            ReflectionTestUtils.setField(hazelcastTaskService, "hazelcastInstance", hazelcastInstance);
+            ReflectionTestUtils.setField(hazelcastTaskService, "cpuMemoryScheduler", cpuMemoryScheduler);
+            when(hazelcastInstance.getJet()).thenReturn(jetService);
+        }
+
+        @Test
+        void testStartTaskDoesNotStartAdjustBatchSizeWhenDagHasNoOneByOneNode() {
+            startTaskAndVerifyAdjustBatchSize(List.of(Capability.create("stream_read_function")), true, false);
+        }
+
+        @Test
+        void testStartTaskStartsAdjustBatchSizeWhenDagHasOneByOneNode() {
+            startTaskAndVerifyAdjustBatchSize(List.of(Capability.create(STREAM_READ_ONE_BY_ONE_FUNCTION)), true, true);
+        }
+
+        private void startTaskAndVerifyAdjustBatchSize(List<Capability> capabilities, boolean expectedOpen, boolean expectAdjustStart) {
+            TaskDto taskDto = new TaskDto();
+            taskDto.setId(new ObjectId());
+            taskDto.setName("auto-adjust-task");
+            taskDto.setSyncType("migrate");
+            taskDto.setAutoIncrementalBatchSize(true);
+
+            Connections sourceConnection = new Connections();
+            sourceConnection.setId("source-connection");
+            sourceConnection.setPdkType("pdk");
+            sourceConnection.setPdkHash("source-pdk-hash");
+            DatabaseTypeEnum.DatabaseType sourceDatabaseType = new DatabaseTypeEnum.DatabaseType();
+            sourceDatabaseType.setCapabilities(capabilities);
+
+            TableNode sourceNode = new TableNode();
+            sourceNode.setId("source-node");
+            sourceNode.setConnectionId(sourceConnection.getId());
+            TableNode targetNode = new TableNode();
+            targetNode.setId("target-node");
+
+            Graph<Node, Edge> graph = new Graph<>();
+            graph.setNode(sourceNode.getId(), sourceNode);
+            graph.setNode(targetNode.getId(), targetNode);
+            graph.setEdge(sourceNode.getId(), targetNode.getId(), new Edge(sourceNode.getId(), targetNode.getId()));
+            taskDto.setDag(new DAG(graph));
+
+            ObsLoggerFactory obsLoggerFactory = mock(ObsLoggerFactory.class);
+            ObsLogger obsLogger = mock(ObsLogger.class);
+            LogFactory logFactory = mock(LogFactory.class);
+            Log log = mock(Log.class);
+            JetDag jetDag = mock(JetDag.class);
+            com.hazelcast.jet.core.DAG hazelcastDag = mock(com.hazelcast.jet.core.DAG.class);
+            Job job = mock(Job.class);
+            HazelcastTaskClient taskClient = mock(HazelcastTaskClient.class);
+
+            when(obsLoggerFactory.getObsLogger(taskDto)).thenReturn(obsLogger);
+            when(logFactory.getLog(taskDto)).thenReturn(log);
+            when(jetDag.getDag()).thenReturn(hazelcastDag);
+            when(jetService.newJob(eq(hazelcastDag), any(JobConfig.class))).thenReturn(job);
+            doNothing().when(hazelcastTaskService).cleanAllUnselectedError(eq(taskDto), eq(obsLogger));
+            doReturn(sourceConnection).when(hazelcastTaskService).getConnection(sourceConnection.getId());
+            doReturn(jetDag).when(hazelcastTaskService).task2HazelcastDAG(eq(taskDto), eq(true), any(Boolean.class));
+
+            try (
+                    MockedStatic<ObsLoggerFactory> obsLoggerFactoryMockedStatic = mockStatic(ObsLoggerFactory.class);
+                    MockedStatic<InstanceFactory> instanceFactoryMockedStatic = mockStatic(InstanceFactory.class);
+                    MockedStatic<AspectUtils> aspectUtilsMockedStatic = mockStatic(AspectUtils.class);
+                    MockedStatic<ConnectionUtil> connectionUtilMockedStatic = mockStatic(ConnectionUtil.class);
+                    MockedStatic<HazelcastTaskClient> taskClientMockedStatic = mockStatic(HazelcastTaskClient.class);
+                    MockedStatic<AdjustBatchSizeFactory> adjustBatchSizeFactoryMockedStatic = mockStatic(AdjustBatchSizeFactory.class)
+            ) {
+                obsLoggerFactoryMockedStatic.when(ObsLoggerFactory::getInstance).thenReturn(obsLoggerFactory);
+                instanceFactoryMockedStatic.when(() -> InstanceFactory.instance(LogFactory.class)).thenReturn(logFactory);
+                aspectUtilsMockedStatic.when(() -> AspectUtils.executeAspect(any())).thenReturn(null);
+                connectionUtilMockedStatic.when(() -> ConnectionUtil.getDatabaseType(eq(clientMongoOperator), eq(sourceConnection.getPdkHash()))).thenReturn(sourceDatabaseType);
+                taskClientMockedStatic.when(() -> HazelcastTaskClient.create(eq(taskDto), eq(clientMongoOperator), eq(clientMongoOperator), eq(configurationCenter), eq(hazelcastInstance))).thenReturn(taskClient);
+
+                TaskClient<TaskDto> actual = hazelcastTaskService.startTask(taskDto);
+
+                assertSame(taskClient, actual);
+                verify(hazelcastTaskService).task2HazelcastDAG(taskDto, true, expectedOpen);
+                if (expectAdjustStart) {
+                    adjustBatchSizeFactoryMockedStatic.verify(() -> AdjustBatchSizeFactory.start(taskDto.getId().toHexString(), obsLogger), times(1));
+                } else {
+                    adjustBatchSizeFactoryMockedStatic.verify(() -> AdjustBatchSizeFactory.start(anyString(), any(ObsLogger.class)), never());
+                }
             }
         }
     }


### PR DESCRIPTION
…ad when the task does not include nodes that implement stream_dead_one-by_one_function capability

Fixed issues with AI scanning such as "each manager's node list actually shares the same static Node_LIST", "using Ehcache's internal Concurrent HashMap instead of java.util.cncurrent.Concurrent HashMap", "disabled nodes do not need to register for automatic batch size adjustment", and "thread safety issues with concurrent startup tasks"