### PR TITLE
ws/vault uri var format

### DIFF
--- a/manager/tm/src/main/java/com/tapdata/tm/group/handler/ResourceHandler.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/group/handler/ResourceHandler.java
@@ -557,6 +557,24 @@ public interface ResourceHandler {
      */
     static void injectVaultSecretsToConnection(DataSourceConnectionDto conn,
             Map<String, String> vaultSecrets, DataSourceDefinitionDto definition) {
+        injectVaultSecretsToConnection(conn, vaultSecrets, definition, null);
+    }
+
+    /**
+     * 同上，但允许调用方传入已经算好的 schema BFS 结果（{@code configPath -> apiServerKey}）。
+     *
+     * <p>BFS 是 {@code definition} 的纯函数，而一次导入里同类型的连接共用同一份 definition，
+     * 逐条重跑纯属浪费。批量调用方（{@code GroupInfoService.injectVaultSecrets}）已经建好了
+     * {@code pdkHash -> definition} 的 map，顺手按同一把 key 缓存 BFS 结果即可。
+     *
+     * <p>⚠ 记忆化的是**原始 BFS 结果**、不是过滤后的 {@code apiKeyToConfigPath}：
+     * 「schema 里没有 connection.properties」那条告警判的是原始结果为空，而过滤后为空
+     * 是另一回事（schema 有内容、只是没有 vault 关心的键）。缓存错一层，告警就会对
+     * 一批本来正常的连接误报。三参版传 {@code null} ⇒ 行为与从前逐字相同。
+     */
+    static void injectVaultSecretsToConnection(DataSourceConnectionDto conn,
+            Map<String, String> vaultSecrets, DataSourceDefinitionDto definition,
+            Map<String, String> memoizedPathToApiKey) {
         if (conn == null || MapUtils.isEmpty(vaultSecrets)) {
             return;
         }
@@ -575,7 +593,9 @@ public interface ResourceHandler {
         // 使用 BFS 工具方法获取 apiServerKey -> configPath 映射
         Map<String, String> apiKeyToConfigPath = new LinkedHashMap<>();
         if (definition != null) {
-            Map<String, String> pathToApiKey = buildConfigPathToApiKeyMap(definition);
+            Map<String, String> pathToApiKey = memoizedPathToApiKey != null
+                    ? memoizedPathToApiKey
+                    : buildConfigPathToApiKeyMap(definition);
             if (pathToApiKey.isEmpty()) {
                 log.warn("Vault inject: definition schema missing 'connection.properties' for connection '{}', pdkType={}",
                         connectionName, conn.getDatabase_type());

--- a/manager/tm/src/main/java/com/tapdata/tm/group/handler/ResourceHandler.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/group/handler/ResourceHandler.java
@@ -532,12 +532,28 @@ public interface ResourceHandler {
     /**
      * maskSensitiveConfigFields 的逆操作：将 vault.json 中的敏感信息注入连接的 config。
      *
-     * 注入优先级：
-     * 1. password：直接查找 {connName}_password，按 schema 路径写入
-     * 2. uri：查找 {connName}_uri
-     *    - 若 schema 中存在 database_uri（如 MongoDB）→ 整体直接写入 uri 字段
-     *    - 否则 → 按 "host:port/username" 格式解析，拆分写入 host/port/username
-     * 3. url（仅当 vault 中无 uri 时）：查找 {connName}_url，同样按 "host:port/username" 解析写入
+     * <p><b>注入优先级——六级，逐级下降，命中即停。</b> 这条链在三处各有一份表述
+     * （本注释、worker 的 {@code generate-vault.sh} 里两处），三处必须对得上：
+     * 漂开一处就够让人把 GitHub 那边配错，而配错的表现是「部署报绿、连接连的是别的东西」。
+     *
+     * <ol>
+     *   <li><b>dsn</b>（格式 3）：{@code {conn}_DSN}（Variables）+ {@code {conn}_PASSWORD}（Secrets）。
+     *       schema 含 {@code database_uri}（MongoDB）→ 密码 splice 回 userinfo 后**整串直写**；
+     *       否则（JDBC）→ 归一化后拆成 host/port/username/<b>database_name</b>。
+     *       <b>只认精确连接名</b>，不回落（回落＝连错库＝数据事故，[ADR-0036] D4）。</li>
+     *   <li><b>uri</b>（格式 1）：{@code {conn}_URI}。schema 含 {@code database_uri} → 整串直写；
+     *       否则按 {@code host:port/username} 解析。<b>此路径从不注入 password。</b></li>
+     *   <li><b>url + user + password</b>（格式 2）：三个键用<b>精确</b>连接名，缺一不可。</li>
+     *   <li>同上三键，用<b>截断</b>后的连接名（{@code A_B_C} → {@code A_B}）。</li>
+     *   <li>同上三键，用 {@code default} 前缀。</li>
+     *   <li>全不命中 → 抛 {@link IllegalArgumentException}。⚠ 调用方
+     *       {@code GroupInfoService.injectVaultSecrets} <b>没有 per-connection try/catch</b>，
+     *       所以这一抛会中止<b>整批</b>连接导入——文案因此要点名 DSN（见 [ADR-0036] D12 的升级顺序）。</li>
+     * </ol>
+     *
+     * <p>缺值一律走同一条规则（[ADR-0036] D10）：<b>不报错、不写空值</b>，保留目标环境既有值，
+     * 并发一条逐字点名缺了什么的 WARN。写空值会让 [ADR-0034] D5 误以为「包里有值」而放行，
+     * 目标凭据当场被抹空。
      */
     static void injectVaultSecretsToConnection(DataSourceConnectionDto conn,
             Map<String, String> vaultSecrets, DataSourceDefinitionDto definition) {
@@ -583,9 +599,17 @@ public interface ResourceHandler {
             String dsnValue = vaultSecrets.get(dsnVaultKey);
             String pwVaultKey = findVaultKey(vaultSecrets, connectionName, "password");
             String pwValue = pwVaultKey == null ? null : vaultSecrets.get(pwVaultKey);
+            if (pwValue == null) {
+                // 缺值统一规则（[ADR-0036] D10）：不报错、不写空值，但要**逐字点名那个键**——
+                // 泛化的告警读不出该去配哪个键，而拼错键名与「真的没密码」在数据上完全一样。
+                log.warn("Vault inject: connection='{}', no {}_PASSWORD in vault; keeping the target's"
+                        + " existing password. If this connection does have a password, that key name"
+                        + " is misspelled or missing.", connectionName, connectionName);
+            }
             if (hasDatabaseUri) {
                 String configPath = apiKeyToConfigPath.get("database_uri");
                 String uriWithPassword = splicePasswordIntoDsn(dsnValue, pwValue);
+                validateMongoDsn(uriWithPassword, connectionName, pwValue);
                 log.info("Vault inject: connection='{}', configPath='{}' <- dsn (direct)", connectionName, configPath);
                 setNestedValue(finalConfig, configPath, uriWithPassword);
                 // 顶层镜像字段与 config 一起写（[ADR-0036] D9）。保存链路**不会**从 config
@@ -597,6 +621,22 @@ public interface ResourceHandler {
             } else {
                 Map<String, Object> parts = parseDsnComponents(dsnValue);
                 log.info("Vault inject (dsn): connection='{}', parsed components={}", connectionName, parts);
+                if (parts.get("query") != null) {
+                    // [ADR-0036] D11：JDBC 的 query 串本期不解析、丢弃并告警。丢弃必须是响亮的——
+                    // 静默丢弃会让「参数配了但没生效」在目标环境才浮现。参数仍走包内 additionalString。
+                    log.warn("Vault inject: connection='{}', the DSN query string '?{}' is discarded"
+                            + " (not supported in this release); connection parameters still come from"
+                            + " the package's additionalString.", connectionName, parts.get("query"));
+                }
+                if (parts.get("user") == null) {
+                    log.warn("Vault inject: connection='{}', the DSN carries no userinfo, so no username"
+                            + " was taken from it; keeping the target's existing username."
+                            + " Format 3 does not read {}_USER.", connectionName, connectionName);
+                }
+                if (parts.get("database") == null) {
+                    log.warn("Vault inject: connection='{}', the DSN carries no database name;"
+                            + " keeping the target's existing database name.", connectionName);
+                }
                 injectParsedField(finalConfig, connectionName, "host", parts.get("host"), apiKeyToConfigPath);
                 injectParsedField(finalConfig, connectionName, "port", parts.get("port"), apiKeyToConfigPath);
                 injectParsedField(finalConfig, connectionName, "user", parts.get("user"), apiKeyToConfigPath);
@@ -658,9 +698,16 @@ public interface ResourceHandler {
         }
 
         // 优先级6：所有策略均未命中，报错退出
+        // 文案点名 DSN 是刻意的（[ADR-0036] D12）：只含 _DSN 的 vault 撞上一个不认识格式 3 的 TM 时，
+        // 走的正是这一条，而 injectVaultSecrets 没有 per-connection try/catch ⇒ 整批导入中止。
+        // 不提 DSN 的话，那条报错读起来像租户把键配错了，而不是「这个环境的 TM 该升级了」。
         throw new IllegalArgumentException(
                 "Vault inject: connection='" + connectionName + "' has no matching vault keys (tried: "
-                        + connectionName + ", " + (truncated != null ? truncated : "<no truncation>") + ", default)");
+                        + connectionName + "_DSN, " + connectionName + "_URI, "
+                        + connectionName + "_URL/_USER/_PASSWORD, "
+                        + (truncated != null ? truncated : "<no truncation>") + ", default). "
+                        + "If the repository is configured with " + connectionName
+                        + "_DSN, this TM predates format 3 and needs upgrading first.");
     }
 
     /**
@@ -816,6 +863,29 @@ public interface ResourceHandler {
     }
 
     /**
+     * 「先拼后验」的**验**（[ADR-0036] D8）：splice 完的串必须仍是合法 MongoDB 连接串。
+     *
+     * ⚠ 报错消息**绝不回显这个串**——splice 之后它带着明文密码。驱动本身的消息
+     * 经实测不回显（2026-08-18 探针），但仍防御性地把密码从中抹掉，避免驱动升级后走样。
+     */
+    private static void validateMongoDsn(String splicedUri, String connectionName, String password) {
+        if (StringUtils.isBlank(splicedUri)) return;
+        try {
+            new com.mongodb.ConnectionString(splicedUri);
+        } catch (RuntimeException e) {
+            String detail = e.getMessage() == null ? "" : e.getMessage();
+            if (password != null && !password.isEmpty()) {
+                detail = detail.replace(password, "***");
+            }
+            throw new IllegalArgumentException(
+                    "Vault inject: connection='" + connectionName + "', the DSN is not a valid MongoDB"
+                            + " connection string after splicing the password in: " + detail
+                            + " (the DSN is not echoed here because it now carries the password;"
+                            + " check that the username is percent-encoded)");
+        }
+    }
+
+    /**
      * 按 RFC 3986 对 userinfo 成分做 percent-encoding：只放行 unreserved
      * （{@code ALPHA / DIGIT / - . _ ~}），其余一律编码。
      *
@@ -852,9 +922,11 @@ public interface ResourceHandler {
         if (StringUtils.isBlank(dsn)) return result;
 
         String rest = dsn.trim();
-        if (rest.regionMatches(true, 0, "jdbc:", 0, 5)) {
-            rest = rest.substring(5);
-        }
+        // 剥 scheme 这一步**同时**吃掉 `jdbc:` 前缀：D5 收的三种形态里带前缀的两种
+        // （`jdbc:mysql://…` / `mysql://…`）都含 `://`，从它往后截即可。
+        // ⚠ 刻意**没有**单独再剥一次 `jdbc:`：那一步对本 ADR 收的任何形态都不可达
+        // （变异测试实证——去掉它没有任何用例变红），而对不含 `://` 的
+        // `jdbc:mysql:user@h/db` 它反而解析出 user=`mysql`，是错的而不是更宽容的。
         int schemeIdx = rest.indexOf("://");
         if (schemeIdx >= 0) {
             rest = rest.substring(schemeIdx + 3);

--- a/manager/tm/src/main/java/com/tapdata/tm/group/handler/ResourceHandler.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/group/handler/ResourceHandler.java
@@ -59,7 +59,11 @@ public interface ResourceHandler {
             "port",     "database_port",
             "user",     "database_username",
             "password", "database_password",
-            "uri",      "database_uri"
+            "uri",      "database_uri",
+            // 格式 3 新增：库名不是 vault 里的独立键，而是从 DSN 解析出来的成分，
+            // 但它要走同一套 apiServerKey -> configPath 查表，故占一个伪 suffix。
+            // ⚠ 它**不进** SENSITIVE_API_KEYS——库名不是凭据，导出不脱敏（[ADR-0036]）。
+            "database", "database_name"
     );
 
     /**
@@ -70,7 +74,11 @@ public interface ResourceHandler {
             "host",     "host",
             "port",     "port",
             "user",     "username",
-            "password", "password"
+            "password", "password",
+            // schema BFS 落空时库名的落点。选 "database" 而非 "databaseName"/"database_name"：
+            // 与同表其余四项一样取 PDK config 的通用根键名（[ADR-0036] D8 要求把它定死，
+            // 否则 schema 缺失的连接会静默丢库名）。
+            "database", "database"
     );
 
     /**
@@ -569,7 +577,45 @@ public interface ResourceHandler {
 
         boolean hasDatabaseUri = apiKeyToConfigPath.containsKey("database_uri");
 
-        // 优先级1：查找 {connectionName}_uri
+        // 优先级1：格式 3——{connectionName}_DSN（Variables）+ {connectionName}_PASSWORD（Secrets）
+        String dsnVaultKey = findVaultKey(vaultSecrets, connectionName, "dsn");
+        if (dsnVaultKey != null) {
+            String dsnValue = vaultSecrets.get(dsnVaultKey);
+            String pwVaultKey = findVaultKey(vaultSecrets, connectionName, "password");
+            String pwValue = pwVaultKey == null ? null : vaultSecrets.get(pwVaultKey);
+            if (hasDatabaseUri) {
+                String configPath = apiKeyToConfigPath.get("database_uri");
+                String uriWithPassword = splicePasswordIntoDsn(dsnValue, pwValue);
+                log.info("Vault inject: connection='{}', configPath='{}' <- dsn (direct)", connectionName, configPath);
+                setNestedValue(finalConfig, configPath, uriWithPassword);
+                // 顶层镜像字段与 config 一起写（[ADR-0036] D9）。保存链路**不会**从 config
+                // 重推顶层，而 MetaDataBuilderUtils.generateQualifiedName 建元数据限定名读的
+                // 正是顶层——只写 config 会得到「连接连新库、元数据挂旧库名」的半改状态。
+                // 必须写在 preserveExistingSecrets 之前：restoreMirroredField 只在 incoming
+                // 缺该字段时回填，不写就会被目标环境的旧值填上。
+                conn.setDatabase_uri(uriWithPassword);
+            } else {
+                Map<String, Object> parts = parseDsnComponents(dsnValue);
+                log.info("Vault inject (dsn): connection='{}', parsed components={}", connectionName, parts);
+                injectParsedField(finalConfig, connectionName, "host", parts.get("host"), apiKeyToConfigPath);
+                injectParsedField(finalConfig, connectionName, "port", parts.get("port"), apiKeyToConfigPath);
+                injectParsedField(finalConfig, connectionName, "user", parts.get("user"), apiKeyToConfigPath);
+                injectParsedField(finalConfig, connectionName, "database", parts.get("database"), apiKeyToConfigPath);
+                if (pwValue != null) {
+                    injectParsedField(finalConfig, connectionName, "password", pwValue, apiKeyToConfigPath);
+                }
+                // 顶层镜像字段，同上（[ADR-0036] D9）。⚠ 顶层 database_password 刻意不写：
+                // 它存的是 AES 密文（beforeSave 由 plain_password 推出），塞明文会毁掉那个契约；
+                // 密码的缺值语义由 [ADR-0034] D5 管，连接器读的是 config 那一份。
+                if (parts.get("host") != null)     conn.setDatabase_host((String) parts.get("host"));
+                if (parts.get("port") != null)     conn.setDatabase_port((Integer) parts.get("port"));
+                if (parts.get("user") != null)     conn.setDatabase_username((String) parts.get("user"));
+                if (parts.get("database") != null) conn.setDatabase_name((String) parts.get("database"));
+            }
+            return;
+        }
+
+        // 优先级2：查找 {connectionName}_uri
         String uriVaultKey = findVaultKey(vaultSecrets, connectionName, "uri");
         if (uriVaultKey != null) {
             String uriValue = vaultSecrets.get(uriVaultKey);
@@ -584,7 +630,7 @@ public interface ResourceHandler {
             return;
         }
 
-        // 优先级2：查找 {connectionName}_url + _user + _password
+        // 优先级3：查找 {connectionName}_url + _user + _password
         String[] resolved = resolveVaultStrategy(vaultSecrets, connectionName);
         if (resolved != null) {
             log.info("Vault inject: connection='{}', resolved with prefix='{}'", connectionName, connectionName);
@@ -592,7 +638,7 @@ public interface ResourceHandler {
             return;
         }
 
-        // 优先级3：截取连接名后查找
+        // 优先级4：截取连接名后查找
         String truncated = truncateName(connectionName);
         if (truncated != null) {
             resolved = resolveVaultStrategy(vaultSecrets, truncated);
@@ -603,7 +649,7 @@ public interface ResourceHandler {
             }
         }
 
-        // 优先级4：使用 default 前缀查找
+        // 优先级5：使用 default 前缀查找
         resolved = resolveVaultStrategy(vaultSecrets, "default");
         if (resolved != null) {
             log.info("Vault inject: connection='{}', resolved with prefix='default'", connectionName);
@@ -611,7 +657,7 @@ public interface ResourceHandler {
             return;
         }
 
-        // 优先级5：所有策略均未命中，报错退出
+        // 优先级6：所有策略均未命中，报错退出
         throw new IllegalArgumentException(
                 "Vault inject: connection='" + connectionName + "' has no matching vault keys (tried: "
                         + connectionName + ", " + (truncated != null ? truncated : "<no truncation>") + ", default)");
@@ -740,6 +786,114 @@ public interface ResourceHandler {
      * 支持标准格式：scheme://user:password@host:port/db
      * 支持简化格式：host:port/username（无 scheme、无密码）
      */
+    /**
+     * 把 {@code {CONN}_PASSWORD} 补进 DSN 的 userinfo。
+     *
+     * 顺序是**先拼后验**（[ADR-0036] D8）：{@code ConnectionString} 会拒掉
+     * {@code mongodb://u@h/db}（无冒号那种空密码写法），所以不能先解析再拼——
+     * 那种形态在解析阶段就死了。改为在**原始串**上做字符串手术，再交给
+     * {@code ConnectionString} 做最终校验。
+     */
+    private static String splicePasswordIntoDsn(String dsn, String password) {
+        if (StringUtils.isBlank(dsn) || password == null) {
+            return dsn;
+        }
+        int schemeIdx = dsn.indexOf("://");
+        int userInfoStart = schemeIdx < 0 ? 0 : schemeIdx + 3;
+        int atIdx = dsn.indexOf('@', userInfoStart);
+        if (atIdx < 0) {
+            // 无 userinfo：不 splice，交给缺值规则（[ADR-0036] D10）
+            return dsn;
+        }
+        String userInfo = dsn.substring(userInfoStart, atIdx);
+        int colonIdx = userInfo.indexOf(':');
+        // 用户名**原样透传**：它是 DSN 作者写进 URI 的，已经该是编码态；再编码一次会把
+        // `%40` 变成 `%2540`。作者漏编码时由末尾的 ConnectionString 校验抓出来，
+        // 而不是我们悄悄替他改写（[ADR-0036] D8）。密码来自 Secrets、是裸值，必须由我们编码。
+        String user = colonIdx < 0 ? userInfo : userInfo.substring(0, colonIdx);
+        return dsn.substring(0, userInfoStart) + user + ":" + percentEncodeUserInfo(password)
+                + dsn.substring(atIdx);
+    }
+
+    /**
+     * 按 RFC 3986 对 userinfo 成分做 percent-encoding：只放行 unreserved
+     * （{@code ALPHA / DIGIT / - . _ ~}），其余一律编码。
+     *
+     * 刻意**不用** {@code URLEncoder}——那是 form 编码，会把空格写成 {@code +}，
+     * 而 {@code +} 在 URI 的 userinfo 里是字面加号，密码含空格时就会反解错。
+     */
+    private static String percentEncodeUserInfo(String raw) {
+        StringBuilder sb = new StringBuilder(raw.length() + 8);
+        for (byte b : raw.getBytes(java.nio.charset.StandardCharsets.UTF_8)) {
+            int c = b & 0xFF;
+            if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9')
+                    || c == '-' || c == '.' || c == '_' || c == '~') {
+                sb.append((char) c);
+            } else {
+                sb.append('%').append(String.format("%02X", c));
+            }
+        }
+        return sb.toString();
+    }
+
+    /**
+     * 解析格式 3 的 DSN，得到归一化目标四元组 {@code (host, port, user, database)}。
+     *
+     * ⚠ **刻意不复用 {@link #parseUriComponents}**（[ADR-0036] D5/D8）：那个函数在无 userinfo 时
+     * 把 path 首段当 username，而 DSN 的 path 首段是**库名**（`localhost:3306/test` 会得到
+     * `user=test`）；它底下的 {@code java.net.URI} 又把 `jdbc:xxx://…` 当 opaque URI，
+     * host/port/path 全为 null ⇒ 整个 JDBC 分支静默空跑。
+     *
+     * 归一化必须发生在解析**之前**：先剥可选的 {@code jdbc:}，再剥可选的 {@code scheme://}。
+     * 两个前缀都**只是入口宽容度、一律丢弃**，永不用于判型（类型来自连接自身的 definition/pdkHash）。
+     */
+    private static Map<String, Object> parseDsnComponents(String dsn) {
+        Map<String, Object> result = new LinkedHashMap<>();
+        if (StringUtils.isBlank(dsn)) return result;
+
+        String rest = dsn.trim();
+        if (rest.regionMatches(true, 0, "jdbc:", 0, 5)) {
+            rest = rest.substring(5);
+        }
+        int schemeIdx = rest.indexOf("://");
+        if (schemeIdx >= 0) {
+            rest = rest.substring(schemeIdx + 3);
+        }
+
+        int queryIdx = rest.indexOf('?');
+        if (queryIdx >= 0) {
+            result.put("query", rest.substring(queryIdx + 1));
+            rest = rest.substring(0, queryIdx);
+        }
+
+        int atIdx = rest.lastIndexOf('@');
+        if (atIdx >= 0) {
+            String userInfo = rest.substring(0, atIdx);
+            int colonIdx = userInfo.indexOf(':');
+            String user = colonIdx < 0 ? userInfo : userInfo.substring(0, colonIdx);
+            if (StringUtils.isNotBlank(user)) result.put("user", user);
+            rest = rest.substring(atIdx + 1);
+        }
+
+        int slashIdx = rest.indexOf('/');
+        if (slashIdx >= 0) {
+            String database = rest.substring(slashIdx + 1);
+            if (StringUtils.isNotBlank(database)) result.put("database", database);
+            rest = rest.substring(0, slashIdx);
+        }
+
+        int colonIdx = rest.lastIndexOf(':');
+        if (colonIdx >= 0) {
+            String portStr = rest.substring(colonIdx + 1);
+            if (StringUtils.isNotBlank(portStr) && portStr.chars().allMatch(Character::isDigit)) {
+                result.put("port", Integer.parseInt(portStr));
+                rest = rest.substring(0, colonIdx);
+            }
+        }
+        if (StringUtils.isNotBlank(rest)) result.put("host", rest);
+        return result;
+    }
+
     private static Map<String, Object> parseUriComponents(String uriStr) {
         Map<String, Object> result = new LinkedHashMap<>();
         if (StringUtils.isBlank(uriStr)) return result;

--- a/manager/tm/src/main/java/com/tapdata/tm/group/handler/ResourceHandler.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/group/handler/ResourceHandler.java
@@ -654,16 +654,16 @@ public interface ResourceHandler {
                             + " Format 3 does not read {}_USER.", connectionName, connectionName);
                 }
                 if (parts.get("database") == null) {
-                    // ⚠ 不能说「保留目标既有库名」：database_name **不在** SENSITIVE_API_KEYS 里，
-                    // 导出不脱敏它、restoreMissingSecretsFromExisting 也不回填它（它只补
-                    // getMaskedConfigPaths 与那七个顶层镜像字段）。而 GROUP_IMPORT 是整文档覆盖，
-                    // 所以真正落到目标上的是**包里那个、即源环境的**库名。旁边 username/password
-                    // 两条同形告警成立，恰恰因为那两个字段是被脱敏的。
-                    log.warn("Vault inject: connection='{}', the DSN carries no database name, so the"
-                            + " database name shipped in the package (the source environment's) is used"
-                            + " as-is. The target's own database name is NOT preserved: database_name is"
-                            + " not a masked field, so nothing restores it. Put the database name in the"
-                            + " DSN to make it environment-specific.", connectionName);
+                    // ⚠ 这条只是预告，**真正的保留发生在 restoreDatabaseNameWhenDsnOmitsIt**——
+                    // 此处看不见目标环境那条连接，所以说不出最终用的是哪个库名（目标已有该连接
+                    // ⇒ 保留它的；首次部署 ⇒ 只能用包里的）。措辞对两种结局都要成立，具体结果
+                    // 由那一步逐字打出来。database_name 不在 SENSITIVE_API_KEYS 里，所以它走的
+                    // 不是 restoreMissingSecretsFromExisting 那条「缺值回填」链路。
+                    log.warn("Vault inject: connection='{}', the DSN carries no database name; the target"
+                            + " environment's existing database name will be kept if that connection"
+                            + " already exists there, otherwise the name shipped in the package is used."
+                            + " Put the database name in the DSN to make it environment-specific.",
+                            connectionName);
                 }
                 injectParsedField(finalConfig, connectionName, "host", parts.get("host"), apiKeyToConfigPath);
                 injectParsedField(finalConfig, connectionName, "port", parts.get("port"), apiKeyToConfigPath);
@@ -1075,6 +1075,155 @@ public interface ResourceHandler {
      *
      * @return 被保留（即包内缺值、改用目标既有值）的 config path，供调用方汇报——D7 要求绝不静默。
      */
+    /**
+     * apiServerKey -> configPath 的反查表（只收 {@link #VAULT_SUFFIX_TO_API_KEY} 认识的那几个）。
+     * 单点定义：注入与下面的库名保留都读它，免得两处各建一份而悄悄漂开。
+     */
+    static Map<String, String> buildApiKeyToConfigPath(Map<String, String> pathToApiKey) {
+        Map<String, String> apiKeyToConfigPath = new LinkedHashMap<>();
+        if (pathToApiKey == null) {
+            return apiKeyToConfigPath;
+        }
+        for (Map.Entry<String, String> entry : pathToApiKey.entrySet()) {
+            if (VAULT_SUFFIX_TO_API_KEY.containsValue(entry.getValue())) {
+                apiKeyToConfigPath.put(entry.getValue(), entry.getKey());
+            }
+        }
+        return apiKeyToConfigPath;
+    }
+
+    /** MongoDB 连接串里的库名；解析不了或没有就返回 null。 */
+    private static String mongoDatabaseOf(String uri) {
+        if (StringUtils.isBlank(uri)) {
+            return null;
+        }
+        try {
+            return new com.mongodb.ConnectionString(uri).getDatabase();
+        } catch (RuntimeException e) {
+            return null;
+        }
+    }
+
+    /**
+     * 把库名拼进一个没有 path 段的 MongoDB 连接串。
+     *
+     * 与 {@link #splicePasswordIntoDsn} 同样是**原始串上的字符串手术**：种子列表
+     * （{@code h1:27017,h2:27017}）与 {@code ?replicaSet=}/{@code ?authSource=} 必须原样保真，
+     * 而先解析再重建一定会把它们normalize掉。
+     */
+    private static String spliceDatabaseIntoMongoUri(String uri, String database) {
+        int schemeIdx = uri.indexOf("://");
+        int start = schemeIdx < 0 ? 0 : schemeIdx + 3;
+        int atIdx = uri.indexOf('@', start);
+        int authorityStart = atIdx < 0 ? start : atIdx + 1;
+
+        int queryIdx = uri.indexOf('?', authorityStart);
+        int slashIdx = uri.indexOf('/', authorityStart);
+        boolean hasPathSeparator = slashIdx >= 0 && (queryIdx < 0 || slashIdx < queryIdx);
+
+        if (hasPathSeparator) {
+            int pathEnd = queryIdx < 0 ? uri.length() : queryIdx;
+            if (slashIdx + 1 != pathEnd) {
+                return null;    // 已经有库名了，不该走到这儿
+            }
+            return uri.substring(0, slashIdx + 1) + database + uri.substring(pathEnd);
+        }
+        int insertAt = queryIdx < 0 ? uri.length() : queryIdx;
+        return uri.substring(0, insertAt) + "/" + database + uri.substring(insertAt);
+    }
+
+    /**
+     * 格式 3 的 DSN **没写库名**时，把目标环境既有的库名放回 incoming（[ADR-0036] D10 第二行）。
+     *
+     * <p>⚠ 这件事**不能**交给 {@link #restoreMissingSecretsFromExisting}，两个理由：
+     * ① 那条链路的语义是「脱敏抹出来的洞」——只在 incoming 为空时回填，而这里 incoming
+     * <b>不为空</b>，它带着**源环境**的库名（{@code database_name} 不在
+     * {@link #SENSITIVE_API_KEYS} 里，导出根本不抹它）；② 它整条被保真包早退挡掉，而这条
+     * 保留不分包类型——DSN 分支只在操作者真的配了 {@code {CONN}_DSN} 时才走，那时格式 3
+     * 的语义压过打包模式。
+     *
+     * <p>不做这件事的后果：GROUP_IMPORT 是整文档覆盖 ⇒ SIT 的 {@code sit_orders} 覆盖掉
+     * PROD 的 {@code prod_orders}，部署报绿、测试连接也通过（库真实存在），
+     * 而连接从此指着**上一个环境的库**。
+     *
+     * @return 被保留下来的库名；没做任何事时返回 null（交给导入报告，D7 不许静默）
+     */
+    static String restoreDatabaseNameWhenDsnOmitsIt(DataSourceConnectionDto incoming,
+            DataSourceConnectionDto existing, DataSourceDefinitionDto definition,
+            Map<String, String> vaultSecrets) {
+        if (incoming == null || existing == null || MapUtils.isEmpty(vaultSecrets)) {
+            return null;
+        }
+        String connectionName = incoming.getName();
+        // 作用域仅精确名（[ADR-0036] D4）：DSN 携带库的身份，回落＝连错库。
+        String dsnVaultKey = findVaultKey(vaultSecrets, connectionName, "dsn");
+        if (dsnVaultKey == null) {
+            return null;    // 非格式 3 —— D5 推论：格式 1/2 的库名不被新逻辑碰到
+        }
+        String dsnValue = vaultSecrets.get(dsnVaultKey);
+        if (StringUtils.isBlank(dsnValue)) {
+            return null;
+        }
+        Map<String, String> apiKeyToConfigPath =
+                buildApiKeyToConfigPath(buildConfigPathToApiKeyMap(definition));
+        Map<String, Object> incomingConfig = incoming.getConfig();
+        Map<String, Object> existingConfig = existing.getConfig();
+        if (incomingConfig == null) {
+            return null;
+        }
+
+        if (apiKeyToConfigPath.containsKey("database_uri")) {
+            // MongoDB：库名没有独立字段，它活在整串 uri 的 path 段里。
+            String configPath = apiKeyToConfigPath.get("database_uri");
+            Object incomingUriValue = getNestedValue(incomingConfig, configPath);
+            String incomingUri = incomingUriValue instanceof String ? (String) incomingUriValue : null;
+            if (StringUtils.isBlank(incomingUri) || mongoDatabaseOf(incomingUri) != null) {
+                return null;    // DSN 自己带了库名 ⇒ DSN 赢
+            }
+            Object existingUriValue = existingConfig == null ? null : getNestedValue(existingConfig, configPath);
+            String existingUri = existingUriValue instanceof String
+                    ? (String) existingUriValue : existing.getDatabase_uri();
+            String existingDb = mongoDatabaseOf(existingUri);
+            if (StringUtils.isBlank(existingDb)) {
+                return null;    // 目标也没有库名 ⇒ 不写空值
+            }
+            String merged = spliceDatabaseIntoMongoUri(incomingUri, existingDb);
+            if (merged == null) {
+                return null;
+            }
+            setNestedValue(incomingConfig, configPath, merged);
+            incoming.setDatabase_uri(merged);
+            log.warn("Vault inject: connection='{}', the DSN carries no database name; kept the target"
+                    + " environment's existing database name '{}'. Put the database name in the DSN if"
+                    + " this environment should use a different one.", connectionName, existingDb);
+            return existingDb;
+        }
+
+        // JDBC：库名是独立字段 database_name。
+        Map<String, Object> parts = parseDsnComponents(dsnValue);
+        if (parts.get("database") != null) {
+            return null;    // DSN 赢——「库名可逐环境不同」是本期的核心能力
+        }
+        String configPath = apiKeyToConfigPath.get("database_name");
+        Object existingValue = (configPath == null || existingConfig == null)
+                ? null : getNestedValue(existingConfig, configPath);
+        String existingDb = existingValue instanceof String
+                ? (String) existingValue : existing.getDatabase_name();
+        if (StringUtils.isBlank(existingDb)) {
+            return null;
+        }
+        if (configPath != null) {
+            setNestedValue(incomingConfig, configPath, existingDb);
+        }
+        // 顶层镜像与 config 一起改（[ADR-0036] D9）：MetaDataBuilderUtils.generateQualifiedName
+        // 读的是顶层，只改 config 会得到「连接连对库、元数据挂错库名」的半改状态。
+        incoming.setDatabase_name(existingDb);
+        log.warn("Vault inject: connection='{}', the DSN carries no database name; kept the target"
+                + " environment's existing database name '{}'. Put the database name in the DSN if"
+                + " this environment should use a different one.", connectionName, existingDb);
+        return existingDb;
+    }
+
     static List<String> restoreMissingSecretsFromExisting(DataSourceConnectionDto incoming,
             DataSourceConnectionDto existing, DataSourceDefinitionDto definition) {
         List<String> preserved = new ArrayList<>();

--- a/manager/tm/src/main/java/com/tapdata/tm/group/handler/ResourceHandler.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/group/handler/ResourceHandler.java
@@ -628,7 +628,7 @@ public interface ResourceHandler {
             }
             if (hasDatabaseUri) {
                 String configPath = apiKeyToConfigPath.get("database_uri");
-                String uriWithPassword = splicePasswordIntoDsn(dsnValue, pwValue);
+                String uriWithPassword = splicePasswordIntoDsn(dsnValue, pwValue, connectionName);
                 validateMongoDsn(uriWithPassword, connectionName, pwValue);
                 log.info("Vault inject: connection='{}', configPath='{}' <- dsn (direct)", connectionName, configPath);
                 setNestedValue(finalConfig, configPath, uriWithPassword);
@@ -654,8 +654,16 @@ public interface ResourceHandler {
                             + " Format 3 does not read {}_USER.", connectionName, connectionName);
                 }
                 if (parts.get("database") == null) {
-                    log.warn("Vault inject: connection='{}', the DSN carries no database name;"
-                            + " keeping the target's existing database name.", connectionName);
+                    // ⚠ 不能说「保留目标既有库名」：database_name **不在** SENSITIVE_API_KEYS 里，
+                    // 导出不脱敏它、restoreMissingSecretsFromExisting 也不回填它（它只补
+                    // getMaskedConfigPaths 与那七个顶层镜像字段）。而 GROUP_IMPORT 是整文档覆盖，
+                    // 所以真正落到目标上的是**包里那个、即源环境的**库名。旁边 username/password
+                    // 两条同形告警成立，恰恰因为那两个字段是被脱敏的。
+                    log.warn("Vault inject: connection='{}', the DSN carries no database name, so the"
+                            + " database name shipped in the package (the source environment's) is used"
+                            + " as-is. The target's own database name is NOT preserved: database_name is"
+                            + " not a masked field, so nothing restores it. Put the database name in the"
+                            + " DSN to make it environment-specific.", connectionName);
                 }
                 injectParsedField(finalConfig, connectionName, "host", parts.get("host"), apiKeyToConfigPath);
                 injectParsedField(finalConfig, connectionName, "port", parts.get("port"), apiKeyToConfigPath);
@@ -861,7 +869,7 @@ public interface ResourceHandler {
      * 那种形态在解析阶段就死了。改为在**原始串**上做字符串手术，再交给
      * {@code ConnectionString} 做最终校验。
      */
-    private static String splicePasswordIntoDsn(String dsn, String password) {
+    private static String splicePasswordIntoDsn(String dsn, String password, String connectionName) {
         if (StringUtils.isBlank(dsn) || password == null) {
             return dsn;
         }
@@ -869,7 +877,15 @@ public interface ResourceHandler {
         int userInfoStart = schemeIdx < 0 ? 0 : schemeIdx + 3;
         int atIdx = dsn.indexOf('@', userInfoStart);
         if (atIdx < 0) {
-            // 无 userinfo：不 splice，交给缺值规则（[ADR-0036] D10）
+            // 无 userinfo：没有地方 splice，密码只能丢。缺值规则（[ADR-0036] D10）的两半
+            // 是「不写空值」**和**「逐字点名地告警」——只做前半条，这就成了格式 3 里唯一一处
+            // 静默丢值：不带凭据的 mongodb URI 本身合法，validateMongoDsn 会放行，日志只留下
+            // 一条 INFO「<- dsn (direct)」，操作者要到测试连接鉴权失败时才发现。JDBC 分支对
+            // 同一种输入是告警的，这里必须对称。
+            log.warn("Vault inject: connection='{}', the DSN carries no userinfo, so {}_PASSWORD could"
+                    + " not be spliced in and was dropped; the imported connection will have no"
+                    + " credentials. Write the DSN with an empty password position, e.g."
+                    + " 'mongodb://<user>:@host:27017/db'.", connectionName, connectionName);
             return dsn;
         }
         String userInfo = dsn.substring(userInfoStart, atIdx);

--- a/manager/tm/src/main/java/com/tapdata/tm/group/service/GroupInfoService.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/group/service/GroupInfoService.java
@@ -2975,11 +2975,19 @@ public class GroupInfoService extends BaseService<GroupInfoDto, GroupInfoEntity,
         connections.values().forEach(c -> {
             if (c.getPdkHash() != null) pdkHashes.add(c.getPdkHash());
         });
+        // ⚠ 合并函数不能是 (a, b) -> a：被替换掉的 findByPdkHash 是
+        // `Sort.by("pdkAPIBuildNumber").descending()` + findOne，即**确定性地取 build number
+        // 最高的那份**，而 findByPdkHashList 是无序 findAll。同一个 pdkHash 确实会有多份文档
+        // （PkdSourceService 的 upsert 键含 pdkAPIBuildNumber，集合上那条
+        // pdkHash_1_pdkAPIBuildNumber_1 索引就是为它建的）；取错一份 ⇒ BFS 落在旧 schema 上，
+        // 而旧 schema 缺 database_uri 会让 MongoDB 连接的 hasDatabaseUri 变 false、格式 3 误走
+        // JDBC 分支，静默把连接写坏。故显式挑 build number 更高的那份。
         Map<String, DataSourceDefinitionDto> defByPdkHash = pdkHashes.isEmpty()
                 ? Collections.emptyMap()
                 : dataSourceDefinitionService.findByPdkHashList(pdkHashes, user)
                     .stream().collect(Collectors.toMap(
-                        DataSourceDefinitionDto::getPdkHash, d -> d, (a, b) -> a));
+                        DataSourceDefinitionDto::getPdkHash, d -> d,
+                        GroupInfoService::preferHigherPdkApiBuild));
 
         // schema BFS 按 pdkHash 记忆化：它是 definition 的纯函数，同型连接结果完全相同。
         // 用的是上面那把 key、这一个循环。
@@ -2996,6 +3004,22 @@ public class GroupInfoService extends BaseService<GroupInfoDto, GroupInfoEntity,
                         h -> ResourceHandler.buildConfigPathToApiKeyMap(definition));
             ResourceHandler.injectVaultSecretsToConnection(conn, vaultSecrets, definition, memoizedBfs);
         });
+    }
+
+    /**
+     * 同一个 pdkHash 的多份 definition 里挑一份——**保留 pdkAPIBuildNumber 更高的那份**，
+     * 复现被批量化替换掉的 {@code findByPdkHash} 的选择规则（按该字段降序取第一条）。
+     *
+     * <p>字段缺失时优先取有值的那一份：老 criteria 的 {@code lte(...)} 在 Mongo 里
+     * 根本不匹配缺字段的文档，所以「有 build number」本身就比「没有」更接近老行为。
+     */
+    private static DataSourceDefinitionDto preferHigherPdkApiBuild(DataSourceDefinitionDto a,
+            DataSourceDefinitionDto b) {
+        Integer buildA = a.getPdkAPIBuildNumber();
+        Integer buildB = b.getPdkAPIBuildNumber();
+        if (buildB == null) return a;
+        if (buildA == null) return b;
+        return buildB > buildA ? b : a;
     }
 
     protected List<GroupInfoDto> loadGroupInfosByIds(List<String> groupIds, UserDetail user) {

--- a/manager/tm/src/main/java/com/tapdata/tm/group/service/GroupInfoService.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/group/service/GroupInfoService.java
@@ -2981,6 +2981,9 @@ public class GroupInfoService extends BaseService<GroupInfoDto, GroupInfoEntity,
                     .stream().collect(Collectors.toMap(
                         DataSourceDefinitionDto::getPdkHash, d -> d, (a, b) -> a));
 
+        // schema BFS 按 pdkHash 记忆化：它是 definition 的纯函数，同型连接结果完全相同。
+        // 用的是上面那把 key、这一个循环。
+        Map<String, Map<String, String>> bfsByPdkHash = new HashMap<>();
         connections.values().forEach(conn -> {
             String pdkHash = conn.getPdkHash();
             DataSourceDefinitionDto definition = pdkHash != null ? defByPdkHash.get(pdkHash) : null;
@@ -2988,7 +2991,10 @@ public class GroupInfoService extends BaseService<GroupInfoDto, GroupInfoEntity,
                 log.warn("Vault inject: definition not found for connection '{}', pdkHash={}, skipping schema BFS",
                         conn.getName(), conn.getPdkHash());
             }
-            ResourceHandler.injectVaultSecretsToConnection(conn, vaultSecrets, definition);
+            Map<String, String> memoizedBfs = definition == null ? null
+                    : bfsByPdkHash.computeIfAbsent(pdkHash,
+                        h -> ResourceHandler.buildConfigPathToApiKeyMap(definition));
+            ResourceHandler.injectVaultSecretsToConnection(conn, vaultSecrets, definition, memoizedBfs);
         });
     }
 

--- a/manager/tm/src/main/java/com/tapdata/tm/group/service/GroupInfoService.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/group/service/GroupInfoService.java
@@ -1041,7 +1041,11 @@ public class GroupInfoService extends BaseService<GroupInfoDto, GroupInfoEntity,
             // （[ADR-0034] D5）。刻意放在 vaultSecrets 判空之外——最危险的正是「没带 vault」。
             // 这条路的 details 本来是空的，保留清单就是它唯一的内容（D7 不许只落日志）。
             List<GroupInfoRecordDetail> details = new ArrayList<>();
-            reportPreservedSecrets(details, preserveExistingSecrets(payloads, connections, user), connections);
+            Map<String, String> keptDatabaseNames = new LinkedHashMap<>();
+            reportPreservedSecrets(details,
+                    preserveExistingSecrets(payloads, connections, user, vaultSecrets, keptDatabaseNames),
+                    connections);
+            reportKeptDatabaseNames(details, keptDatabaseNames, connections);
             refreshImportLastUpdate(connections.values(), connectionMetadata);
             Map<String, DataSourceConnectionDto> conMap = dataSourceService.batchImport(
                     new ArrayList<>(connections.values()), user, importMode);
@@ -2612,7 +2616,11 @@ public class GroupInfoService extends BaseService<GroupInfoDto, GroupInfoEntity,
             }
             // 同上：无条件保护，缺 vault 时才是真正会把目标凭据抹空的那条路（[ADR-0034] D5）；
             // 保留清单挂到 details 里已有的连接行上，随下一次 updateImportProgress 落库（D7）
-            reportPreservedSecrets(details, preserveExistingSecrets(payloads, connections, user), connections);
+            Map<String, String> keptDatabaseNames = new LinkedHashMap<>();
+            reportPreservedSecrets(details,
+                    preserveExistingSecrets(payloads, connections, user, vaultSecrets, keptDatabaseNames),
+                    connections);
+            reportKeptDatabaseNames(details, keptDatabaseNames, connections);
             List<MetadataInstancesDto> connectionMetadata = metadataByType
                     .getOrDefault(ResourceType.CONNECTION, Collections.emptyList());
             refreshImportLastUpdate(connections.values(), connectionMetadata);
@@ -2854,21 +2862,35 @@ public class GroupInfoService extends BaseService<GroupInfoDto, GroupInfoEntity,
      */
     Map<String, List<String>> preserveExistingSecrets(Map<String, List<TaskUpAndLoadDto>> payloads,
             Map<String, DataSourceConnectionDto> connections, UserDetail user) {
+        return preserveExistingSecrets(payloads, connections, user, null, null);
+    }
+
+    /**
+     * @param vaultSecrets      格式 3 的库名保留要重新判定「DSN 有没有写库名」，得看得见 vault
+     * @param keptDatabaseNames 出参：连接 id → 被保留下来的库名，交给 {@link #reportKeptDatabaseNames}
+     */
+    Map<String, List<String>> preserveExistingSecrets(Map<String, List<TaskUpAndLoadDto>> payloads,
+            Map<String, DataSourceConnectionDto> connections, UserDetail user,
+            Map<String, String> vaultSecrets, Map<String, String> keptDatabaseNames) {
         Map<String, List<String>> preserved = new LinkedHashMap<>();
         if (connections == null || connections.isEmpty()) {
             return preserved;
         }
-        if (!packageSecretsMasked(payloads)) {
-            // 保真包：包里的空缺就是用户的真实配置，照写。拿目标旧值回填会让用户永远删不掉一个
-            // 配置项，而且同样是「以为更新了其实没有」——D7 要防的正是这个。
-            return preserved;
-        }
+        // 保真包：包里的空缺就是用户的真实配置，照写。拿目标旧值回填会让用户永远删不掉一个
+        // 配置项，而且同样是「以为更新了其实没有」——D7 要防的正是这个。
+        //
+        // ⚠ 它**只**关掉「缺值回填」这一半。格式 3 的库名保留不归它管：那不是缺值——包里
+        // 那个库名是实打实的**源环境**值（database_name 不在 SENSITIVE_API_KEYS 里，导出
+        // 根本不抹它），而 DSN 分支只在操作者真的配了 {CONN}_DSN 时才走，那时格式 3 的
+        // 语义压过打包模式（[ADR-0036] D10 第二行）。
+        boolean restoreMissing = packageSecretsMasked(payloads);
         for (DataSourceConnectionDto conn : connections.values()) {
             if (conn == null || conn.getId() == null) {
                 continue;   // 新连接，目标环境没有可保留的既有值
             }
-            // 投影必须同时带上 config 与顶层镜像字段——导出把两处一起抹了，这里就得能看见两处
-            String[] projection = Stream.concat(Stream.of("config"),
+            // 投影必须同时带上 config 与顶层镜像字段——导出把两处一起抹了，这里就得能看见两处。
+            // database_name 额外带上：它不是镜像密钥字段，但格式 3 的库名保留要读目标那份。
+            String[] projection = Stream.concat(Stream.of("config", "database_name"),
                     ResourceHandler.MIRRORED_SECRET_FIELDS.stream()).toArray(String[]::new);
             DataSourceConnectionDto existing = dataSourceService.findById(conn.getId(), projection);
             if (existing == null) {
@@ -2876,7 +2898,16 @@ public class GroupInfoService extends BaseService<GroupInfoDto, GroupInfoEntity,
             }
             DataSourceDefinitionDto definition =
                     dataSourceDefinitionService.findByPdkHash(conn.getPdkHash(), Integer.MAX_VALUE, user);
-            List<String> paths = ResourceHandler.restoreMissingSecretsFromExisting(conn, existing, definition);
+
+            String keptDb = ResourceHandler.restoreDatabaseNameWhenDsnOmitsIt(
+                    conn, existing, definition, vaultSecrets);
+            if (keptDb != null && keptDatabaseNames != null) {
+                keptDatabaseNames.put(conn.getId().toHexString(), keptDb);
+            }
+
+            List<String> paths = restoreMissing
+                    ? ResourceHandler.restoreMissingSecretsFromExisting(conn, existing, definition)
+                    : Collections.emptyList();
             if (paths.isEmpty()) {
                 continue;
             }
@@ -2943,6 +2974,65 @@ public class GroupInfoService extends BaseService<GroupInfoDto, GroupInfoEntity,
         if (!added.isEmpty()) {
             GroupInfoRecordDetail detail = new GroupInfoRecordDetail();
             detail.setMessage("Some secret fields were kept from the target environment");
+            detail.getRecordDetails().addAll(added);
+            details.add(detail);
+        }
+    }
+
+    /** 库名保留的报告文案——**刻意不复用** {@link #preservedSecretsMessage}：那句说的是
+     * 「包里缺了敏感字段」，而库名既不敏感也不缺，包里带着的是源环境那个值。用错句子比不报更坏。 */
+    static String keptDatabaseNameMessage(String databaseName) {
+        return "The DSN carried no database name, so the target environment's existing database name '"
+                + databaseName + "' was kept instead of the one shipped in the package.";
+    }
+
+    /**
+     * 把格式 3 的库名保留写进导入报告（[ADR-0034] D7「绝不静默」）。
+     *
+     * 与 {@link #reportPreservedSecrets} 同形：报告里已有该连接的行就挂消息，没有就补一行。
+     * 分成两个方法而不是合并，是因为两者的**原因**不同——一个是脱敏留下的洞，一个是
+     * DSN 没写库名——合并就只能给出一句对其中一半不成立的话。
+     */
+    void reportKeptDatabaseNames(List<GroupInfoRecordDetail> details,
+            Map<String, String> keptByConnectionId,
+            Map<String, DataSourceConnectionDto> connections) {
+        if (details == null || MapUtils.isEmpty(keptByConnectionId)) {
+            return;
+        }
+        Set<String> attached = new HashSet<>();
+        for (GroupInfoRecordDetail detail : details) {
+            if (detail == null || CollectionUtils.isEmpty(detail.getRecordDetails())) {
+                continue;
+            }
+            for (GroupInfoRecordDetail.RecordDetail row : detail.getRecordDetails()) {
+                if (row == null || ResourceType.CONNECTION != row.getResourceType()) {
+                    continue;
+                }
+                String kept = keptByConnectionId.get(row.getResourceId());
+                if (StringUtils.isBlank(kept)) {
+                    continue;
+                }
+                String message = keptDatabaseNameMessage(kept);
+                row.setMessage(StringUtils.isBlank(row.getMessage()) ? message : row.getMessage() + " | " + message);
+                attached.add(row.getResourceId());
+            }
+        }
+        List<GroupInfoRecordDetail.RecordDetail> added = new ArrayList<>();
+        for (Map.Entry<String, String> entry : keptByConnectionId.entrySet()) {
+            if (attached.contains(entry.getKey())) {
+                continue;
+            }
+            GroupInfoRecordDetail.RecordDetail row = new GroupInfoRecordDetail.RecordDetail();
+            row.setResourceType(ResourceType.CONNECTION);
+            row.setResourceId(entry.getKey());
+            row.setResourceName(resolveConnectionName(connections, entry.getKey()));
+            row.setAction(GroupInfoRecordDetail.RecordAction.IMPORTED);
+            row.setMessage(keptDatabaseNameMessage(entry.getValue()));
+            added.add(row);
+        }
+        if (!added.isEmpty()) {
+            GroupInfoRecordDetail detail = new GroupInfoRecordDetail();
+            detail.setMessage("Some connections kept the target environment's database name");
             detail.getRecordDetails().addAll(added);
             details.add(detail);
         }

--- a/manager/tm/src/main/java/com/tapdata/tm/group/service/GroupInfoService.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/group/service/GroupInfoService.java
@@ -1567,7 +1567,8 @@ public class GroupInfoService extends BaseService<GroupInfoDto, GroupInfoEntity,
                 ? Collections.emptyMap()
                 : dataSourceDefinitionService.findByPdkHashList(pdkHashes, user)
                     .stream().collect(Collectors.toMap(
-                        DataSourceDefinitionDto::getPdkHash, d -> d, (a, b) -> a));
+                        DataSourceDefinitionDto::getPdkHash, d -> d,
+                        GroupInfoService::preferHigherPdkApiBuild));
 
         // Inject vault secrets into file connections before comparison
         Map<String, String> vaultSecrets = parseVaultSecrets(payloads);
@@ -1581,6 +1582,35 @@ public class GroupInfoService extends BaseService<GroupInfoDto, GroupInfoEntity,
                     log.warn("Vault inject failed for connection '{}' during diff, skipping: {}",
                             fileConn.getName(), e.getMessage());
                 }
+            }
+        }
+
+        // 预览必须跑与真实导入**同一套**保留逻辑，否则它报的是一件不会发生的变更。
+        // 导入侧 preserveExistingSecrets 做两件事，这里逐件对齐：
+        //   ① restoreMissingSecretsFromExisting —— 受 packageSecretsMasked 管辖（保真包里
+        //      空缺就是用户的真实配置），且**不受 vaultSecrets 是否为空影响**，与
+        //      importGroupInfo 那条路径的注释同源：最危险的正是「没带 vault」。
+        //   ② restoreDatabaseNameWhenDsnOmitsIt —— 不受包类型管辖（[ADR-0036] D10 第二行）。
+        // 不复用 preserveExistingSecrets 本体：它按连接逐条 findById，而这里 existingById
+        // 已经批量load好了，再查一遍就是把刚去掉的 N+1 又加回来。
+        boolean restoreMissingOnDiff = packageSecretsMasked(payloads);
+        for (Map.Entry<String, DataSourceConnectionDto> preserveEntry : fileConnsById.entrySet()) {
+            DataSourceConnectionDto fileConn = preserveEntry.getValue();
+            DataSourceConnectionDto existingConn = existingById.get(preserveEntry.getKey());
+            if (existingConn == null) {
+                continue;   // 目标还没有这条连接 ⇒ 没有可保留的既有值，预览就是 add
+            }
+            try {
+                String pdkHash = fileConn.getPdkHash();
+                DataSourceDefinitionDto def = pdkHash != null ? defByPdkHash.get(pdkHash) : null;
+                if (restoreMissingOnDiff) {
+                    ResourceHandler.restoreMissingSecretsFromExisting(fileConn, existingConn, def);
+                }
+                ResourceHandler.restoreDatabaseNameWhenDsnOmitsIt(fileConn, existingConn, def, vaultSecrets);
+            } catch (Exception e) {
+                // 与上面的注入循环同样的姿势：预览不该因为一条连接算不出来就整份失败
+                log.warn("Preserve-on-diff failed for connection '{}', showing the raw package value: {}",
+                        fileConn.getName(), e.getMessage());
             }
         }
 

--- a/manager/tm/src/main/java/com/tapdata/tm/group/service/GroupInfoService.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/group/service/GroupInfoService.java
@@ -2966,9 +2966,24 @@ public class GroupInfoService extends BaseService<GroupInfoDto, GroupInfoEntity,
      */
     private void injectVaultSecrets(Map<String, DataSourceConnectionDto> connections,
             Map<String, String> vaultSecrets, UserDetail user) {
+        // 批量查 definition，与本文件 diff 路径（:1559-1566）同一写法：原来是每条连接一次
+        // findByPdkHash，一次导入 N 条连接就是 N 次往返。
+        // ⚠ pdkHash == null 的连接必须**过滤出查询集合、但仍然照常注入**：逐条版把 null
+        // 直接传进 findByPdkHash（拿回 null），批量版若不过滤会把 null 塞进 IN 查询。
+        // 两者对外行为必须逐字相同——definition 为 null、走无 schema 的 fallback 分支。
+        Set<String> pdkHashes = new HashSet<>();
+        connections.values().forEach(c -> {
+            if (c.getPdkHash() != null) pdkHashes.add(c.getPdkHash());
+        });
+        Map<String, DataSourceDefinitionDto> defByPdkHash = pdkHashes.isEmpty()
+                ? Collections.emptyMap()
+                : dataSourceDefinitionService.findByPdkHashList(pdkHashes, user)
+                    .stream().collect(Collectors.toMap(
+                        DataSourceDefinitionDto::getPdkHash, d -> d, (a, b) -> a));
+
         connections.values().forEach(conn -> {
-            DataSourceDefinitionDto definition =
-                    dataSourceDefinitionService.findByPdkHash(conn.getPdkHash(), Integer.MAX_VALUE, user);
+            String pdkHash = conn.getPdkHash();
+            DataSourceDefinitionDto definition = pdkHash != null ? defByPdkHash.get(pdkHash) : null;
             if (definition == null) {
                 log.warn("Vault inject: definition not found for connection '{}', pdkHash={}, skipping schema BFS",
                         conn.getName(), conn.getPdkHash());

--- a/manager/tm/src/test/java/com/tapdata/tm/group/handler/ResourceHandlerImportPreserveTest.java
+++ b/manager/tm/src/test/java/com/tapdata/tm/group/handler/ResourceHandlerImportPreserveTest.java
@@ -99,4 +99,184 @@ public class ResourceHandlerImportPreserveTest {
                 "包里给了值就是用户的意图，保护不能反过来把新凭据顶掉");
         assertTrue(preserved.isEmpty(), "什么都没保留就不该报，否则报告全是噪声：" + preserved);
     }
+
+    // =====================================================================
+    // [ADR-0036] D10 第二行：DSN 没写库名 ⇒ 目标环境既有库名不被覆盖。
+    //
+    // ⚠ 这一组的对照必须是 incoming(包/源环境) vs existing(目标环境) 两个不同对象。
+    // 老用例 ResourceHandlerVaultTest#d10_missingDatabaseNameWarnsAndKeepsOld 正是
+    // 栽在这里：它把 "olddb" 塞在 **incoming** 上、断言 inject 没动它，然后把结论写成
+    // 「保留目标既有库名」。inject 本来就不会动它（injectParsedField 遇 null 直接 no-op），
+    // 所以那条断言恒真、与目标环境毫无关系——覆盖发生在 GROUP_IMPORT 整文档替换那一层，
+    // 而 incoming 携带的恰恰是**源环境**的库名。一条绿着的用例把这个缺陷盖了下去。
+    // =====================================================================
+
+    /** JDBC 型 definition：库名是独立字段 database_name。 */
+    private DataSourceDefinitionDto definitionWithDatabaseName() {
+        Map<String, Object> dbMeta = new LinkedHashMap<>();
+        dbMeta.put("apiServerKey", "database_name");
+        Map<String, Object> hostMeta = new LinkedHashMap<>();
+        hostMeta.put("apiServerKey", "database_host");
+        Map<String, Object> connProps = new LinkedHashMap<>();
+        connProps.put("database", dbMeta);
+        connProps.put("host", hostMeta);
+        Map<String, Object> connection = new LinkedHashMap<>();
+        connection.put("properties", connProps);
+        LinkedHashMap<String, Object> properties = new LinkedHashMap<>();
+        properties.put("connection", connection);
+
+        DataSourceDefinitionDto definition = new DataSourceDefinitionDto();
+        definition.setProperties(properties);
+        return definition;
+    }
+
+    private DataSourceConnectionDto named(String name, Map<String, Object> config) {
+        DataSourceConnectionDto conn = new DataSourceConnectionDto();
+        conn.setName(name);
+        conn.setConfig(config);
+        return conn;
+    }
+
+    @Test
+    @DisplayName("JDBC：DSN 漏写库名 ⇒ 目标既有库名压过包里的源环境库名")
+    void jdbc_dsnOmitsDatabase_targetNameWins() {
+        // 包来自 SIT，带着 sit_orders；目标 PROD 上这条连接已有 prod_orders。
+        DataSourceConnectionDto incoming = named("ORDERS_PG",
+                new LinkedHashMap<>(Map.of("database", "sit_orders", "host", "pg.prod.internal")));
+        incoming.setDatabase_name("sit_orders");
+        DataSourceConnectionDto existing = named("ORDERS_PG",
+                new LinkedHashMap<>(Map.of("database", "prod_orders", "host", "pg.prod.internal")));
+        existing.setDatabase_name("prod_orders");
+
+        Map<String, String> vault = new LinkedHashMap<>();
+        vault.put("ORDERS_PG_DSN", "tapuser@pg.prod.internal:5432");   // 漏了 /prod_orders
+        vault.put("ORDERS_PG_PASSWORD", "pw");
+
+        String preserved = ResourceHandler.restoreDatabaseNameWhenDsnOmitsIt(
+                incoming, existing, definitionWithDatabaseName(), vault);
+
+        assertEquals("prod_orders", incoming.getConfig().get("database"),
+                "DSN 没写库名时，落地的必须是目标既有库名，而不是包里那个源环境的");
+        assertEquals("prod_orders", incoming.getDatabase_name(),
+                "顶层镜像要一起改——MetaDataBuilderUtils 建限定名读的是顶层，只改 config 会得到半改状态");
+        assertEquals("prod_orders", preserved, "保留了什么必须报出来（[ADR-0034] D7 绝不静默）");
+    }
+
+    @Test
+    @DisplayName("JDBC：DSN 写了库名 ⇒ DSN 赢，目标既有库名不得反压回来")
+    void jdbc_dsnCarriesDatabase_dsnWins() {
+        DataSourceConnectionDto incoming = named("ORDERS_PG",
+                new LinkedHashMap<>(Map.of("database", "newdb")));
+        incoming.setDatabase_name("newdb");
+        DataSourceConnectionDto existing = named("ORDERS_PG",
+                new LinkedHashMap<>(Map.of("database", "prod_orders")));
+        existing.setDatabase_name("prod_orders");
+
+        Map<String, String> vault = new LinkedHashMap<>();
+        vault.put("ORDERS_PG_DSN", "tapuser@pg.prod.internal:5432/newdb");
+
+        String preserved = ResourceHandler.restoreDatabaseNameWhenDsnOmitsIt(
+                incoming, existing, definitionWithDatabaseName(), vault);
+
+        assertEquals("newdb", incoming.getConfig().get("database"),
+                "「库名可逐环境不同」是本期的核心能力——保护绝不能把它顶掉");
+        assertNull(preserved, "什么都没保留就不该报");
+    }
+
+    @Test
+    @DisplayName("非格式 3（没有 _DSN 键）⇒ 一个字段都不碰")
+    void notFormat3_untouched() {
+        DataSourceConnectionDto incoming = named("ORDERS_PG",
+                new LinkedHashMap<>(Map.of("database", "sit_orders")));
+        DataSourceConnectionDto existing = named("ORDERS_PG",
+                new LinkedHashMap<>(Map.of("database", "prod_orders")));
+
+        Map<String, String> vault = new LinkedHashMap<>();
+        vault.put("ORDERS_PG_URL", "pg.prod.internal:5432");   // 格式 2
+        vault.put("ORDERS_PG_PASSWORD", "pw");
+
+        String preserved = ResourceHandler.restoreDatabaseNameWhenDsnOmitsIt(
+                incoming, existing, definitionWithDatabaseName(), vault);
+
+        assertEquals("sit_orders", incoming.getConfig().get("database"),
+                "[ADR-0036] D5 推论：库名只被格式 3 覆盖，格式 1/2 的 database_name 不被新逻辑碰到");
+        assertNull(preserved);
+    }
+
+    @Test
+    @DisplayName("MongoDB：DSN 漏写库名 ⇒ 目标既有库名拼回 uri，query 串与种子列表保真")
+    void mongo_dsnOmitsDatabase_targetNameSplicedBack() {
+        DataSourceConnectionDto incoming = named("ORDERS_MONGO", new LinkedHashMap<>(Map.of(
+                "uri", "mongodb://tapuser:pw@h1:27017,h2:27017/?replicaSet=rs0")));
+        incoming.setDatabase_uri("mongodb://tapuser:pw@h1:27017,h2:27017/?replicaSet=rs0");
+        DataSourceConnectionDto existing = named("ORDERS_MONGO", new LinkedHashMap<>(Map.of(
+                "uri", "mongodb://tapuser:oldpw@h1:27017/prod_orders")));
+        existing.setDatabase_uri("mongodb://tapuser:oldpw@h1:27017/prod_orders");
+
+        Map<String, String> vault = new LinkedHashMap<>();
+        vault.put("ORDERS_MONGO_DSN", "mongodb://tapuser:@h1:27017,h2:27017/?replicaSet=rs0");
+        vault.put("ORDERS_MONGO_PASSWORD", "pw");
+
+        String preserved = ResourceHandler.restoreDatabaseNameWhenDsnOmitsIt(
+                incoming, existing, definitionWithUri(), vault);
+
+        String uri = (String) incoming.getConfig().get("uri");
+        assertEquals("mongodb://tapuser:pw@h1:27017,h2:27017/prod_orders?replicaSet=rs0", uri,
+                "库名要拼进 path 段，且种子列表与 ?replicaSet= 必须原样保真");
+        assertEquals(uri, incoming.getDatabase_uri(), "顶层镜像与 config 必须一致");
+        assertEquals("prod_orders", preserved);
+    }
+
+    @Test
+    @DisplayName("MongoDB：DSN 写了库名 ⇒ DSN 赢")
+    void mongo_dsnCarriesDatabase_dsnWins() {
+        DataSourceConnectionDto incoming = named("ORDERS_MONGO", new LinkedHashMap<>(Map.of(
+                "uri", "mongodb://tapuser:pw@h1:27017/newdb")));
+        incoming.setDatabase_uri("mongodb://tapuser:pw@h1:27017/newdb");
+        DataSourceConnectionDto existing = named("ORDERS_MONGO", new LinkedHashMap<>(Map.of(
+                "uri", "mongodb://tapuser:oldpw@h1:27017/prod_orders")));
+
+        Map<String, String> vault = new LinkedHashMap<>();
+        vault.put("ORDERS_MONGO_DSN", "mongodb://tapuser:@h1:27017/newdb");
+
+        String preserved = ResourceHandler.restoreDatabaseNameWhenDsnOmitsIt(
+                incoming, existing, definitionWithUri(), vault);
+
+        assertEquals("mongodb://tapuser:pw@h1:27017/newdb", incoming.getConfig().get("uri"));
+        assertNull(preserved);
+    }
+
+    @Test
+    @DisplayName("目标环境也没有库名 ⇒ 不写空值，安静放过")
+    void targetHasNoDatabaseEither_noop() {
+        DataSourceConnectionDto incoming = named("ORDERS_PG",
+                new LinkedHashMap<>(Map.of("database", "sit_orders")));
+        DataSourceConnectionDto existing = named("ORDERS_PG", new LinkedHashMap<>());
+
+        Map<String, String> vault = new LinkedHashMap<>();
+        vault.put("ORDERS_PG_DSN", "tapuser@pg.prod.internal:5432");
+
+        String preserved = ResourceHandler.restoreDatabaseNameWhenDsnOmitsIt(
+                incoming, existing, definitionWithDatabaseName(), vault);
+
+        assertEquals("sit_orders", incoming.getConfig().get("database"),
+                "目标没有可保留的值时，绝不能反过来把包里那个抹空");
+        assertNull(preserved);
+    }
+
+    @Test
+    @DisplayName("目标环境还没有这条连接（首次部署）⇒ 不报错，包里的库名照用")
+    void noExistingConnection_noop() {
+        DataSourceConnectionDto incoming = named("ORDERS_PG",
+                new LinkedHashMap<>(Map.of("database", "sit_orders")));
+
+        Map<String, String> vault = new LinkedHashMap<>();
+        vault.put("ORDERS_PG_DSN", "tapuser@pg.prod.internal:5432");
+
+        String preserved = ResourceHandler.restoreDatabaseNameWhenDsnOmitsIt(
+                incoming, null, definitionWithDatabaseName(), vault);
+
+        assertEquals("sit_orders", incoming.getConfig().get("database"));
+        assertNull(preserved);
+    }
 }

--- a/manager/tm/src/test/java/com/tapdata/tm/group/handler/ResourceHandlerVaultTest.java
+++ b/manager/tm/src/test/java/com/tapdata/tm/group/handler/ResourceHandlerVaultTest.java
@@ -186,4 +186,242 @@ public class ResourceHandlerVaultTest {
                     () -> ResourceHandler.injectVaultSecretsToConnection(conn, vault, null));
         }
     }
+
+    @Nested
+    @DisplayName("格式 3：{CONN}_DSN(Variables) + {CONN}_PASSWORD(Secrets)")
+    class DsnFormatTest {
+
+        private DataSourceConnectionDto makeConn(String name) {
+            DataSourceConnectionDto conn = new DataSourceConnectionDto();
+            conn.setName(name);
+            conn.setConfig(new LinkedHashMap<>());
+            return conn;
+        }
+
+        /** 造一份只声明 configPath -> apiServerKey 的 definition，喂 buildConfigPathToApiKeyMap 的 BFS。 */
+        private DataSourceDefinitionDto defWith(Map<String, String> configPathToApiKey) {
+            LinkedHashMap<String, Object> props = new LinkedHashMap<>();
+            configPathToApiKey.forEach((path, apiKey) -> {
+                LinkedHashMap<String, Object> meta = new LinkedHashMap<>();
+                meta.put("apiServerKey", apiKey);
+                props.put(path, meta);
+            });
+            LinkedHashMap<String, Object> connection = new LinkedHashMap<>();
+            connection.put("properties", props);
+            LinkedHashMap<String, Object> properties = new LinkedHashMap<>();
+            properties.put("connection", connection);
+
+            DataSourceDefinitionDto def = new DataSourceDefinitionDto();
+            def.setProperties(properties);
+            return def;
+        }
+
+        @Test
+        @DisplayName("T7-7 MongoDB(L5)：DSN 整串直写 database_uri，{CONN}_PASSWORD splice 回 userinfo")
+        void t7_7_mongoDsnDirectWriteWithPasswordSplice() {
+            DataSourceConnectionDto conn = makeConn("ORDERS_MONGO");
+            // 包里带来的是源环境旧值，应被 DSN 整串覆盖
+            conn.getConfig().put("uri", "mongodb://tapuser:oldpw@oldhost:27017/olddb");
+
+            Map<String, String> vault = new LinkedHashMap<>();
+            vault.put("ORDERS_MONGO_DSN", "mongodb://tapuser:@h:27017/orders?authSource=admin"); // L5
+            vault.put("ORDERS_MONGO_PASSWORD", "p");
+
+            ResourceHandler.injectVaultSecretsToConnection(conn, vault,
+                    defWith(Map.of("uri", "database_uri")));
+
+            assertEquals("mongodb://tapuser:p@h:27017/orders?authSource=admin",
+                    conn.getConfig().get("uri"));
+        }
+
+        @Test
+        @DisplayName("T7-7a MongoDB(L6) 副本集：两个 host 与 replicaSet 保真，密码已填回")
+        void t7_7a_replicaSetSeedListSurvives() {
+            DataSourceConnectionDto conn = makeConn("ORDERS_MONGO");
+            Map<String, String> vault = new LinkedHashMap<>();
+            vault.put("ORDERS_MONGO_DSN",
+                    "mongodb://tapuser:@h1:27017,h2:27017/orders?replicaSet=rs0"); // L6
+            vault.put("ORDERS_MONGO_PASSWORD", "p");
+
+            ResourceHandler.injectVaultSecretsToConnection(conn, vault,
+                    defWith(Map.of("uri", "database_uri")));
+
+            String written = (String) conn.getConfig().get("uri");
+            assertEquals("mongodb://tapuser:p@h1:27017,h2:27017/orders?replicaSet=rs0", written);
+            // 反解确认不是巧合的字符串相等：两个 host + replicaSet 真的还在
+            com.mongodb.ConnectionString parsed = new com.mongodb.ConnectionString(written);
+            assertEquals(java.util.List.of("h1:27017", "h2:27017"), parsed.getHosts());
+            assertEquals("rs0", parsed.getRequiredReplicaSetName());
+            assertEquals("orders", parsed.getDatabase());
+        }
+
+        @Test
+        @DisplayName("T7-7b MongoDB(L5+L12)：含 @ : / 的密码 splice 时 percent-encode，反解等于原密码")
+        void t7_7b_specialCharPasswordIsPercentEncoded() {
+            DataSourceConnectionDto conn = makeConn("ORDERS_MONGO");
+            Map<String, String> vault = new LinkedHashMap<>();
+            vault.put("ORDERS_MONGO_DSN", "mongodb://tapuser:@h:27017/orders?authSource=admin"); // L5
+            vault.put("ORDERS_MONGO_PASSWORD", "p@ss:w/rd");                                     // L12
+
+            ResourceHandler.injectVaultSecretsToConnection(conn, vault,
+                    defWith(Map.of("uri", "database_uri")));
+
+            String written = (String) conn.getConfig().get("uri");
+            assertEquals("mongodb://tapuser:p%40ss%3Aw%2Frd@h:27017/orders?authSource=admin", written);
+            // 真正的判据：驱动能把它反解回原密码
+            com.mongodb.ConnectionString parsed = new com.mongodb.ConnectionString(written);
+            assertEquals("p@ss:w/rd", new String(parsed.getPassword()));
+            assertEquals("tapuser", parsed.getUsername());
+        }
+
+        /** JDBC 侧 schema：不含 database_uri，含四项 + database_name。 */
+        private DataSourceDefinitionDto jdbcDef() {
+            LinkedHashMap<String, String> m = new LinkedHashMap<>();
+            m.put("host", "database_host");
+            m.put("port", "database_port");
+            m.put("user", "database_username");
+            m.put("password", "database_password");
+            m.put("database", "database_name");
+            return defWith(m);
+        }
+
+        @Test
+        @DisplayName("T7-8a JDBC(L1) 裸写形态：解析出 (user, localhost, 3306, test)，库名没被当用户名")
+        void t7_8a_bareFormNormalizes() {
+            DataSourceConnectionDto conn = makeConn("ORDERS_PG");
+            conn.getConfig().put("database", "olddb");
+
+            Map<String, String> vault = new LinkedHashMap<>();
+            vault.put("ORDERS_PG_DSN", "user@localhost:3306/test"); // L1
+            vault.put("ORDERS_PG_PASSWORD", "p");
+
+            ResourceHandler.injectVaultSecretsToConnection(conn, vault, jdbcDef());
+
+            Map<String, Object> config = conn.getConfig();
+            assertEquals("localhost", config.get("host"));
+            assertEquals(3306, config.get("port"));
+            assertEquals("test", config.get("database"), "库名必须来自 DSN，覆盖包里的 olddb");
+            assertEquals("user", config.get("user"), "用户名取自 DSN 的 userinfo");
+            assertEquals("p", config.get("password"));
+            assertNotEquals("test", config.get("user"), "库名绝不能被当成用户名");
+        }
+
+        @Test
+        @DisplayName("T7-8 JDBC(L2) jdbc: 形态：库名跨环境覆盖 olddb -> test，path 首段没被当用户名")
+        void t7_8_jdbcPrefixedForm() {
+            DataSourceConnectionDto conn = makeConn("ORDERS_PG");
+            conn.getConfig().put("database", "olddb");
+
+            Map<String, String> vault = new LinkedHashMap<>();
+            vault.put("ORDERS_PG_DSN", "jdbc:mysql://user@localhost:3306/test"); // L2
+            vault.put("ORDERS_PG_PASSWORD", "p");
+
+            ResourceHandler.injectVaultSecretsToConnection(conn, vault, jdbcDef());
+
+            Map<String, Object> config = conn.getConfig();
+            assertEquals("localhost", config.get("host"));
+            assertEquals(3306, config.get("port"));
+            assertEquals("test", config.get("database"));
+            assertEquals("user", config.get("user"));
+            assertNotEquals("test", config.get("user"));
+        }
+
+        @Test
+        @DisplayName("T7-8d JDBC(L3) 只有 scheme 无 jdbc:：与 L1/L2 得到同一组四元组")
+        void t7_8d_schemeOnlyForm() {
+            DataSourceConnectionDto conn = makeConn("ORDERS_PG");
+            Map<String, String> vault = new LinkedHashMap<>();
+            vault.put("ORDERS_PG_DSN", "mysql://user@localhost:3306/test"); // L3
+            vault.put("ORDERS_PG_PASSWORD", "p");
+
+            ResourceHandler.injectVaultSecretsToConnection(conn, vault, jdbcDef());
+
+            Map<String, Object> config = conn.getConfig();
+            assertEquals("localhost", config.get("host"));
+            assertEquals(3306, config.get("port"));
+            assertEquals("test", config.get("database"));
+            assertEquals("user", config.get("user"));
+        }
+
+        @Test
+        @DisplayName("T7-8c JDBC(L11) 漏写 userinfo：库名是 test、用户名不动，且不去读 {CONN}_USER")
+        void t7_8c_missingUserInfoDoesNotReadFormat2Key() {
+            DataSourceConnectionDto conn = makeConn("ORDERS_PG");
+            conn.getConfig().put("user", "existing-user"); // 目标既有值，缺值规则应保留
+
+            Map<String, String> vault = new LinkedHashMap<>();
+            vault.put("ORDERS_PG_DSN", "localhost:3306/test"); // L11
+            vault.put("ORDERS_PG_USER", "format2-user");       // 格式 2 的键，格式 3 不认
+            vault.put("ORDERS_PG_PASSWORD", "p");
+
+            ResourceHandler.injectVaultSecretsToConnection(conn, vault, jdbcDef());
+
+            Map<String, Object> config = conn.getConfig();
+            assertEquals("test", config.get("database"), "path 首段是库名，不是用户名");
+            assertEquals("existing-user", config.get("user"), "缺 userinfo 时保留目标既有用户名");
+            assertNotEquals("test", config.get("user"));
+            assertNotEquals("format2-user", config.get("user"), "格式 3 不得混读 {CONN}_USER");
+        }
+
+        @Test
+        @DisplayName("T7-8e JDBC query 串被丢弃，additionalString 原封不动")
+        void t7_8e_queryStringDiscarded() {
+            DataSourceConnectionDto conn = makeConn("ORDERS_PG");
+            conn.getConfig().put("additionalString", "SENTINEL-UNTOUCHED");
+
+            Map<String, String> vault = new LinkedHashMap<>();
+            vault.put("ORDERS_PG_DSN", "jdbc:postgresql://h:5432/newdb?currentSchema=other");
+            vault.put("ORDERS_PG_PASSWORD", "p");
+
+            ResourceHandler.injectVaultSecretsToConnection(conn, vault, jdbcDef());
+
+            Map<String, Object> config = conn.getConfig();
+            assertEquals("newdb", config.get("database"), "query 串不得混进库名");
+            assertEquals("SENTINEL-UNTOUCHED", config.get("additionalString"),
+                    "query 串必须丢弃，不得塞进 additionalString");
+        }
+
+        @Test
+        @DisplayName("T7-8b 顶层镜像字段与 config 一起写：顶层 database_name = DSN 的库名")
+        void t7_8b_topLevelMirrorFieldsWritten() {
+            DataSourceConnectionDto conn = makeConn("ORDERS_PG");
+            conn.getConfig().put("database", "olddb");
+            // 源环境带来的顶层值：全部指向旧环境
+            conn.setDatabase_name("olddb");
+            conn.setDatabase_host("oldhost");
+            conn.setDatabase_port(5432);
+            conn.setDatabase_username("olduser");
+
+            Map<String, String> vault = new LinkedHashMap<>();
+            vault.put("ORDERS_PG_DSN", "jdbc:mysql://user@localhost:3306/test"); // L2
+            vault.put("ORDERS_PG_PASSWORD", "p");
+
+            ResourceHandler.injectVaultSecretsToConnection(conn, vault, jdbcDef());
+
+            assertEquals("test", conn.getConfig().get("database"));
+            assertEquals("test", conn.getDatabase_name(),
+                    "顶层 database_name 决定元数据限定名，只写 config 会造成半改状态");
+            // 同样的半改危险适用于其余镜像字段：不写 ⇒ preserveExistingSecrets 用目标旧值填回
+            assertEquals("localhost", conn.getDatabase_host());
+            assertEquals(3306, conn.getDatabase_port());
+            assertEquals("user", conn.getDatabase_username());
+        }
+
+        @Test
+        @DisplayName("T7-8b(mongo) 顶层 database_uri 同样被更新")
+        void t7_8b_mongoTopLevelUriWritten() {
+            DataSourceConnectionDto conn = makeConn("ORDERS_MONGO");
+            conn.setDatabase_uri("mongodb://tapuser:oldpw@oldhost:27017/olddb");
+
+            Map<String, String> vault = new LinkedHashMap<>();
+            vault.put("ORDERS_MONGO_DSN", "mongodb://tapuser:@h:27017/orders?authSource=admin"); // L5
+            vault.put("ORDERS_MONGO_PASSWORD", "p");
+
+            ResourceHandler.injectVaultSecretsToConnection(conn, vault,
+                    defWith(Map.of("uri", "database_uri")));
+
+            assertEquals("mongodb://tapuser:p@h:27017/orders?authSource=admin",
+                    conn.getDatabase_uri());
+        }
+    }
 }

--- a/manager/tm/src/test/java/com/tapdata/tm/group/handler/ResourceHandlerVaultTest.java
+++ b/manager/tm/src/test/java/com/tapdata/tm/group/handler/ResourceHandlerVaultTest.java
@@ -482,8 +482,8 @@ public class ResourceHandlerVaultTest {
         }
 
         @Test
-        @DisplayName("D10(L10) DSN 无库名：沿用目标旧库名并告警，不报错")
-        void d10_missingDatabaseNameWarnsAndKeepsOld() {
+        @DisplayName("D10(L10) DSN 无库名：inject 不写库名、只告警，不报错")
+        void d10_missingDatabaseNameWarnsAndDoesNotWrite() {
             DataSourceConnectionDto conn = makeConn("ORDERS_PG");
             conn.getConfig().put("database", "olddb");
 
@@ -493,7 +493,14 @@ public class ResourceHandlerVaultTest {
 
             ResourceHandler.injectVaultSecretsToConnection(conn, vault, jdbcDef());
 
-            assertEquals("olddb", conn.getConfig().get("database"), "无库名时保留目标既有库名");
+            // ⚠ 这条**只**证明 inject 没往 database 写东西（injectParsedField 遇 null 直接
+            // no-op）。它一度被写成「保留目标既有库名」，那是错的：conn 是 **incoming**、
+            // 即包里那份，携带的是**源环境**的库名，与目标环境毫无关系。真正的覆盖发生在
+            // GROUP_IMPORT 整文档替换那一层，而「目标既有库名不被覆盖」由
+            // ResourceHandlerImportPreserveTest 那组 incoming/existing 双对象用例钉死。
+            // 一条名字撒谎的绿用例把这个缺陷盖了很久——改名是修复的一部分。
+            assertEquals("olddb", conn.getConfig().get("database"),
+                    "inject 不该往 database 写值；这里的 olddb 是包里那份，不是目标环境的");
             assertWarnContains("database name");
         }
 

--- a/manager/tm/src/test/java/com/tapdata/tm/group/handler/ResourceHandlerVaultTest.java
+++ b/manager/tm/src/test/java/com/tapdata/tm/group/handler/ResourceHandlerVaultTest.java
@@ -513,6 +513,27 @@ public class ResourceHandlerVaultTest {
         }
 
         @Test
+        @DisplayName("D10(mongo · L11) DSN 漏写 userinfo：密码无处可拼，必须告警而不是静默丢")
+        void d10_mongoMissingUserInfoWarnsInsteadOfDroppingPasswordSilently() {
+            DataSourceConnectionDto conn = makeConn("ORDERS_MONGO");
+            Map<String, String> vault = new LinkedHashMap<>();
+            // 漏了 "tapuser:@" 那一截——不带凭据的 mongodb URI 本身合法，
+            // 所以 validateMongoDsn 放行、整条链路一路绿灯。
+            vault.put("ORDERS_MONGO_DSN", "mongodb://h:27017/orders");
+            vault.put("ORDERS_MONGO_PASSWORD", "p");
+
+            ResourceHandler.injectVaultSecretsToConnection(conn, vault,
+                    defWith(Map.of("uri", "database_uri")));
+
+            // 串照写、不报错（缺值规则不是「报错」）
+            assertEquals("mongodb://h:27017/orders", conn.getConfig().get("uri"));
+            // 但密码确实被丢了 ⇒ 必须留下逐字点名那个键的 WARN。
+            // 鉴别性：pwValue 非 null，所以「no {CONN}_PASSWORD in vault」那条压根不触发，
+            // 命中这个断言的只可能是 splice 侧新加的那条。
+            assertWarnContains("ORDERS_MONGO_PASSWORD");
+        }
+
+        @Test
         @DisplayName("D10 无 {CONN}_PASSWORD：不报错，告警逐字点名那个键名")
         void d10_missingPasswordWarnsNamingTheKeyVerbatim() {
             DataSourceConnectionDto conn = makeConn("ORDERS_PG");

--- a/manager/tm/src/test/java/com/tapdata/tm/group/handler/ResourceHandlerVaultTest.java
+++ b/manager/tm/src/test/java/com/tapdata/tm/group/handler/ResourceHandlerVaultTest.java
@@ -1,12 +1,19 @@
 package com.tapdata.tm.group.handler;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import com.tapdata.tm.commons.schema.DataSourceConnectionDto;
 import com.tapdata.tm.commons.schema.DataSourceDefinitionDto;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -253,6 +260,10 @@ public class ResourceHandlerVaultTest {
             assertEquals(java.util.List.of("h1:27017", "h2:27017"), parsed.getHosts());
             assertEquals("rs0", parsed.getRequiredReplicaSetName());
             assertEquals("orders", parsed.getDatabase());
+            // D11 的对照：MongoDB 整串直写、不受 query 丢弃之限。把丢弃写成与类型无关的
+            // 实现会在这里误丢 replicaSet 并误报告警——而 HA 的常态就是副本集。
+            assertTrue(loggedAt(Level.WARN).stream().noneMatch(m -> m.contains("discarded")),
+                    "MongoDB 侧不得发 query 丢弃告警，实际 WARN=" + loggedAt(Level.WARN));
         }
 
         @Test
@@ -422,6 +433,191 @@ public class ResourceHandlerVaultTest {
 
             assertEquals("mongodb://tapuser:p@h:27017/orders?authSource=admin",
                     conn.getDatabase_uri());
+        }
+
+        /** 「响亮」是有级别的契约，故真去接日志，不靠肉眼看控制台。 */
+        private ListAppender<ILoggingEvent> logs;
+
+        @BeforeEach
+        void attachAppender() {
+            logs = new ListAppender<>();
+            logs.start();
+            handlerLogger().addAppender(logs);
+        }
+
+        @AfterEach
+        void detachAppender() {
+            handlerLogger().detachAppender(logs);
+        }
+
+        private ch.qos.logback.classic.Logger handlerLogger() {
+            return (ch.qos.logback.classic.Logger)
+                    org.slf4j.LoggerFactory.getLogger(ResourceHandler.class);
+        }
+
+        private List<String> loggedAt(Level level) {
+            List<String> messages = new ArrayList<>();
+            for (ILoggingEvent event : logs.list) {
+                if (event.getLevel() == level) messages.add(event.getFormattedMessage());
+            }
+            return messages;
+        }
+
+        private void assertWarnContains(String needle) {
+            assertTrue(loggedAt(Level.WARN).stream().anyMatch(m -> m.contains(needle)),
+                    "期望一条 WARN 逐字包含 '" + needle + "'，实际 WARN=" + loggedAt(Level.WARN));
+        }
+
+        @Test
+        @DisplayName("T7-8e query 串被丢弃时，告警逐字点名被丢掉的那一段")
+        void t7_8e_queryDiscardWarningNamesIt() {
+            DataSourceConnectionDto conn = makeConn("ORDERS_PG");
+            Map<String, String> vault = new LinkedHashMap<>();
+            vault.put("ORDERS_PG_DSN", "jdbc:postgresql://h:5432/newdb?currentSchema=other");
+            vault.put("ORDERS_PG_PASSWORD", "p");
+
+            ResourceHandler.injectVaultSecretsToConnection(conn, vault, jdbcDef());
+
+            assertWarnContains("currentSchema=other");
+        }
+
+        @Test
+        @DisplayName("D10(L10) DSN 无库名：沿用目标旧库名并告警，不报错")
+        void d10_missingDatabaseNameWarnsAndKeepsOld() {
+            DataSourceConnectionDto conn = makeConn("ORDERS_PG");
+            conn.getConfig().put("database", "olddb");
+
+            Map<String, String> vault = new LinkedHashMap<>();
+            vault.put("ORDERS_PG_DSN", "localhost:3306"); // L10
+            vault.put("ORDERS_PG_PASSWORD", "p");
+
+            ResourceHandler.injectVaultSecretsToConnection(conn, vault, jdbcDef());
+
+            assertEquals("olddb", conn.getConfig().get("database"), "无库名时保留目标既有库名");
+            assertWarnContains("database name");
+        }
+
+        @Test
+        @DisplayName("D10(L11) DSN 漏写 userinfo：保留目标既有用户名并告警")
+        void d10_missingUserInfoWarns() {
+            DataSourceConnectionDto conn = makeConn("ORDERS_PG");
+            conn.getConfig().put("user", "existing-user");
+
+            Map<String, String> vault = new LinkedHashMap<>();
+            vault.put("ORDERS_PG_DSN", "localhost:3306/test"); // L11
+            vault.put("ORDERS_PG_PASSWORD", "p");
+
+            ResourceHandler.injectVaultSecretsToConnection(conn, vault, jdbcDef());
+
+            assertWarnContains("username");
+        }
+
+        @Test
+        @DisplayName("D10 无 {CONN}_PASSWORD：不报错，告警逐字点名那个键名")
+        void d10_missingPasswordWarnsNamingTheKeyVerbatim() {
+            DataSourceConnectionDto conn = makeConn("ORDERS_PG");
+            Map<String, String> vault = new LinkedHashMap<>();
+            vault.put("ORDERS_PG_DSN", "user@localhost:3306/test"); // L1，无 _PASSWORD
+
+            ResourceHandler.injectVaultSecretsToConnection(conn, vault, jdbcDef());
+
+            assertEquals("test", conn.getConfig().get("database"), "缺密码不影响其余成分照常写入");
+            // 泛化的 "no matching vault keys" 不算——操作者要能一眼看出该去配哪个键
+            assertWarnContains("ORDERS_PG_PASSWORD");
+        }
+
+        @Test
+        @DisplayName("T7-12 无 {CONN}_PASSWORD 时 password 路径原封不动，不写空串也不写 null")
+        void t7_12_noPasswordLeavesPasswordPathUntouched() {
+            DataSourceConnectionDto conn = makeConn("ORDERS_PG");
+            conn.getConfig().put("password", "SENTINEL-TARGET-PASSWORD");
+
+            Map<String, String> vault = new LinkedHashMap<>();
+            vault.put("ORDERS_PG_DSN", "user@localhost:3306/test"); // L1，无 _PASSWORD
+
+            ResourceHandler.injectVaultSecretsToConnection(conn, vault, jdbcDef());
+
+            assertEquals("SENTINEL-TARGET-PASSWORD", conn.getConfig().get("password"),
+                    "写空值会让 [ADR-0034] D5 认为包里有值而放行，目标密码当场被抹空");
+            assertEquals("localhost", conn.getConfig().get("host"), "其余成分照常写入");
+        }
+
+        @Test
+        @DisplayName("D8 先拼后验：splice 结果非法时报错，且消息不回显拼出来的串")
+        void d8_splicedResultIsValidatedAndErrorDoesNotEchoIt() {
+            DataSourceConnectionDto conn = makeConn("ORDERS_MONGO");
+            Map<String, String> vault = new LinkedHashMap<>();
+            // 作者漏编码的用户名：raw '@' 在 userinfo 里，ConnectionString 会拒
+            vault.put("ORDERS_MONGO_DSN", "mongodb://us@er:@h:27017/db");
+            vault.put("ORDERS_MONGO_PASSWORD", "secret-pw");
+
+            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                    () -> ResourceHandler.injectVaultSecretsToConnection(conn, vault,
+                            defWith(Map.of("uri", "database_uri"))));
+
+            assertTrue(ex.getMessage().contains("ORDERS_MONGO"), "消息要点名是哪条连接");
+            assertFalse(ex.getMessage().contains("secret-pw"),
+                    "splice 之后串里带着密码，消息绝不能回显它");
+        }
+
+        @Test
+        @DisplayName("优先级6 无命中报错文案提到 DSN，让老 TM 撞上时自解释")
+        void priority6_errorMessageMentionsDsn() {
+            DataSourceConnectionDto conn = makeConn("ORDERS_PG");
+            Map<String, String> vault = new LinkedHashMap<>();
+            vault.put("OTHER_url", "h:1");
+            vault.put("OTHER_user", "u");
+            vault.put("OTHER_password", "p");
+
+            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                    () -> ResourceHandler.injectVaultSecretsToConnection(conn, vault, jdbcDef()));
+
+            assertTrue(ex.getMessage().toLowerCase().contains("dsn"),
+                    "老 TM 遇到只含 _DSN 的 vault 会走到这里中止整批导入，文案不提 DSN 就读成租户配错了；实际=" + ex.getMessage());
+        }
+
+        @Test
+        @DisplayName("T7-9 老 vault 回归：只有 {CONN}_URI 时行为逐字不变，password 字段不被碰")
+        void t7_9_legacyUriPathUnchanged() {
+            DataSourceConnectionDto conn = makeConn("ORDERS_MONGO");
+            conn.getConfig().put("password", "SENTINEL-TARGET-PASSWORD");
+
+            Map<String, String> vault = new LinkedHashMap<>();
+            vault.put("ORDERS_MONGO_uri", "mongodb://u:pw@h:27017/db");
+            // ⚠ vault 里**必须**同时放一个 password 键，否则这条断言是假闸：
+            // 没有这个键时，任何"多去找一次 password"的实现都因查不到而跳过，哨兵照样活着。
+            vault.put("ORDERS_MONGO_password", "SHOULD-NOT-BE-INJECTED");
+
+            ResourceHandler.injectVaultSecretsToConnection(conn, vault,
+                    defWith(Map.of("uri", "database_uri")));
+
+            assertEquals("mongodb://u:pw@h:27017/db", conn.getConfig().get("uri"), "整串直写，与今天一致");
+            assertEquals("SENTINEL-TARGET-PASSWORD", conn.getConfig().get("password"),
+                    "老 uri 路径从不注入 password；新逻辑若无条件去找 password，这里会多写一个字段");
+        }
+
+        @Test
+        @DisplayName("T7-10 老格式回归：{CONN}_URL/_USER/_PASSWORD 结果不变，且库名不被新逻辑碰到")
+        void t7_10_legacyUrlPathDoesNotTouchDatabaseName() {
+            DataSourceConnectionDto conn = makeConn("ORDERS_PG");
+            conn.getConfig().put("database", "olddb");
+            conn.setDatabase_name("olddb");
+
+            Map<String, String> vault = new LinkedHashMap<>();
+            vault.put("ORDERS_PG_URL", "pghost:5432");
+            vault.put("ORDERS_PG_USER", "pguser");
+            vault.put("ORDERS_PG_PASSWORD", "pgpass");
+
+            ResourceHandler.injectVaultSecretsToConnection(conn, vault, jdbcDef());
+
+            Map<String, Object> config = conn.getConfig();
+            assertEquals("pghost", config.get("host"));
+            assertEquals(5432, config.get("port"));
+            assertEquals("pguser", config.get("user"));
+            assertEquals("pgpass", config.get("password"));
+            // 「已定口径 3」：库名覆盖是格式 3 独有的能力，老格式一个字都不改
+            assertEquals("olddb", config.get("database"), "老格式不得获得库名覆盖能力");
+            assertEquals("olddb", conn.getDatabase_name(), "顶层同理");
         }
     }
 }

--- a/manager/tm/src/test/java/com/tapdata/tm/group/service/GroupInfoServiceTest.java
+++ b/manager/tm/src/test/java/com/tapdata/tm/group/service/GroupInfoServiceTest.java
@@ -2315,6 +2315,147 @@ public class GroupInfoServiceTest {
             return new TaskUpAndLoadDto(GroupConstants.COLLECTION_CONNECTION, JsonUtil.toJsonUseJackson(json));
         }
 
+        // ---- diff 预览与真实导入必须说同一件事 -------------------------------
+        // 这两条盯的是同一类故障：预览路径 buildConnectionDiff 与导入路径各算各的，
+        // 一处修了另一处没修，而**预览错了不会有任何东西报出来**——它只是让操作者
+        // 据以批准导入的那张表是错的。
+
+        /** 带 pdkHash 的连接 payload——预览路径靠它去 defByPdkHash 里取 definition。 */
+        private TaskUpAndLoadDto connPayloadWithPdkHash(String id, String name, String pdkHash,
+                Map<String, Object> config) {
+            Map<String, Object> json = new LinkedHashMap<>();
+            json.put("id", id);
+            json.put("name", name);
+            json.put("connection_type", "source");
+            json.put("database_type", "MySQL");
+            json.put("pdkHash", pdkHash);
+            if (config != null) json.put("config", config);
+            return new TaskUpAndLoadDto(GroupConstants.COLLECTION_CONNECTION, JsonUtil.toJsonUseJackson(json));
+        }
+
+        /** 只声明 configPath -> apiServerKey 的 definition。 */
+        private DataSourceDefinitionDto defWithPaths(String pdkHash, Integer buildNumber,
+                Map<String, String> configPathToApiKey) {
+            LinkedHashMap<String, Object> props = new LinkedHashMap<>();
+            configPathToApiKey.forEach((path, apiKey) -> {
+                LinkedHashMap<String, Object> meta = new LinkedHashMap<>();
+                meta.put("apiServerKey", apiKey);
+                props.put(path, meta);
+            });
+            LinkedHashMap<String, Object> connection = new LinkedHashMap<>();
+            connection.put("properties", props);
+            LinkedHashMap<String, Object> properties = new LinkedHashMap<>();
+            properties.put("connection", connection);
+            DataSourceDefinitionDto def = new DataSourceDefinitionDto();
+            def.setPdkHash(pdkHash);
+            def.setPdkAPIBuildNumber(buildNumber);
+            def.setProperties(properties);
+            return def;
+        }
+
+        private List<String> changedFieldsOf(ResourceDiff diff) {
+            List<String> fields = new ArrayList<>();
+            for (ResourceDiffItem item : diff.getUpdate()) {
+                if (item.getChanges() == null) continue;
+                for (FieldChange c : item.getChanges()) fields.add(c.getField());
+            }
+            return fields;
+        }
+
+        @Test
+        @DisplayName("DSN 漏写库名：预览不得报一处不会发生的库名变更")
+        void diffRunsTheSamePreservationTheImportRuns() {
+            ObjectId connId = new ObjectId();
+            String pdkHash = "hash-pg";
+
+            // 包来自 SIT，带 sit_orders；目标 PROD 上已有 prod_orders。
+            Map<String, Object> fileConfig = new LinkedHashMap<>();
+            fileConfig.put("database", "sit_orders");
+            TaskUpAndLoadDto connItem = connPayloadWithPdkHash(
+                    connId.toHexString(), "conn1", pdkHash, fileConfig);
+
+            // DSN 只给 host/port/user、**没有库名**，且这三项与目标一致——
+            // 好让「库名」成为唯一可能的差异，断言因此是精确的。
+            Map<String, String> vaultMap = new LinkedHashMap<>();
+            vaultMap.put("conn1_dsn", "tapuser@pg.prod.internal:5432");
+            TaskUpAndLoadDto vaultItem = new TaskUpAndLoadDto(
+                    GroupConstants.VAULT_FILE, JsonUtil.toJsonUseJackson(vaultMap));
+
+            Map<String, List<TaskUpAndLoadDto>> payloads = new HashMap<>();
+            payloads.put("Connection.json", List.of(connItem));
+            payloads.put(GroupConstants.VAULT_FILE, List.of(vaultItem));
+
+            DataSourceConnectionDto existing = new DataSourceConnectionDto();
+            existing.setId(connId);
+            existing.setName("conn1");
+            existing.setConnection_type("source");
+            existing.setDatabase_type("MySQL");
+            existing.setPdkHash(pdkHash);
+            Map<String, Object> existingConfig = new LinkedHashMap<>();
+            existingConfig.put("host", "pg.prod.internal");
+            existingConfig.put("port", 5432);
+            existingConfig.put("user", "tapuser");
+            existingConfig.put("database", "prod_orders");
+            existing.setConfig(existingConfig);
+
+            when(dataSourceService.findAllDto(any(Query.class), any(UserDetail.class)))
+                    .thenReturn(List.of(existing));
+            lenient().when(dataSourceDefinitionService.findByPdkHashList(anySet(), any(UserDetail.class)))
+                    .thenReturn(List.of(defWithPaths(pdkHash, 2, Map.of(
+                            "host", "database_host", "port", "database_port",
+                            "user", "database_username", "database", "database_name"))));
+
+            ResourceDiff diff = invoke(payloads);
+
+            List<String> changed = changedFieldsOf(diff);
+            assertFalse(changed.contains("config.database"),
+                    "真实导入会保留目标的 prod_orders，预览报一处库名变更就是在报一件不会发生的事：" + changed);
+        }
+
+        @Test
+        @DisplayName("同 pdkHash 多份 definition：预览路径也要取 pdkAPIBuildNumber 更高的那份")
+        void diffPicksHighestPdkApiBuildNumberAmongDuplicates() {
+            ObjectId connId = new ObjectId();
+            String pdkHash = "hash-dup";
+
+            Map<String, Object> fileConfig = new LinkedHashMap<>();
+            fileConfig.put("database", "olddb");
+            TaskUpAndLoadDto connItem = connPayloadWithPdkHash(
+                    connId.toHexString(), "conn1", pdkHash, fileConfig);
+
+            Map<String, String> vaultMap = new LinkedHashMap<>();
+            vaultMap.put("conn1_dsn", "tapuser@h:5432/newdb");
+            TaskUpAndLoadDto vaultItem = new TaskUpAndLoadDto(
+                    GroupConstants.VAULT_FILE, JsonUtil.toJsonUseJackson(vaultMap));
+
+            Map<String, List<TaskUpAndLoadDto>> payloads = new HashMap<>();
+            payloads.put("Connection.json", List.of(connItem));
+            payloads.put(GroupConstants.VAULT_FILE, List.of(vaultItem));
+
+            DataSourceConnectionDto existing = new DataSourceConnectionDto();
+            existing.setId(connId);
+            existing.setName("conn1");
+            existing.setConnection_type("source");
+            existing.setDatabase_type("MySQL");
+            existing.setPdkHash(pdkHash);
+            existing.setConfig(new LinkedHashMap<>(Map.of("database", "olddb")));
+
+            // 用 configPath 当指纹：旧 build 把库名挂在 legacy_database 上，新 build 挂在
+            // database 上。返回顺序**刻意**把旧的排前面——(a, b) -> a 会保留它。
+            DataSourceDefinitionDto oldBuild = defWithPaths(pdkHash, 1, Map.of("legacy_database", "database_name"));
+            DataSourceDefinitionDto newBuild = defWithPaths(pdkHash, 2, Map.of("database", "database_name"));
+            when(dataSourceService.findAllDto(any(Query.class), any(UserDetail.class)))
+                    .thenReturn(List.of(existing));
+            when(dataSourceDefinitionService.findByPdkHashList(anySet(), any(UserDetail.class)))
+                    .thenReturn(List.of(oldBuild, newBuild));
+
+            ResourceDiff diff = invoke(payloads);
+
+            List<String> changed = changedFieldsOf(diff);
+            assertTrue(changed.contains("config.database"),
+                    "取到旧 definition 就会把新库名写进 legacy_database，预览里 config.database 纹丝不动：" + changed);
+        }
+
         @Test
         @DisplayName("Empty payloads returns empty diff")
         void testEmptyPayloads() {

--- a/manager/tm/src/test/java/com/tapdata/tm/group/service/GroupInfoServiceVaultInjectTest.java
+++ b/manager/tm/src/test/java/com/tapdata/tm/group/service/GroupInfoServiceVaultInjectTest.java
@@ -1,0 +1,116 @@
+package com.tapdata.tm.group.service;
+
+import com.tapdata.tm.commons.schema.DataSourceConnectionDto;
+import com.tapdata.tm.commons.schema.DataSourceDefinitionDto;
+import com.tapdata.tm.config.security.SimpleGrantedAuthority;
+import com.tapdata.tm.config.security.UserDetail;
+import com.tapdata.tm.ds.service.impl.DataSourceDefinitionService;
+import com.tapdata.tm.group.repostitory.GroupInfoRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * T7-12a · {@code GroupInfoService.injectVaultSecrets} 的 N+1 批量化。
+ *
+ * <p>它今天对<b>每条连接</b>调一次 {@code findByPdkHash}；同文件的 diff 路径早已改成
+ * {@code findByPdkHashList} 批量查 + map 查找。两者对 {@code pdkHash == null} 的处理
+ * <b>不同</b>（批量路径有 {@code != null} 过滤，逐条路径把 null 直接传进去）——
+ * 这正是批量化改写最容易悄悄改掉的边角，故单独钉住。
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class GroupInfoServiceVaultInjectTest {
+
+    @Mock
+    private GroupInfoRepository groupInfoRepository;
+    @Mock
+    private DataSourceDefinitionService dataSourceDefinitionService;
+
+    private GroupInfoService groupInfoService;
+    private UserDetail user;
+
+    @BeforeEach
+    void setUp() {
+        groupInfoService = new GroupInfoService(groupInfoRepository);
+        ReflectionTestUtils.setField(groupInfoService, "dataSourceDefinitionService", dataSourceDefinitionService);
+        user = new UserDetail("userId123", "customerId", "testuser", "password", "customerType",
+                "accessCode", false, false, false, false,
+                Collections.singletonList(new SimpleGrantedAuthority("role")));
+    }
+
+    private DataSourceConnectionDto conn(String name, String pdkHash) {
+        DataSourceConnectionDto c = new DataSourceConnectionDto();
+        c.setName(name);
+        c.setPdkHash(pdkHash);
+        c.setConfig(new LinkedHashMap<>());
+        return c;
+    }
+
+    @Test
+    @DisplayName("T7-12a 批量查 definition：一次 findByPdkHashList，null pdkHash 被过滤且该连接照常注入")
+    void t7_12a_batchesDefinitionLookupAndToleratesNullPdkHash() {
+        DataSourceConnectionDto a = conn("CONN_A", "hash-1");
+        DataSourceConnectionDto b = conn("CONN_B", "hash-1"); // 同型，应共用一次查询
+        DataSourceConnectionDto c = conn("CONN_C", null);     // 边角：没有 pdkHash
+
+        Map<String, DataSourceConnectionDto> connections = new LinkedHashMap<>();
+        connections.put("a", a);
+        connections.put("b", b);
+        connections.put("c", c);
+
+        DataSourceDefinitionDto def = new DataSourceDefinitionDto();
+        def.setPdkHash("hash-1");
+        when(dataSourceDefinitionService.findByPdkHashList(any(), any())).thenReturn(List.of(def));
+
+        Map<String, String> vault = new LinkedHashMap<>();
+        vault.put("CONN_A_URL", "ha:5432");
+        vault.put("CONN_A_USER", "ua");
+        vault.put("CONN_A_PASSWORD", "pa");
+        vault.put("CONN_B_URL", "hb:5432");
+        vault.put("CONN_B_USER", "ub");
+        vault.put("CONN_B_PASSWORD", "pb");
+        vault.put("CONN_C_URL", "hc:5432");
+        vault.put("CONN_C_USER", "uc");
+        vault.put("CONN_C_PASSWORD", "pc");
+
+        ReflectionTestUtils.invokeMethod(groupInfoService, "injectVaultSecrets", connections, vault, user);
+
+        // 批量：一次查询覆盖全部连接
+        ArgumentCaptor<Set<String>> captor = ArgumentCaptor.forClass(Set.class);
+        verify(dataSourceDefinitionService, times(1)).findByPdkHashList(captor.capture(), any());
+        assertEquals(Set.of("hash-1"), captor.getValue(), "null pdkHash 必须被过滤掉，不能进查询集合");
+
+        // 逐条查询必须彻底消失，否则 N+1 还在
+        verify(dataSourceDefinitionService, never()).findByPdkHash(anyString(), anyInt(), any());
+
+        // pdkHash == null 的那条不抛异常、照常走无 definition 的分支（fallback config key）
+        assertEquals("pc", c.getConfig().get("password"));
+        assertEquals("uc", c.getConfig().get("username"));
+        assertEquals("hc", c.getConfig().get("host"));
+        assertFalse(a.getConfig().isEmpty(), "有 definition 的连接同样照常注入");
+    }
+}

--- a/manager/tm/src/test/java/com/tapdata/tm/group/service/GroupInfoServiceVaultInjectTest.java
+++ b/manager/tm/src/test/java/com/tapdata/tm/group/service/GroupInfoServiceVaultInjectTest.java
@@ -113,4 +113,47 @@ class GroupInfoServiceVaultInjectTest {
         assertEquals("hc", c.getConfig().get("host"));
         assertFalse(a.getConfig().isEmpty(), "有 definition 的连接同样照常注入");
     }
+
+    @Test
+    @DisplayName("同型连接的 schema BFS 只跑一次：按 pdkHash 记忆化")
+    void memoizesSchemaBfsPerPdkHash() {
+        DataSourceConnectionDto a = conn("CONN_A", "hash-1");
+        DataSourceConnectionDto b = conn("CONN_B", "hash-1"); // 同型
+        DataSourceConnectionDto c = conn("CONN_C", "hash-1"); // 同型
+
+        Map<String, DataSourceConnectionDto> connections = new LinkedHashMap<>();
+        connections.put("a", a);
+        connections.put("b", b);
+        connections.put("c", c);
+
+        // BFS 的入口是 definition.getProperties()——用 mock 数它被读了几次，
+        // 就等于数 schema BFS 跑了几遍。三条同型连接应当只跑一遍。
+        DataSourceDefinitionDto def = org.mockito.Mockito.mock(DataSourceDefinitionDto.class);
+        when(def.getPdkHash()).thenReturn("hash-1");
+        LinkedHashMap<String, Object> props = new LinkedHashMap<>();
+        LinkedHashMap<String, Object> connection = new LinkedHashMap<>();
+        LinkedHashMap<String, Object> inner = new LinkedHashMap<>();
+        LinkedHashMap<String, Object> meta = new LinkedHashMap<>();
+        meta.put("apiServerKey", "database_password");
+        inner.put("password", meta);
+        connection.put("properties", inner);
+        props.put("connection", connection);
+        when(def.getProperties()).thenReturn(props);
+        when(dataSourceDefinitionService.findByPdkHashList(any(), any())).thenReturn(List.of(def));
+
+        Map<String, String> vault = new LinkedHashMap<>();
+        for (String n : List.of("CONN_A", "CONN_B", "CONN_C")) {
+            vault.put(n + "_URL", "h:5432");
+            vault.put(n + "_USER", "u");
+            vault.put(n + "_PASSWORD", "p");
+        }
+
+        ReflectionTestUtils.invokeMethod(groupInfoService, "injectVaultSecrets", connections, vault, user);
+
+        verify(def, times(1)).getProperties();
+        // 记忆化不得改变结果：三条都要按 schema 路径写到 password 上
+        assertEquals("p", a.getConfig().get("password"));
+        assertEquals("p", b.getConfig().get("password"));
+        assertEquals("p", c.getConfig().get("password"));
+    }
 }

--- a/manager/tm/src/test/java/com/tapdata/tm/group/service/GroupInfoServiceVaultInjectTest.java
+++ b/manager/tm/src/test/java/com/tapdata/tm/group/service/GroupInfoServiceVaultInjectTest.java
@@ -25,6 +25,7 @@ import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -112,6 +113,51 @@ class GroupInfoServiceVaultInjectTest {
         assertEquals("uc", c.getConfig().get("username"));
         assertEquals("hc", c.getConfig().get("host"));
         assertFalse(a.getConfig().isEmpty(), "有 definition 的连接同样照常注入");
+    }
+
+    /** 造一份把 database_password 挂在指定 configPath 上的 definition，用 configPath 当指纹。 */
+    private DataSourceDefinitionDto defWithPasswordPath(String pdkHash, Integer buildNumber, String configPath) {
+        DataSourceDefinitionDto def = new DataSourceDefinitionDto();
+        def.setPdkHash(pdkHash);
+        def.setPdkAPIBuildNumber(buildNumber);
+        LinkedHashMap<String, Object> meta = new LinkedHashMap<>();
+        meta.put("apiServerKey", "database_password");
+        LinkedHashMap<String, Object> inner = new LinkedHashMap<>();
+        inner.put(configPath, meta);
+        LinkedHashMap<String, Object> connection = new LinkedHashMap<>();
+        connection.put("properties", inner);
+        LinkedHashMap<String, Object> props = new LinkedHashMap<>();
+        props.put("connection", connection);
+        def.setProperties(props);
+        return def;
+    }
+
+    @Test
+    @DisplayName("同 pdkHash 多份 definition：取 pdkAPIBuildNumber 最高的那份，不取返回顺序里的第一份")
+    void picksHighestPdkApiBuildNumberAmongDuplicates() {
+        // 同一个 pdkHash 有多份文档是设计使然：PkdSourceService 的 upsert 键含
+        // pdkAPIBuildNumber，集合上那条 pdkHash_1_pdkAPIBuildNumber_1 索引就是为它建的。
+        // 被批量化替换掉的 findByPdkHash 是「按该字段降序取第一条」，批量版必须复现这一点。
+        DataSourceConnectionDto a = conn("CONN_A", "hash-1");
+        Map<String, DataSourceConnectionDto> connections = new LinkedHashMap<>();
+        connections.put("a", a);
+
+        // 返回顺序刻意把**旧** build 排在前面——findAll 无序，(a, b) -> a 会取到它。
+        DataSourceDefinitionDto oldDef = defWithPasswordPath("hash-1", 5, "legacy_password");
+        DataSourceDefinitionDto newDef = defWithPasswordPath("hash-1", 8, "password");
+        when(dataSourceDefinitionService.findByPdkHashList(any(), any()))
+                .thenReturn(List.of(oldDef, newDef));
+
+        Map<String, String> vault = new LinkedHashMap<>();
+        vault.put("CONN_A_URL", "ha:5432");
+        vault.put("CONN_A_USER", "ua");
+        vault.put("CONN_A_PASSWORD", "pa");
+
+        ReflectionTestUtils.invokeMethod(groupInfoService, "injectVaultSecrets", connections, vault, user);
+
+        // configPath 就是指纹：写到哪个键上，就说明 BFS 跑的是哪一份 schema。
+        assertEquals("pa", a.getConfig().get("password"), "必须落在 build=8 那份 schema 的路径上");
+        assertNull(a.getConfig().get("legacy_password"), "落在 legacy 路径上 = 取到了旧 build 的 definition");
     }
 
     @Test


### PR DESCRIPTION
- **feat(vault): TM 侧支持格式 3——{CONN}_DSN + {CONN}_PASSWORD 注入连接**
- **feat(vault): 格式 3 的缺值/丢弃告警、splice 校验、六级优先级注释、N+1 批量化**
- **perf(vault): schema BFS 按 pdkHash 记忆化——同型连接只跑一遍**
