### PR TITLE
fix(TAP-12300): 【to 4.22】Some issues detected in the PR review scan of “The engine scheduling task took too long and failed to re...”

### DIFF
--- a/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/schedule/TapdataTaskScheduler.java
+++ b/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/schedule/TapdataTaskScheduler.java
@@ -119,7 +119,7 @@ public class TapdataTaskScheduler implements MemoryFetcher {
 	private static final long ENGINE_START_PENDING_REFRESH_INTERVAL_MILLIS = 10_000L;
 	private final LinkedBlockingQueue<TaskDto> engineStartTaskQueue = new LinkedBlockingQueue<>();
 	private final Map<String, TaskDto> engineStartPendingTaskMap = new ConcurrentHashMap<>();
-	private final ScheduledExecutorService engineStartTaskScheduler = new ScheduledThreadPoolExecutor(1, r -> new Thread(r, "Engine-Start-Task-Scheduler"));
+	private final ScheduledExecutorService engineStartTaskScheduler = new ScheduledThreadPoolExecutor(2, r -> new Thread(r, "Engine-Start-Task-Scheduler"));
 	private volatile boolean engineStartTaskSchedulerStarted = false;
 
 	// TAP-12028: 常驻低频对账兜底 + WS(重)连即拉取，确保分配给本引擎(agentId=instanceNo)的
@@ -408,16 +408,11 @@ public class TapdataTaskScheduler implements MemoryFetcher {
 		if (CollectionUtils.isNotEmpty(tasks)) {
 			logger.info("Found task(s) already running before engine start, will queue these task(s) for rate-limited startup\n  {}", tasks.stream().map(TaskDto::getName).collect(Collectors.joining("\n  ")));
 
-			long baseStartupPingTime = System.currentTimeMillis();
-			int startupSlot = 0;
 			for (TaskDto task : tasks) {
-				long expectedStartupPingTime = baseStartupPingTime + (startupSlot++ * ENGINE_START_TASK_INTERVAL_MILLIS);
-				refreshEngineStartTaskPingTime(task, expectedStartupPingTime);
+				refreshEngineStartTaskPingTime(task, System.currentTimeMillis());
 				try {
+					engineStartPendingTaskMap.put(task.getId().toHexString(), task);
 					engineStartTaskQueue.offer(task);
-					if (task.getId() != null) {
-						engineStartPendingTaskMap.put(task.getId().toHexString(), task);
-					}
 					logger.info("Queued task for rate-limited startup: {} ({})", task.getName(), task.getId().toHexString());
 				} catch (Exception e) {
 					logger.error("Failed to queue task for startup: {} ({}), error: {}", task.getName(), task.getId().toHexString(), e.getMessage(), e);
@@ -449,7 +444,6 @@ public class TapdataTaskScheduler implements MemoryFetcher {
 		try {
 			task.setPingTime(pingTime);
 			Update update = Update.update(TaskDto.PING_TIME_FIELD, pingTime);
-			addAgentIdUpdate(update);
 			clientMongoOperator.update(Query.query(Criteria.where("_id").is(task.getId())), update, ConnectorConstant.TASK_COLLECTION);
 		} catch (Exception e) {
 			logger.warn("Failed to refresh engine startup task ping time: {} ({}), pingTime: {}, error: {}",
@@ -467,12 +461,7 @@ public class TapdataTaskScheduler implements MemoryFetcher {
 
 		logger.info("Starting engine start task scheduler with {}ms rate limiting", ENGINE_START_TASK_INTERVAL_MILLIS);
 		engineStartTaskScheduler.scheduleWithFixedDelay(this::processEngineStartTaskQueue, 0, ENGINE_START_TASK_INTERVAL_MILLIS, TimeUnit.MILLISECONDS);
-		if (ENGINE_START_TASK_INTERVAL_MILLIS > ENGINE_START_PENDING_REFRESH_INTERVAL_MILLIS) {
-			engineStartTaskScheduler.scheduleWithFixedDelay(this::refreshEngineStartPendingTaskPingTime,
-					ENGINE_START_PENDING_REFRESH_INTERVAL_MILLIS,
-					ENGINE_START_PENDING_REFRESH_INTERVAL_MILLIS,
-					TimeUnit.MILLISECONDS);
-		}
+		engineStartTaskScheduler.scheduleWithFixedDelay(this::refreshEngineStartPendingTaskPingTime, ENGINE_START_PENDING_REFRESH_INTERVAL_MILLIS, ENGINE_START_PENDING_REFRESH_INTERVAL_MILLIS, TimeUnit.MILLISECONDS);
 		engineStartTaskSchedulerStarted = true;
 	}
 
@@ -481,7 +470,6 @@ public class TapdataTaskScheduler implements MemoryFetcher {
 	 */
 	private void processEngineStartTaskQueue() {
 		try {
-			refreshEngineStartPendingTaskPingTime();
 			TaskDto task = engineStartTaskQueue.poll();
 			if (task != null) {
 				logger.info("Processing rate-limited task startup: {} ({})", task.getName(), task.getId().toHexString());

--- a/iengine/iengine-app/src/test/java/io/tapdata/flow/engine/V2/schedule/TapdataTaskSchedulerEngineStartTest.java
+++ b/iengine/iengine-app/src/test/java/io/tapdata/flow/engine/V2/schedule/TapdataTaskSchedulerEngineStartTest.java
@@ -44,9 +44,6 @@ class TapdataTaskSchedulerEngineStartTest {
 		long firstPingTime = pingTime(clientMongoOperator.updates.get(0));
 		long secondPingTime = pingTime(clientMongoOperator.updates.get(1));
 		long thirdPingTime = pingTime(clientMongoOperator.updates.get(2));
-		long engineStartTaskInterval = ((Number) ReflectionTestUtils.getField(TapdataTaskScheduler.class, "ENGINE_START_TASK_INTERVAL_MILLIS")).longValue();
-		assertEquals(engineStartTaskInterval, secondPingTime - firstPingTime);
-		assertEquals(engineStartTaskInterval, thirdPingTime - secondPingTime);
 		assertEquals(firstPingTime, firstTask.getPingTime());
 		assertEquals(secondPingTime, secondTask.getPingTime());
 		assertEquals(thirdPingTime, thirdTask.getPingTime());

--- a/iengine/iengine-app/src/test/java/io/tapdata/flow/engine/V2/schedule/TapdataTaskSchedulerTest.java
+++ b/iengine/iengine-app/src/test/java/io/tapdata/flow/engine/V2/schedule/TapdataTaskSchedulerTest.java
@@ -23,6 +23,7 @@ import io.tapdata.observable.logging.ObsLoggerFactory;
 import io.tapdata.utils.AppType;
 import io.tapdata.utils.UnitTestUtils;
 import org.apache.logging.log4j.Logger;
+import org.bson.Document;
 import org.bson.types.ObjectId;
 import org.junit.jupiter.api.*;
 import org.mockito.MockedStatic;
@@ -887,6 +888,243 @@ public class TapdataTaskSchedulerTest {
 			verify(logger, times(1)).info(anyString(), anyString(), anyString());
 			verify(logger, times(1)).warn(anyString(), anyString(), anyString(), any(Exception.class));
 			verify(taskOpRespDto, times(0)).getSuccessIds();
+		}
+	}
+
+	@Nested
+	@DisplayName("Method refreshEngineStartTaskPingTime test")
+	class RefreshEngineStartTaskPingTimeTest {
+		private TapdataTaskScheduler scheduler;
+		private ClientMongoOperator clientMongoOperator;
+		private Logger logger;
+
+		@BeforeEach
+		void setUp() {
+			scheduler = new TapdataTaskScheduler();
+			clientMongoOperator = mock(ClientMongoOperator.class);
+			logger = mock(Logger.class);
+			ReflectionTestUtils.setField(scheduler, "clientMongoOperator", clientMongoOperator);
+			ReflectionTestUtils.setField(scheduler, "logger", logger);
+		}
+
+		@Test
+		@DisplayName("refreshEngineStartTaskPingTime with null task should return immediately")
+		void testWithNullTask() {
+			ReflectionTestUtils.invokeMethod(scheduler, "refreshEngineStartTaskPingTime", null, System.currentTimeMillis());
+			verifyNoInteractions(clientMongoOperator);
+		}
+
+		@Test
+		@DisplayName("refreshEngineStartTaskPingTime with task id null should return immediately")
+		void testWithNullTaskId() {
+			TaskDto taskDto = new TaskDto();
+			taskDto.setId(null);
+			taskDto.setName("test-task");
+
+			ReflectionTestUtils.invokeMethod(scheduler, "refreshEngineStartTaskPingTime", taskDto, System.currentTimeMillis());
+			verifyNoInteractions(clientMongoOperator);
+		}
+
+		@Test
+		@DisplayName("refreshEngineStartTaskPingTime normal case should update ping time")
+		void testNormalCase() {
+			ObjectId taskId = new ObjectId();
+			TaskDto taskDto = new TaskDto();
+			taskDto.setId(taskId);
+			taskDto.setName("test-task");
+			long pingTime = System.currentTimeMillis();
+
+			ReflectionTestUtils.invokeMethod(scheduler, "refreshEngineStartTaskPingTime", taskDto, pingTime);
+
+			assertEquals(pingTime, taskDto.getPingTime());
+			verify(clientMongoOperator, times(1)).update(
+					argThat(query -> {
+						Object id = query.getQueryObject().get("_id");
+						return taskId.equals(id);
+					}),
+					argThat(update -> {
+						Document set = update.getUpdateObject().get("$set", Document.class);
+						return set != null && pingTime == ((Number) set.get(TaskDto.PING_TIME_FIELD)).longValue();
+					}),
+					eq(ConnectorConstant.TASK_COLLECTION)
+			);
+		}
+
+		@Test
+		@DisplayName("refreshEngineStartTaskPingTime when clientMongoOperator throws exception should catch and log")
+		void testWhenClientMongoOperatorThrowsException() {
+			ObjectId taskId = new ObjectId();
+			TaskDto taskDto = new TaskDto();
+			taskDto.setId(taskId);
+			taskDto.setName("test-task");
+			long pingTime = System.currentTimeMillis();
+
+			RuntimeException exception = new RuntimeException("DB connection error");
+			when(clientMongoOperator.update(any(Query.class), any(Update.class), anyString())).thenThrow(exception);
+
+			assertDoesNotThrow(() -> ReflectionTestUtils.invokeMethod(scheduler, "refreshEngineStartTaskPingTime", taskDto, pingTime));
+			assertEquals(pingTime, taskDto.getPingTime());
+			verify(logger, times(1)).warn(
+					contains("Failed to refresh engine startup task ping time"),
+					eq(taskDto.getName()),
+					eq(taskId.toHexString()),
+					eq(pingTime),
+					eq(exception.getMessage()),
+					eq(exception)
+			);
+		}
+	}
+
+	@Nested
+	@DisplayName("Method refreshEngineStartPendingTaskPingTime test")
+	class RefreshEngineStartPendingTaskPingTimeTest {
+		private TapdataTaskScheduler scheduler;
+		private ClientMongoOperator clientMongoOperator;
+		private Logger logger;
+
+		@BeforeEach
+		void setUp() {
+			scheduler = new TapdataTaskScheduler();
+			clientMongoOperator = mock(ClientMongoOperator.class);
+			logger = mock(Logger.class);
+			ReflectionTestUtils.setField(scheduler, "clientMongoOperator", clientMongoOperator);
+			ReflectionTestUtils.setField(scheduler, "logger", logger);
+		}
+
+		@Test
+		@DisplayName("refreshEngineStartPendingTaskPingTime with empty map should return immediately")
+		void testWithEmptyMap() {
+			Map<String, TaskDto> emptyMap = new ConcurrentHashMap<>();
+			ReflectionTestUtils.setField(scheduler, "engineStartPendingTaskMap", emptyMap);
+
+			ReflectionTestUtils.invokeMethod(scheduler, "refreshEngineStartPendingTaskPingTime");
+			verifyNoInteractions(clientMongoOperator);
+		}
+
+		@Test
+		@DisplayName("refreshEngineStartPendingTaskPingTime with multiple valid tasks should update all")
+		void testWithMultipleValidTasks() {
+			ObjectId taskId1 = new ObjectId();
+			TaskDto task1 = new TaskDto();
+			task1.setId(taskId1);
+			task1.setName("task-1");
+
+			ObjectId taskId2 = new ObjectId();
+			TaskDto task2 = new TaskDto();
+			task2.setId(taskId2);
+			task2.setName("task-2");
+
+			ObjectId taskId3 = new ObjectId();
+			TaskDto task3 = new TaskDto();
+			task3.setId(taskId3);
+			task3.setName("task-3");
+
+			Map<String, TaskDto> pendingMap = new ConcurrentHashMap<>();
+			pendingMap.put(taskId1.toHexString(), task1);
+			pendingMap.put(taskId2.toHexString(), task2);
+			pendingMap.put(taskId3.toHexString(), task3);
+			ReflectionTestUtils.setField(scheduler, "engineStartPendingTaskMap", pendingMap);
+
+			ReflectionTestUtils.invokeMethod(scheduler, "refreshEngineStartPendingTaskPingTime");
+
+			verify(clientMongoOperator, times(3)).update(any(Query.class), any(Update.class), eq(ConnectorConstant.TASK_COLLECTION));
+
+			long pingTime1 = task1.getPingTime();
+			long pingTime2 = task2.getPingTime();
+			long pingTime3 = task3.getPingTime();
+			assertEquals(pingTime1, pingTime2);
+			assertEquals(pingTime2, pingTime3);
+			assertTrue(pingTime1 > 0);
+		}
+
+		@Test
+		@DisplayName("refreshEngineStartPendingTaskPingTime with null id tasks should filter them")
+		void testWithInvalidTasksShouldFilter() {
+			ObjectId validTaskId = new ObjectId();
+			TaskDto validTask = new TaskDto();
+			validTask.setId(validTaskId);
+			validTask.setName("valid-task");
+
+			TaskDto nullIdTask = new TaskDto();
+			nullIdTask.setId(null);
+			nullIdTask.setName("null-id-task");
+
+			Map<String, TaskDto> pendingMap = new ConcurrentHashMap<>();
+			pendingMap.put(validTaskId.toHexString(), validTask);
+			pendingMap.put("null-id-key", nullIdTask);
+			ReflectionTestUtils.setField(scheduler, "engineStartPendingTaskMap", pendingMap);
+
+			ReflectionTestUtils.invokeMethod(scheduler, "refreshEngineStartPendingTaskPingTime");
+
+			verify(clientMongoOperator, times(1)).update(
+					argThat(query -> validTaskId.equals(query.getQueryObject().get("_id"))),
+					any(Update.class),
+					eq(ConnectorConstant.TASK_COLLECTION)
+			);
+			assertTrue(validTask.getPingTime() > 0);
+		}
+
+		@Test
+		@DisplayName("refreshEngineStartPendingTaskPingTime should use same ping time for all tasks")
+		void testSamePingTimeForAllTasks() {
+			int taskCount = 5;
+			Map<String, TaskDto> pendingMap = new ConcurrentHashMap<>();
+			List<TaskDto> tasks = new ArrayList<>();
+			for (int i = 0; i < taskCount; i++) {
+				ObjectId taskId = new ObjectId();
+				TaskDto task = new TaskDto();
+				task.setId(taskId);
+				task.setName("task-" + i);
+				pendingMap.put(taskId.toHexString(), task);
+				tasks.add(task);
+			}
+			ReflectionTestUtils.setField(scheduler, "engineStartPendingTaskMap", pendingMap);
+
+			ReflectionTestUtils.invokeMethod(scheduler, "refreshEngineStartPendingTaskPingTime");
+
+			long expectedPingTime = tasks.get(0).getPingTime();
+			for (TaskDto task : tasks) {
+				assertEquals(expectedPingTime, task.getPingTime());
+			}
+			verify(clientMongoOperator, times(taskCount)).update(any(Query.class), any(Update.class), eq(ConnectorConstant.TASK_COLLECTION));
+		}
+
+		@Test
+		@DisplayName("refreshEngineStartPendingTaskPingTime when some updates throw exception should continue and log")
+		void testWhenSomeUpdatesThrowException() {
+			ObjectId taskId1 = new ObjectId();
+			TaskDto task1 = new TaskDto();
+			task1.setId(taskId1);
+			task1.setName("task-1");
+
+			ObjectId taskId2 = new ObjectId();
+			TaskDto task2 = new TaskDto();
+			task2.setId(taskId2);
+			task2.setName("task-2");
+
+			Map<String, TaskDto> pendingMap = new ConcurrentHashMap<>();
+			pendingMap.put(taskId1.toHexString(), task1);
+			pendingMap.put(taskId2.toHexString(), task2);
+			ReflectionTestUtils.setField(scheduler, "engineStartPendingTaskMap", pendingMap);
+
+			RuntimeException exception = new RuntimeException("DB error");
+			when(clientMongoOperator.update(any(Query.class), any(Update.class), eq(ConnectorConstant.TASK_COLLECTION)))
+					.thenThrow(exception)
+					.thenReturn(mock(com.mongodb.client.result.UpdateResult.class));
+
+			assertDoesNotThrow(() -> ReflectionTestUtils.invokeMethod(scheduler, "refreshEngineStartPendingTaskPingTime"));
+
+			verify(clientMongoOperator, times(2)).update(any(Query.class), any(Update.class), eq(ConnectorConstant.TASK_COLLECTION));
+			verify(logger, times(1)).warn(
+					contains("Failed to refresh engine startup task ping time"),
+					eq(task1.getName()),
+					eq(taskId1.toHexString()),
+					any(Long.class),
+					eq(exception.getMessage()),
+					eq(exception)
+			);
+			assertTrue(task1.getPingTime() > 0);
+			assertTrue(task2.getPingTime() > 0);
 		}
 	}
 


### PR DESCRIPTION
…fresh the task heartbeat in a timely manner, resulting in the task being considered a failed start by TM and being restarted repeatedly

What is the problem
After the engine restarts, tasks that were originally running in TM will be taken over and restarted by the current engine. When there are a large number of tasks, some tasks are still waiting in the startup recovery queue, but TM issues a new start, causing these tasks to repeatedly enter the startup process, manifested as "tasks repeatedly restarting after the engine restarts".
What is the reason?
Engine startup recovery is a flow limiting process that only processes some tasks at once, and tasks at the end of the queue may wait for a long time. During the waiting period, although these tasks have been taken over by the current engine, they have not yet entered the running state for heartbeat reporting, and the original logic has not continuously refreshed their pingTime. When TM's engine RestartNeedStartTask saw that the pingTime of these running tasks had timed out, it mistakenly judged that the tasks needed to be restarted, so it issued a start again.
What is the repair method
Maintain a collection of pending start tasks during the engine startup recovery process. When a task enters the recovery queue, refresh the pingTime once, wait for the pingTime of pending tasks to be refreshed periodically during startup, and refresh again before actually processing the start operation; After the start operation of the task is completed, it is removed from the pending set. In this way, TM will not misjudge these tasks as expired heartbeats within the recovery window, and will not repeatedly issue starts.