### PR TITLE
fix(TAP-12570): [to 4.21] The single node DAG was mistakenly replaced as the "t…

### DIFF
--- a/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/task/preview/TaskPreviewService.java
+++ b/iengine/iengine-app/src/main/java/io/tapdata/flow/engine/V2/task/preview/TaskPreviewService.java
@@ -247,11 +247,13 @@ public class TaskPreviewService {
 
 	protected Dag handlePreviewTargetNode(DAG dag) {
 		List<Node> allTypeTargetNodes = dag.getAllTypeTargetNodes();
+		List<Node> sourceNodes = dag.getSourceNodes();
 		for (Node targetNode : allTypeTargetNodes) {
 			PreviewTargetNode previewTargetNode = new PreviewTargetNode();
 			previewTargetNode.setName(PreviewTargetNode.class.getSimpleName());
 			previewTargetNode.setId(UUID.randomUUID().toString());
-			if (targetNode.isDataNode() || targetNode instanceof VirtualTargetNode) {
+			boolean isSourceNode = sourceNodes.stream().anyMatch(sourceNode -> Objects.equals(sourceNode.getId(), targetNode.getId()));
+			if ((targetNode.isDataNode() || targetNode instanceof VirtualTargetNode) && !isSourceNode) {
 				dag.replaceNode(targetNode, previewTargetNode);
 			} else {
 				dag.addTargetNode(targetNode, previewTargetNode);

--- a/iengine/iengine-app/src/test/java/io/tapdata/flow/engine/V2/task/preview/TaskPreviewServiceTest.java
+++ b/iengine/iengine-app/src/test/java/io/tapdata/flow/engine/V2/task/preview/TaskPreviewServiceTest.java
@@ -1,6 +1,12 @@
 package io.tapdata.flow.engine.V2.task.preview;
 
 import com.tapdata.constant.BeanUtil;
+import com.tapdata.tm.commons.dag.DAG;
+import com.tapdata.tm.commons.dag.Edge;
+import com.tapdata.tm.commons.dag.Node;
+import com.tapdata.tm.commons.dag.nodes.PreviewTargetNode;
+import com.tapdata.tm.commons.dag.nodes.TableNode;
+import com.tapdata.tm.commons.task.dto.Dag;
 import com.tapdata.tm.commons.task.dto.TaskDto;
 import io.tapdata.flow.engine.V2.task.TaskClient;
 import io.tapdata.flow.engine.V2.task.impl.HazelcastTaskService;
@@ -11,6 +17,8 @@ import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -115,6 +123,31 @@ class TaskPreviewServiceTest {
 				assertNotNull(taskPreviewResultVO.getStats());
 				assertNull(taskPreviewResultVO.getErrorMsg());
 			}
+		}
+	}
+
+	@Nested
+	@DisplayName("Method handlePreviewTargetNode test")
+	class handlePreviewTargetNodeTest {
+		@Test
+		@DisplayName("test single table node should be kept as source")
+		void test1() {
+			TableNode tableNode = new TableNode();
+			tableNode.setId("source-node");
+			tableNode.setName("source-node");
+			tableNode.setTableName("AAAAA");
+
+			Dag previewDag = taskPreviewService.handlePreviewTargetNode(DAG.build(new Dag(new LinkedList<>(), Collections.singletonList(tableNode))));
+
+			assertEquals(2, previewDag.getNodes().size());
+			Node sourceNode = previewDag.getNodes().stream().filter(node -> "source-node".equals(node.getId())).findFirst().orElse(null);
+			assertSame(tableNode, sourceNode);
+			Node previewTargetNode = previewDag.getNodes().stream().filter(PreviewTargetNode.class::isInstance).findFirst().orElse(null);
+			assertNotNull(previewTargetNode);
+			assertEquals(1, previewDag.getEdges().size());
+			Edge previewEdge = previewDag.getEdges().get(0);
+			assertEquals("source-node", previewEdge.getSource());
+			assertEquals(previewTargetNode.getId(), previewEdge.getTarget());
 		}
 	}
 }


### PR DESCRIPTION
…arget node" by the preview transformation logic, resulting in the real table source node not being queried