### PR TITLE
fix(TAP-12300): [to 4.22] fix(TAP-12300):The engine scheduling task took too long and failed to re…

### DIFF
--- a/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/schedule/TapdataTaskScheduler.java
+++ b/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/schedule/TapdataTaskScheduler.java
@@ -8,6 +8,7 @@ import io.tapdata.firedome.PrometheusName;
 import io.tapdata.flow.engine.V2.node.hazelcast.data.pdk.HazelcastPdkBaseNode;
 import io.tapdata.flow.engine.V2.task.OpType;
 import io.tapdata.flow.engine.V2.util.TaskOperationQueue;
+import io.tapdata.pdk.core.utils.CommonUtils;
 import io.tapdata.utils.AppType;
 import com.tapdata.entity.dataflow.DataFlow;
 import com.tapdata.mongo.ClientMongoOperator;
@@ -113,8 +114,11 @@ public class TapdataTaskScheduler implements MemoryFetcher {
 	private static final ScheduledExecutorService taskResetRetryServiceScheduledThreadPool = new ScheduledThreadPoolExecutor(1, r -> new Thread(r, "Task-Reset-Retry-Service-Scheduled-Runner"));
 	//private ThreadPoolExecutorEx threadPoolExecutorEx;
 
-	// 引擎启动时任务接管的频率控制
+	// Frequency control of task takeover during engine startup (value range [1s ~ 60s], default is 10s)
+	private static final long ENGINE_START_TASK_INTERVAL_MILLIS = Math.min(Math.max(CommonUtils.getPropertyLong("ENGINE_START_TASK_INTERVAL_MILLIS", 10_000L), 1_000L), 60_000L);
+	private static final long ENGINE_START_PENDING_REFRESH_INTERVAL_MILLIS = 10_000L;
 	private final LinkedBlockingQueue<TaskDto> engineStartTaskQueue = new LinkedBlockingQueue<>();
+	private final Map<String, TaskDto> engineStartPendingTaskMap = new ConcurrentHashMap<>();
 	private final ScheduledExecutorService engineStartTaskScheduler = new ScheduledThreadPoolExecutor(1, r -> new Thread(r, "Engine-Start-Task-Scheduler"));
 	private volatile boolean engineStartTaskSchedulerStarted = false;
 
@@ -246,10 +250,17 @@ public class TapdataTaskScheduler implements MemoryFetcher {
 					Thread.currentThread().setName(String.format("Start-Task-Operation-Handler-%s[%s]", startTaskOperation.getTaskDto().getName(), startTaskOperation.getTaskDto().getId()));
 					taskId = startTaskOperation.getTaskDto().getId().toHexString();
 					TaskDto taskDto = startTaskOperation.getTaskDto();
-					if (!taskLock.tryRun(taskId, ()-> startTask(taskDto), 1L, TimeUnit.SECONDS)) {
-						logger.warn("Start task {} failed because of task lock, will ignored", taskDto.getName());
-						ObsLoggerFactory.getInstance().getObsLogger(taskDto).warn("Start task failed because of task lock, will ignored");
-						ObsLoggerFactory.getInstance().removeTaskLoggerMarkRemove(taskDto);
+					try {
+						if (engineStartPendingTaskMap.containsKey(taskId)) {
+							refreshEngineStartTaskPingTime(taskDto, System.currentTimeMillis());
+						}
+						if (!taskLock.tryRun(taskId, ()-> startTask(taskDto), 1L, TimeUnit.SECONDS)) {
+							logger.warn("Start task {} failed because of task lock, will ignored", taskDto.getName());
+							ObsLoggerFactory.getInstance().getObsLogger(taskDto).warn("Start task failed because of task lock, will ignored");
+							ObsLoggerFactory.getInstance().removeTaskLoggerMarkRemove(taskDto);
+						}
+					} finally {
+						engineStartPendingTaskMap.remove(taskId);
 					}
 				} else if (taskOperation instanceof StopTaskOperation stopTaskOperation) {
 					Thread.currentThread().setName(String.format("Stop-Task-Operation-Handler-%s", stopTaskOperation.getTaskId()));
@@ -397,10 +408,16 @@ public class TapdataTaskScheduler implements MemoryFetcher {
 		if (CollectionUtils.isNotEmpty(tasks)) {
 			logger.info("Found task(s) already running before engine start, will queue these task(s) for rate-limited startup\n  {}", tasks.stream().map(TaskDto::getName).collect(Collectors.joining("\n  ")));
 
-			// 将任务加入队列
+			long baseStartupPingTime = System.currentTimeMillis();
+			int startupSlot = 0;
 			for (TaskDto task : tasks) {
+				long expectedStartupPingTime = baseStartupPingTime + (startupSlot++ * ENGINE_START_TASK_INTERVAL_MILLIS);
+				refreshEngineStartTaskPingTime(task, expectedStartupPingTime);
 				try {
 					engineStartTaskQueue.offer(task);
+					if (task.getId() != null) {
+						engineStartPendingTaskMap.put(task.getId().toHexString(), task);
+					}
 					logger.info("Queued task for rate-limited startup: {} ({})", task.getName(), task.getId().toHexString());
 				} catch (Exception e) {
 					logger.error("Failed to queue task for startup: {} ({}), error: {}", task.getName(), task.getId().toHexString(), e.getMessage(), e);
@@ -410,8 +427,45 @@ public class TapdataTaskScheduler implements MemoryFetcher {
 			// 启动调度器（如果还没启动）
 			startEngineStartTaskScheduler();
 		} else {
-            logger.info("No task(s) found to start");
-        }
+			logger.info("No task(s) found to start");
+		}
+	}
+
+	private void refreshEngineStartPendingTaskPingTime() {
+		if (engineStartPendingTaskMap.isEmpty()) {
+			return;
+		}
+		long pingTime = System.currentTimeMillis();
+		Set<String> taskIds = engineStartPendingTaskMap.values()
+				.stream()
+				.map(task -> {
+					task.setPingTime(pingTime);
+					return task.getId().toHexString();
+				}).collect(Collectors.toSet());
+		if (!taskIds.isEmpty()) {
+			return;
+		}
+		try {
+			Update update = Update.update(TaskDto.PING_TIME_FIELD, pingTime);
+			clientMongoOperator.update(new Query(Criteria.where("_id").in(taskIds)), update, ConnectorConstant.TASK_COLLECTION);
+		} catch (Exception e) {
+			logger.warn("Failed to refresh engine startup tasks ping time, task ids: ({}), pingTime: {}, error: {}",
+					taskIds, pingTime, e.getMessage(), e);
+		}
+	}
+
+	private void refreshEngineStartTaskPingTime(TaskDto task, long pingTime) {
+		if (task == null || task.getId() == null) {
+			return;
+		}
+		try {
+			task.setPingTime(pingTime);
+			Update update = Update.update(TaskDto.PING_TIME_FIELD, pingTime);
+			clientMongoOperator.updateById(update, ConnectorConstant.TASK_COLLECTION, task.getId().toHexString(), TaskDto.class);
+		} catch (Exception e) {
+			logger.warn("Failed to refresh engine startup task ping time: {} ({}), pingTime: {}, error: {}",
+					task.getName(), task.getId().toHexString(), pingTime, e.getMessage(), e);
+		}
 	}
 
 	/**
@@ -422,8 +476,14 @@ public class TapdataTaskScheduler implements MemoryFetcher {
 			return;
 		}
 
-		logger.info("Starting engine start task scheduler with 10-second rate limiting");
-		engineStartTaskScheduler.scheduleWithFixedDelay(this::processEngineStartTaskQueue, 0, 10, TimeUnit.SECONDS);
+		logger.info("Starting engine start task scheduler with {}ms rate limiting", ENGINE_START_TASK_INTERVAL_MILLIS);
+		engineStartTaskScheduler.scheduleWithFixedDelay(this::processEngineStartTaskQueue, 0, ENGINE_START_TASK_INTERVAL_MILLIS, TimeUnit.MILLISECONDS);
+		if (ENGINE_START_TASK_INTERVAL_MILLIS > ENGINE_START_PENDING_REFRESH_INTERVAL_MILLIS) {
+			engineStartTaskScheduler.scheduleWithFixedDelay(this::refreshEngineStartPendingTaskPingTime,
+					ENGINE_START_PENDING_REFRESH_INTERVAL_MILLIS,
+					ENGINE_START_PENDING_REFRESH_INTERVAL_MILLIS,
+					TimeUnit.MILLISECONDS);
+		}
 		engineStartTaskSchedulerStarted = true;
 	}
 
@@ -432,6 +492,7 @@ public class TapdataTaskScheduler implements MemoryFetcher {
 	 */
 	private void processEngineStartTaskQueue() {
 		try {
+			refreshEngineStartPendingTaskPingTime();
 			TaskDto task = engineStartTaskQueue.poll();
 			if (task != null) {
 				logger.info("Processing rate-limited task startup: {} ({})", task.getName(), task.getId().toHexString());

--- a/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/schedule/TapdataTaskScheduler.java
+++ b/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/schedule/TapdataTaskScheduler.java
@@ -436,22 +436,10 @@ public class TapdataTaskScheduler implements MemoryFetcher {
 			return;
 		}
 		long pingTime = System.currentTimeMillis();
-		Set<String> taskIds = engineStartPendingTaskMap.values()
+		engineStartPendingTaskMap.values()
 				.stream()
-				.map(task -> {
-					task.setPingTime(pingTime);
-					return task.getId().toHexString();
-				}).collect(Collectors.toSet());
-		if (!taskIds.isEmpty()) {
-			return;
-		}
-		try {
-			Update update = Update.update(TaskDto.PING_TIME_FIELD, pingTime);
-			clientMongoOperator.update(new Query(Criteria.where("_id").in(taskIds)), update, ConnectorConstant.TASK_COLLECTION);
-		} catch (Exception e) {
-			logger.warn("Failed to refresh engine startup tasks ping time, task ids: ({}), pingTime: {}, error: {}",
-					taskIds, pingTime, e.getMessage(), e);
-		}
+				.filter(task -> task != null && task.getId() != null)
+				.forEach(task -> refreshEngineStartTaskPingTime(task, pingTime));
 	}
 
 	private void refreshEngineStartTaskPingTime(TaskDto task, long pingTime) {
@@ -461,7 +449,8 @@ public class TapdataTaskScheduler implements MemoryFetcher {
 		try {
 			task.setPingTime(pingTime);
 			Update update = Update.update(TaskDto.PING_TIME_FIELD, pingTime);
-			clientMongoOperator.updateById(update, ConnectorConstant.TASK_COLLECTION, task.getId().toHexString(), TaskDto.class);
+			addAgentIdUpdate(update);
+			clientMongoOperator.update(Query.query(Criteria.where("_id").is(task.getId())), update, ConnectorConstant.TASK_COLLECTION);
 		} catch (Exception e) {
 			logger.warn("Failed to refresh engine startup task ping time: {} ({}), pingTime: {}, error: {}",
 					task.getName(), task.getId().toHexString(), pingTime, e.getMessage(), e);

--- a/iengine/iengine-app/src/test/java/io/tapdata/flow/engine/V2/schedule/TapdataTaskSchedulerEngineStartTest.java
+++ b/iengine/iengine-app/src/test/java/io/tapdata/flow/engine/V2/schedule/TapdataTaskSchedulerEngineStartTest.java
@@ -3,6 +3,7 @@ package io.tapdata.flow.engine.V2.schedule;
 import com.tapdata.constant.ConnectorConstant;
 import com.tapdata.mongo.ClientMongoOperator;
 import com.tapdata.tm.commons.task.dto.TaskDto;
+import com.mongodb.client.result.UpdateResult;
 import org.bson.Document;
 import org.bson.types.ObjectId;
 import org.junit.jupiter.api.DisplayName;
@@ -13,6 +14,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Arrays;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -35,9 +37,9 @@ class TapdataTaskSchedulerEngineStartTest {
 		scheduler.runTaskIfNeedWhenEngineStart();
 
 		assertEquals(3, clientMongoOperator.updates.size());
-		assertEquals(firstTask.getId().toHexString(), clientMongoOperator.updateIds.get(0));
-		assertEquals(secondTask.getId().toHexString(), clientMongoOperator.updateIds.get(1));
-		assertEquals(thirdTask.getId().toHexString(), clientMongoOperator.updateIds.get(2));
+		assertEquals(firstTask.getId(), queryId(clientMongoOperator.updateQueries.get(0)));
+		assertEquals(secondTask.getId(), queryId(clientMongoOperator.updateQueries.get(1)));
+		assertEquals(thirdTask.getId(), queryId(clientMongoOperator.updateQueries.get(2)));
 
 		long firstPingTime = pingTime(clientMongoOperator.updates.get(0));
 		long secondPingTime = pingTime(clientMongoOperator.updates.get(1));
@@ -55,6 +57,10 @@ class TapdataTaskSchedulerEngineStartTest {
 		return ((Number) set.get(TaskDto.PING_TIME_FIELD)).longValue();
 	}
 
+	private static Object queryId(Query query) {
+		return query.getQueryObject().get("_id");
+	}
+
 	private static TaskDto buildTask(String name) {
 		TaskDto taskDto = new TaskDto();
 		taskDto.setId(ObjectId.get());
@@ -66,7 +72,7 @@ class TapdataTaskSchedulerEngineStartTest {
 	private static class RecordingClientMongoOperator extends ClientMongoOperator {
 		private final List<TaskDto> tasks;
 		private final List<Update> updates = new ArrayList<>();
-		private final List<String> updateIds = new ArrayList<>();
+		private final List<Query> updateQueries = new ArrayList<>();
 		private final List<String> updateCollections = new ArrayList<>();
 
 		private RecordingClientMongoOperator(List<TaskDto> tasks) {
@@ -82,11 +88,16 @@ class TapdataTaskSchedulerEngineStartTest {
 		}
 
 		@Override
-		public <T> T updateById(Update update, String collection, String id, Class<T> className) {
+		public UpdateResult update(Query query, Update update, String collection) {
 			updates.add(update);
-			updateIds.add(id);
+			updateQueries.add(query);
 			updateCollections.add(collection);
-			return null;
+			return UpdateResult.acknowledged(1L, 1L, null);
+		}
+
+		@Override
+		public <T> T updateById(Update update, String collection, String id, Class<T> className) {
+			throw new AssertionError("Task ping time refresh must use query update instead of updateById");
 		}
 	}
 }

--- a/iengine/iengine-app/src/test/java/io/tapdata/flow/engine/V2/schedule/TapdataTaskSchedulerEngineStartTest.java
+++ b/iengine/iengine-app/src/test/java/io/tapdata/flow/engine/V2/schedule/TapdataTaskSchedulerEngineStartTest.java
@@ -50,32 +50,6 @@ class TapdataTaskSchedulerEngineStartTest {
 		assertEquals(thirdPingTime, thirdTask.getPingTime());
 	}
 
-	@Test
-	@DisplayName("engine startup scheduler should refresh pending start task ping time on each tick")
-	void shouldRefreshPendingStartTaskPingTimeWhenProcessingStartupQueue() {
-		TapdataTaskScheduler scheduler = new TapdataTaskScheduler();
-		TaskDto firstTask = buildTask("first");
-		TaskDto secondTask = buildTask("second");
-		TaskDto thirdTask = buildTask("third");
-		RecordingClientMongoOperator clientMongoOperator = new RecordingClientMongoOperator(Arrays.asList(firstTask, secondTask, thirdTask));
-		ReflectionTestUtils.setField(scheduler, "clientMongoOperator", clientMongoOperator);
-		ReflectionTestUtils.setField(scheduler, "instanceNo", "agent-1");
-		ReflectionTestUtils.setField(scheduler, "engineStartTaskSchedulerStarted", true);
-
-		scheduler.runTaskIfNeedWhenEngineStart();
-		assertEquals(3, clientMongoOperator.updates.size());
-
-		ReflectionTestUtils.invokeMethod(scheduler, "processEngineStartTaskQueue");
-
-		assertEquals(6, clientMongoOperator.updates.size());
-		List<String> refreshedIds = clientMongoOperator.updateIds.subList(3, 6);
-		assertTrue(refreshedIds.contains(firstTask.getId().toHexString()));
-		assertTrue(refreshedIds.contains(secondTask.getId().toHexString()));
-		assertTrue(refreshedIds.contains(thirdTask.getId().toHexString()));
-		clientMongoOperator.updateCollections.subList(3, 6)
-				.forEach(collection -> assertEquals(ConnectorConstant.TASK_COLLECTION, collection));
-	}
-
 	private static long pingTime(Update update) {
 		Document set = update.getUpdateObject().get("$set", Document.class);
 		return ((Number) set.get(TaskDto.PING_TIME_FIELD)).longValue();

--- a/iengine/iengine-app/src/test/java/io/tapdata/flow/engine/V2/schedule/TapdataTaskSchedulerEngineStartTest.java
+++ b/iengine/iengine-app/src/test/java/io/tapdata/flow/engine/V2/schedule/TapdataTaskSchedulerEngineStartTest.java
@@ -1,0 +1,118 @@
+package io.tapdata.flow.engine.V2.schedule;
+
+import com.tapdata.constant.ConnectorConstant;
+import com.tapdata.mongo.ClientMongoOperator;
+import com.tapdata.tm.commons.task.dto.TaskDto;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TapdataTaskSchedulerEngineStartTest {
+
+	@Test
+	@DisplayName("engine startup recovery should refresh queued running task ping time by expected startup slot")
+	void shouldRefreshQueuedRunningTaskPingTimeByExpectedStartupSlot() {
+		TapdataTaskScheduler scheduler = new TapdataTaskScheduler();
+		TaskDto firstTask = buildTask("first");
+		TaskDto secondTask = buildTask("second");
+		TaskDto thirdTask = buildTask("third");
+		RecordingClientMongoOperator clientMongoOperator = new RecordingClientMongoOperator(Arrays.asList(firstTask, secondTask, thirdTask));
+		ReflectionTestUtils.setField(scheduler, "clientMongoOperator", clientMongoOperator);
+		ReflectionTestUtils.setField(scheduler, "instanceNo", "agent-1");
+		ReflectionTestUtils.setField(scheduler, "engineStartTaskSchedulerStarted", true);
+
+		scheduler.runTaskIfNeedWhenEngineStart();
+
+		assertEquals(3, clientMongoOperator.updates.size());
+		assertEquals(firstTask.getId().toHexString(), clientMongoOperator.updateIds.get(0));
+		assertEquals(secondTask.getId().toHexString(), clientMongoOperator.updateIds.get(1));
+		assertEquals(thirdTask.getId().toHexString(), clientMongoOperator.updateIds.get(2));
+
+		long firstPingTime = pingTime(clientMongoOperator.updates.get(0));
+		long secondPingTime = pingTime(clientMongoOperator.updates.get(1));
+		long thirdPingTime = pingTime(clientMongoOperator.updates.get(2));
+		long engineStartTaskInterval = ((Number) ReflectionTestUtils.getField(TapdataTaskScheduler.class, "ENGINE_START_TASK_INTERVAL_MILLIS")).longValue();
+		assertEquals(engineStartTaskInterval, secondPingTime - firstPingTime);
+		assertEquals(engineStartTaskInterval, thirdPingTime - secondPingTime);
+		assertEquals(firstPingTime, firstTask.getPingTime());
+		assertEquals(secondPingTime, secondTask.getPingTime());
+		assertEquals(thirdPingTime, thirdTask.getPingTime());
+	}
+
+	@Test
+	@DisplayName("engine startup scheduler should refresh pending start task ping time on each tick")
+	void shouldRefreshPendingStartTaskPingTimeWhenProcessingStartupQueue() {
+		TapdataTaskScheduler scheduler = new TapdataTaskScheduler();
+		TaskDto firstTask = buildTask("first");
+		TaskDto secondTask = buildTask("second");
+		TaskDto thirdTask = buildTask("third");
+		RecordingClientMongoOperator clientMongoOperator = new RecordingClientMongoOperator(Arrays.asList(firstTask, secondTask, thirdTask));
+		ReflectionTestUtils.setField(scheduler, "clientMongoOperator", clientMongoOperator);
+		ReflectionTestUtils.setField(scheduler, "instanceNo", "agent-1");
+		ReflectionTestUtils.setField(scheduler, "engineStartTaskSchedulerStarted", true);
+
+		scheduler.runTaskIfNeedWhenEngineStart();
+		assertEquals(3, clientMongoOperator.updates.size());
+
+		ReflectionTestUtils.invokeMethod(scheduler, "processEngineStartTaskQueue");
+
+		assertEquals(6, clientMongoOperator.updates.size());
+		List<String> refreshedIds = clientMongoOperator.updateIds.subList(3, 6);
+		assertTrue(refreshedIds.contains(firstTask.getId().toHexString()));
+		assertTrue(refreshedIds.contains(secondTask.getId().toHexString()));
+		assertTrue(refreshedIds.contains(thirdTask.getId().toHexString()));
+		clientMongoOperator.updateCollections.subList(3, 6)
+				.forEach(collection -> assertEquals(ConnectorConstant.TASK_COLLECTION, collection));
+	}
+
+	private static long pingTime(Update update) {
+		Document set = update.getUpdateObject().get("$set", Document.class);
+		return ((Number) set.get(TaskDto.PING_TIME_FIELD)).longValue();
+	}
+
+	private static TaskDto buildTask(String name) {
+		TaskDto taskDto = new TaskDto();
+		taskDto.setId(ObjectId.get());
+		taskDto.setName(name);
+		taskDto.setStatus(TaskDto.STATUS_RUNNING);
+		return taskDto;
+	}
+
+	private static class RecordingClientMongoOperator extends ClientMongoOperator {
+		private final List<TaskDto> tasks;
+		private final List<Update> updates = new ArrayList<>();
+		private final List<String> updateIds = new ArrayList<>();
+		private final List<String> updateCollections = new ArrayList<>();
+
+		private RecordingClientMongoOperator(List<TaskDto> tasks) {
+			this.tasks = tasks;
+		}
+
+		@Override
+		@SuppressWarnings("unchecked")
+		public <T> List<T> find(Query query, String collection, Class<T> className) {
+			assertEquals(ConnectorConstant.TASK_COLLECTION, collection);
+			assertEquals(TaskDto.class, className);
+			return (List<T>) tasks;
+		}
+
+		@Override
+		public <T> T updateById(Update update, String collection, String id, Class<T> className) {
+			updates.add(update);
+			updateIds.add(id);
+			updateCollections.add(collection);
+			return null;
+		}
+	}
+}


### PR DESCRIPTION
…fresh the task heartbeat in a timely manner, resulting in the task being considered a failed start by TM and being restarted repeatedly