### PR TITLE
ws/module diff scope

### DIFF
--- a/manager/tm/src/main/java/com/tapdata/tm/group/service/GroupInfoService.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/group/service/GroupInfoService.java
@@ -2121,11 +2121,44 @@ public class GroupInfoService extends BaseService<GroupInfoDto, GroupInfoEntity,
         return sb.toString();
     }
 
-    /** API 对比时排除的顶层字段：环境相关、运行时状态字段 */
-    private static final Set<String> MODULE_EXCLUDED_FIELDS = new HashSet<>(Arrays.asList(
-            "id", "createTime", "datasource",
-            "createUser", "lastUpdBy", "status", "isDeleted"
-    ));
+    /**
+     * API 对比时排除的顶层字段：环境派生 / 运行时状态，<b>两侧对称剔除</b>（本方法对文件侧与 DB 侧
+     * 各跑一次）。逐条「它为什么不是用户可编辑内容」的理由见 [ADR-0037] D2，实测依据见
+     * {@code research/2026-08-module-diff-noise.md}。
+     *
+     * <p><b>复用既有两份常量而不是抄字符串</b>：它们将来增补运行时字段时本表要跟着走，抄一份就等于
+     * 埋下「新字段不被排除、噪声悄悄回来」的下一次同类 bug。</p>
+     *
+     * <p>⚠ {@code connectionId} / {@code connection} <b>刻意不在表内</b>：{@code datasource} 已被排除，
+     * 若把这两个也排除，「用户把 API 改指到另一个连接」就一条证据都不剩。{@code connectionName} /
+     * {@code connectionType} 可以排除，正因为改连接必然连带改 {@code connectionId}。</p>
+     */
+    private static final Set<String> MODULE_EXCLUDED_FIELDS;
+
+    static {
+        Set<String> excluded = new HashSet<>();
+        // id / customId / createTime / last_updated / lastUpdBy / createUser / permissionActions
+        excluded.addAll(BASE_DTO_VOLATILE_FIELDS);
+        // last_updated / lastUpdate / last_user_name —— 导出侧剔这三个、DB 侧不剔，本行让两侧对齐。
+        // 边际贡献只有后两个（last_updated 已由上一行覆盖），而 ModulesDto 今天产不出它们 ——
+        // 留着是为了导出侧这份清单将来增补时 DB 侧自动跟上，不是为了修今天的某一条噪声。
+        excluded.addAll(COMMON_VOLATILE_FIELDS);
+        excluded.addAll(Arrays.asList(
+                "datasource", "status", "isDeleted",
+                // 属主 / 账号 / 凭据。user_id 落进 JSON 的是父类 BaseDto.userId（@JsonProperty("user_id")）；
+                // email 是小写（Jackson 取 Lombok 的 getEmail()），写成 "Email" 排不掉
+                "user_id", "user", "access_token", "email",
+                // 目标环境的发布状态（status 已排除，它是漏网的同类）
+                "publishStatus",
+                // 运行统计：目标一有流量就变，且包里带的是源环境的值
+                "visitCount", "latency", "responseTime", "reqBytes", "resRows", "failRate",
+                // 导入时由 ModulesService.updateConnectionIds 整体用目标连接的名字与类型覆写
+                "connectionName", "connectionType"));
+        MODULE_EXCLUDED_FIELDS = Collections.unmodifiableSet(excluded);
+    }
+
+    /** 一个 {@code Field} 参与比对的全部键：名与别名（[ADR-0037] D3）。其余约 70 个属性一律不比。 */
+    private static final Set<String> FIELD_COMPARED_KEYS = Set.of("field_name", "field_alias");
 
     private static final Set<String> CONFIG_ENV_EXCLUDED_FIELDS = Collections.emptySet();
 
@@ -2134,6 +2167,8 @@ public class GroupInfoService extends BaseService<GroupInfoDto, GroupInfoEntity,
 
         // 解析文件中的 Module，以 _id 为 key 去重
         Map<String, Map<String, Object>> fileModulesById = new LinkedHashMap<>();
+        // 归一化图从 [ADR-0037] 起是刻意有损的（connectionName 等已被排除），展示值另存一份原始 DTO
+        Map<String, ModulesDto> fileDtoById = new LinkedHashMap<>();
         for (TaskUpAndLoadDto item : payloads.getOrDefault("Module.json", Collections.emptyList())) {
             if (!GroupConstants.COLLECTION_MODULES.equals(item.getCollectionName())) continue;
             Map<String, Object> normalized = normalizeModuleForComparison(item.getJson());
@@ -2144,6 +2179,7 @@ public class GroupInfoService extends BaseService<GroupInfoDto, GroupInfoEntity,
                 continue;
             }
             fileModulesById.putIfAbsent(parsedDto.getId().toHexString(), normalized);
+            fileDtoById.putIfAbsent(parsedDto.getId().toHexString(), parsedDto);
         }
         if (fileModulesById.isEmpty()) return diff;
 
@@ -2162,9 +2198,13 @@ public class GroupInfoService extends BaseService<GroupInfoDto, GroupInfoEntity,
             ModulesDto existingModule = existingById.get(key);
             if (existingModule == null) {
                 ResourceDiffItem item = new ResourceDiffItem(name, null);
-                item.setApiPath((String) fileNormalized.get("path"));
-                item.setApiConnectionName((String) fileNormalized.get("connectionName"));
-                item.setApiTableName((String) fileNormalized.get("tableName"));
+                // 展示值取自原始 DTO：归一化图已排除 connectionName，从它读会静默拿到 null（[ADR-0037] D5）
+                ModulesDto fileDto = fileDtoById.get(key);
+                if (fileDto != null) {
+                    item.setApiPath(fileDto.getPath());
+                    item.setApiConnectionName(fileDto.getConnectionName());
+                    item.setApiTableName(fileDto.getTableName());
+                }
                 diff.getAdd().add(item);
             } else {
                 Map<String, Object> existingNormalized = normalizeModuleForComparison(JsonUtil.toJsonUseJackson(existingModule));
@@ -2186,11 +2226,17 @@ public class GroupInfoService extends BaseService<GroupInfoDto, GroupInfoEntity,
             if (map == null) return null;
             // 移除顶层排除字段
             MODULE_EXCLUDED_FIELDS.forEach(map::remove);
-            // 移除 fields 数组中每个元素的 id
-            Object fieldsObj = map.get("fields");
-            if (fieldsObj instanceof List) {
-                for (Object fieldItem : (List<?>) fieldsObj) {
-                    if (fieldItem instanceof Map) ((Map<String, Object>) fieldItem).remove("id");
+            // 四处 Field 数组各自归约成 {field_name, field_alias}（[ADR-0037] D3）。归约之后
+            // ARRAY_KEY_CONFIG 里那四条 keyed 路径自然产出「增 / 删 / 改别名」三种事件，无需新增比对逻辑。
+            reduceFieldsToNameAndAlias(map.get("fields"));
+            Object pathsObj = map.get("paths");
+            if (pathsObj instanceof List) {
+                for (Object pathItem : (List<?>) pathsObj) {
+                    if (!(pathItem instanceof Map)) continue;
+                    Map<String, Object> pathMap = (Map<String, Object>) pathItem;
+                    reduceFieldsToNameAndAlias(pathMap.get("fields"));
+                    reduceFieldsToNameAndAlias(pathMap.get("availableQueryField"));
+                    reduceFieldsToNameAndAlias(pathMap.get("requiredQueryField"));
                 }
             }
             // 移除 listtags 数组中每个元素的 id
@@ -2204,6 +2250,21 @@ public class GroupInfoService extends BaseService<GroupInfoDto, GroupInfoEntity,
         } catch (Exception e) {
             log.warn("Failed to normalize ModulesDto for comparison", e);
             return null;
+        }
+    }
+
+    /**
+     * 把一个 {@code Field} 数组里的每个元素归约成只剩 {@link #FIELD_COMPARED_KEYS}（名与别名）。
+     * 就地改，两侧各跑一次。别名为空的字段归约后只剩一个键，两侧不会互报差异 ——
+     * {@code jsonEqual} 把空串与 null 视为相等，{@code COMPARISON_MAPPER} 又忽略 null。
+     */
+    @SuppressWarnings("unchecked")
+    private static void reduceFieldsToNameAndAlias(Object fieldsObj) {
+        if (!(fieldsObj instanceof List)) return;
+        for (Object fieldItem : (List<?>) fieldsObj) {
+            if (fieldItem instanceof Map) {
+                ((Map<String, Object>) fieldItem).keySet().retainAll(FIELD_COMPARED_KEYS);
+            }
         }
     }
 

--- a/manager/tm/src/main/java/com/tapdata/tm/modules/util/FieldTypeUtil.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/modules/util/FieldTypeUtil.java
@@ -63,7 +63,7 @@ public final class FieldTypeUtil {
             }
         }
         List<Path> paths = modulesDto.getPaths();
-        if (CollectionUtils.isEmpty(paths)) {
+        if (CollectionUtils.isNotEmpty(paths)) {
             for (Path path : paths) {
                 List<Field> fieldsInPath = path.getFields();
                 if (CollectionUtils.isNotEmpty(fieldsInPath)) {

--- a/manager/tm/src/test/java/com/tapdata/tm/cluster/service/RawServerStateServiceTest.java
+++ b/manager/tm/src/test/java/com/tapdata/tm/cluster/service/RawServerStateServiceTest.java
@@ -200,24 +200,43 @@ class RawServerStateServiceTest {
             }
         }
 
+        /**
+         * 钉住存活阈值本身（3 分钟），而不是「恰好整 3 分钟」那个点。
+         *
+         * <p><b>为什么不测那个点。</b>判据是 {@code RawServerStateService:61} 的
+         * {@code now - timestamp <= 3 分钟}，而 {@code now} 是<b>被测代码自己</b>再读一次
+         * {@code System.currentTimeMillis()} 得到的，比本用例读到的那次晚一个未知的 {@code delta >= 0}。
+         * 种子播成 {@code currentTime - 3 分钟} 时，「是否存活」等价于 {@code delta == 0} ——
+         * 也就是整条调用路径是否落在同一毫秒里。这不是可判定的断言，是一次掷硬币。</p>
+         *
+         * <p>本用例此前正是那么写的（种子整 3 分钟、断言 not alive），靠「至少过了 1 毫秒」蒙对；
+         * JVM 一热、这段路径进了同一毫秒就翻红。而且它断言的方向与生产语义（{@code <=} 即存活）
+         * 以及它自己上一行的注释都相反 —— 它从来没有测过它命名的那件事。</p>
+         *
+         * <p><b>改成钉阈值。</b>界内 5 秒必须存活、界外 5 秒必须不存活。界外那条对任何 {@code delta}
+         * 都成立；界内那条的余量是整整 5 秒（原先是 0）。阈值一旦从 3 分钟改成 2 或 4 分钟，两条各红一条。
+         * 整毫秒边界上 {@code <} 与 {@code <=} 的区别用 wall clock 判定不了，也不是任何需求关心的事。</p>
+         */
         @Test
-        void testGetAllLatestIsAliveExactlyThreeMinutes() {
+        void testGetAllLatestIsAliveAroundThreeMinuteThreshold() {
             Filter filter = new Filter();
             filter.setWhere(new Where());
 
+            long threshold = 3 * 60 * 1000L;
+            long margin = 5000L;
             long currentTime = System.currentTimeMillis();
 
-            RawServerStateDto dto1 = new RawServerStateDto();
-            dto1.setServiceId("service1");
-            dto1.setTimestamp(new Date(currentTime - 3 * 60 * 1000L)); // Exactly 3 minutes
+            RawServerStateDto inside = new RawServerStateDto();
+            inside.setServiceId("service-inside");
+            inside.setTimestamp(new Date(currentTime - threshold + margin));  // 2 分 55 秒前
 
-            RawServerStateDto dto2 = new RawServerStateDto();
-            dto2.setServiceId("service2");
-            dto2.setTimestamp(new Date(currentTime - 3 * 60 * 1000L - 1)); // Just over 3 minutes
+            RawServerStateDto outside = new RawServerStateDto();
+            outside.setServiceId("service-outside");
+            outside.setTimestamp(new Date(currentTime - threshold - margin)); // 3 分 05 秒前
 
             List<RawServerStateDto> results = new ArrayList<>();
-            results.add(dto1);
-            results.add(dto2);
+            results.add(inside);
+            results.add(outside);
 
             AggregationResults<RawServerStateDto> aggregationResults = mock(AggregationResults.class);
             when(aggregationResults.getMappedResults()).thenReturn(results);
@@ -233,10 +252,14 @@ class RawServerStateServiceTest {
                 assertNotNull(result);
                 assertEquals(2, result.getTotal());
 
-                // dto1 should be alive (exactly 3 minutes)
-                assertFalse(result.getItems().get(0).getIsAlive());
-                // dto2 should be not alive (over 3 minutes)
-                assertFalse(result.getItems().get(1).getIsAlive());
+                // getAllLatest 按 timestamp 升序排（RawServerStateService:63），所以更早的 outside 在前。
+                // 显式断言 serviceId：旧版把注释挂在了错的下标上，而两条断言恰好都是 assertFalse，
+                // 于是那处错位一直没有被任何东西暴露出来。
+                assertEquals("service-outside", result.getItems().get(0).getServiceId());
+                assertFalse(result.getItems().get(0).getIsAlive(), "超出阈值 5 秒的服务不应判为存活");
+
+                assertEquals("service-inside", result.getItems().get(1).getServiceId());
+                assertTrue(result.getItems().get(1).getIsAlive(), "未到阈值 5 秒的服务必须判为存活");
             }
         }
     }

--- a/manager/tm/src/test/java/com/tapdata/tm/group/service/GroupInfoServiceModuleDiffScopeTest.java
+++ b/manager/tm/src/test/java/com/tapdata/tm/group/service/GroupInfoServiceModuleDiffScopeTest.java
@@ -3,15 +3,20 @@ package com.tapdata.tm.group.service;
 import com.tapdata.tm.commons.schema.Field;
 import com.tapdata.tm.commons.schema.MetadataInstancesDto;
 import com.tapdata.tm.commons.schema.Tag;
+import com.tapdata.tm.commons.task.dto.ImportModeEnum;
 import com.tapdata.tm.commons.util.JsonUtil;
 import com.tapdata.tm.config.security.SimpleGrantedAuthority;
 import com.tapdata.tm.config.security.UserDetail;
 import com.tapdata.tm.group.constant.GroupConstants;
+import com.tapdata.tm.group.dto.ResourceType;
 import com.tapdata.tm.group.handler.ModuleResourceHandler;
+import com.tapdata.tm.group.handler.ResourceHandler;
+import com.tapdata.tm.group.handler.ResourceHandlerRegistry;
 import com.tapdata.tm.group.repostitory.GroupInfoRepository;
 import com.tapdata.tm.group.vo.FieldChange;
 import com.tapdata.tm.group.vo.ResourceDiff;
 import com.tapdata.tm.group.vo.ResourceDiffItem;
+import com.tapdata.tm.metadatainstance.service.MetadataInstancesService;
 import com.tapdata.tm.module.dto.ModulesDto;
 import com.tapdata.tm.module.dto.Param;
 import com.tapdata.tm.module.dto.PathSetting;
@@ -29,6 +34,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.mongodb.core.query.Query;
@@ -42,12 +48,16 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -78,6 +88,12 @@ class GroupInfoServiceModuleDiffScopeTest {
 
 	@Mock
 	private ModulesService modulesService;
+
+	@Mock
+	private MetadataInstancesService metadataInstancesService;
+
+	@Mock
+	private ResourceHandlerRegistry resourceHandlerRegistry;
 
 	private GroupInfoService groupInfoService;
 	private ModuleResourceHandler moduleResourceHandler;
@@ -349,5 +365,224 @@ class GroupInfoServiceModuleDiffScopeTest {
 		f.setComment(name + " 注释");
 		f.setKey(name);
 		return f;
+	}
+
+	// ------------------------------------------------------- T4 · 字段维度只剩增 / 删 / 改别名
+
+	@Test
+	@DisplayName("T4-2 加字段：包侧多暴露一个 ⇒ 恰好一条变更，from 为 null")
+	void exposingOneMoreFieldProducesExactlyOneAdd() {
+		// DB 侧只暴露 2 个字段（没有 TS），包侧 3 个
+		List<FieldChange> changes = changesOf(UNCHANGED, db -> dropExposed(db, "TS"));
+
+		FieldChange only = onlyChange(changes, "paths[customerQuery].fields[TS]");
+		assertNull(only.getFrom(), "DB 侧本来就没有这个字段，from 必须为 null");
+		assertNotNull(only.getTo(), "包侧新增的字段必须出现在 to 里");
+	}
+
+	@Test
+	@DisplayName("T4-3 删字段（删中间那个）：恰好一条变更，from 非空 / to 为 null —— keyed diff 一旦退化成下标，这里会变成一串位移")
+	void removingMiddleExposedFieldProducesExactlyOneDelete() {
+		// 播种顺序 POLICY_ID / CUSTOMER_NO / TS，删中间的 CUSTOMER_NO
+		List<FieldChange> changes = changesOf(file -> dropExposed(file, "CUSTOMER_NO"), UNCHANGED);
+
+		FieldChange only = onlyChange(changes, "paths[customerQuery].fields[CUSTOMER_NO]");
+		assertNotNull(only.getFrom(), "DB 侧仍有这个字段，from 必须非空");
+		assertNull(only.getTo(), "包侧已删掉，to 必须为 null");
+	}
+
+	@Test
+	@DisplayName("T4-4 只改别名：恰好一条变更，路径以 .field_alias 结尾 —— 别名是「改」的唯一定义")
+	void aliasChangeProducesExactlyOneChange() {
+		List<FieldChange> changes = changesOf(file -> renameAlias(file, "CUSTOMER_NO", "客户编号"), UNCHANGED);
+
+		FieldChange only = onlyChange(changes, "paths[customerQuery].fields[CUSTOMER_NO].field_alias");
+		assertEquals("客户号", only.getFrom());
+		assertEquals("客户编号", only.getTo());
+	}
+
+	@Test
+	@DisplayName("T4-5 字段的其余属性全变、名与别名不变 ⇒ 零变更（四处 Field 数组各造一份）")
+	void fieldPropertiesOtherThanNameAndAliasAreIgnored() {
+		ObjectId id = new ObjectId();
+		// 与 T1-B 的区别：顶层内容两侧逐字相同，只有四处 Field 数组的属性不同 ——
+		// 这样它红的时候只可能是「某一处归约漏了」，与顶层排除表无关。
+		ResourceDiff diff = diffOf(fullModule(id, Env.SOURCE),
+				withTargetStyleFieldProperties(fullModule(id, Env.SOURCE)));
+
+		assertEquals(0, diff.getAdd().size(), "同 _id 的 Module 应落 update 而不是 add：" + report(diff));
+		assertTrue(diff.getUpdate().isEmpty(),
+				() -> "字段只有类型/精度/位置/id 这类模型推演产物不同，却报了变更 —— "
+						+ "四处 Field 数组里有一处没被归约：\n" + report(diff));
+	}
+
+	// --------------------------------------------- T4-7 没有收窄过头：其余用户可编辑内容仍被认出
+
+	@Test
+	@DisplayName("T4-7a 新增一个查询参数 ⇒ 恰好一条")
+	void addedParamIsStillReported() {
+		List<FieldChange> changes = changesOf(file -> file.getPaths().get(0).getParams().add(param("policyNo")), UNCHANGED);
+		onlyChange(changes, "paths[customerQuery].params[1]");
+	}
+
+	@Test
+	@DisplayName("T4-7b 改一条 where ⇒ 恰好一条")
+	void changedWhereIsStillReported() {
+		List<FieldChange> changes = changesOf(
+				file -> file.getPaths().get(0).getWhere().get(0).setOperator("gt"), UNCHANGED);
+		FieldChange only = onlyChange(changes, "paths[customerQuery].where[0].operator");
+		assertEquals("eq", only.getFrom());
+		assertEquals("gt", only.getTo());
+	}
+
+	@Test
+	@DisplayName("T4-7c 改 limit ⇒ 恰好一条")
+	void changedLimitIsStillReported() {
+		List<FieldChange> changes = changesOf(file -> file.setLimit(1000), UNCHANGED);
+		FieldChange only = onlyChange(changes, "limit");
+		assertEquals(500, only.getFrom());
+		assertEquals(1000, only.getTo());
+	}
+
+	@Test
+	@DisplayName("T4-7d 改 API 路径 ⇒ 恰好一条")
+	void changedApiPathIsStillReported() {
+		List<FieldChange> changes = changesOf(file -> file.setPath("/api/insurance/v2/policy"), UNCHANGED);
+		FieldChange only = onlyChange(changes, "path");
+		assertEquals("/api/insurance/v1/policy", only.getFrom());
+		assertEquals("/api/insurance/v2/policy", only.getTo());
+	}
+
+	// ------------------------------------------------------------- T4-8 部署闸联动（diff → 真的部署什么）
+
+	@Test
+	@DisplayName("T4-8a 零变更 ⇒ 闸关上：modulesService 与 metadataInstancesService 的 batchImport 都不被调用")
+	void unchangedModuleTriggersNoImportAtAll() {
+		ObjectId id = new ObjectId();
+		runStandaloneImport(fullModule(id, Env.SOURCE), fullModule(id, Env.TARGET));
+
+		verify(modulesService, never()).batchImport(any(), any(), any(), any(), any());
+		// [ADR-0037] 第 ⑦ 项裁决「接受」：MODULE metadata 导入挂在同一个 if 上，零变更时它同样不跑。
+		// 之所以无害，是因为那份列表结构上恒空（moduleExportPayloadCarriesNoMetadataInstances 守着）。
+		verify(metadataInstancesService, never()).batchImport(any(), any(), any(), any(), any());
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	@DisplayName("T4-8b 只改一个别名 ⇒ 闸打开，且入参恰好只有那一个 Module")
+	void aliasChangeImportsExactlyThatOneModule() {
+		ObjectId id = new ObjectId();
+		ModulesDto fileSide = fullModule(id, Env.SOURCE);
+		renameAlias(fileSide, "CUSTOMER_NO", "客户编号");
+		runStandaloneImport(fileSide, fullModule(id, Env.TARGET));
+
+		ArgumentCaptor<List<ModulesDto>> toImport = ArgumentCaptor.forClass(List.class);
+		verify(modulesService).batchImport(toImport.capture(), any(), any(), any(), any());
+		assertEquals(Collections.singletonList("policy_api"),
+				toImport.getValue().stream().map(ModulesDto::getName).toList());
+
+		ArgumentCaptor<List<MetadataInstancesDto>> metadata = ArgumentCaptor.forClass(List.class);
+		verify(metadataInstancesService).batchImport(metadata.capture(), any(), any(), any(), any());
+		assertTrue(metadata.getValue().isEmpty(),
+				"有变更时那两句照旧跑，但传的列表恒空 —— 一旦非空，[ADR-0037] 第 ⑦ 项要重判");
+	}
+
+	// -------------------------------------------------------------- T4 脚手架
+
+	private static final Consumer<ModulesDto> UNCHANGED = m -> { };
+
+	/**
+	 * 造一次「源环境的包 vs 目标环境的库」——两侧先播成用户可编辑内容逐字相同，再各自施加一个改动。
+	 * 环境噪声照旧存在，所以每条用例同时也在证明「收窄没被这次改动破坏」。
+	 */
+	private List<FieldChange> changesOf(Consumer<ModulesDto> mutateFile, Consumer<ModulesDto> mutateDb) {
+		ObjectId id = new ObjectId();
+		ModulesDto fileSide = fullModule(id, Env.SOURCE);
+		ModulesDto dbSide = fullModule(id, Env.TARGET);
+		mutateFile.accept(fileSide);
+		mutateDb.accept(dbSide);
+
+		ResourceDiff diff = diffOf(fileSide, dbSide);
+		assertEquals(0, diff.getAdd().size(), "同 _id 的 Module 应落 update 而不是 add：" + report(diff));
+		assertEquals(1, diff.getUpdate().size(), () -> "应恰好一个 Module 落在 update：\n" + report(diff));
+		List<FieldChange> changes = diff.getUpdate().get(0).getChanges();
+		assertNotNull(changes, "update 项必须带字段级变更");
+		return changes;
+	}
+
+	/** 断言恰好一条变更且落在预期路径上；返回它以便继续断言 from / to。 */
+	private static FieldChange onlyChange(List<FieldChange> changes, String expectedPath) {
+		assertEquals(1, changes.size(),
+				() -> "期望恰好一条变更，实际 " + changes.size() + " 条：" + changedPaths(changes));
+		assertEquals(expectedPath, changes.get(0).getField(),
+				() -> "变更路径不对，实际：" + changedPaths(changes));
+		return changes.get(0);
+	}
+
+	private static List<String> changedPaths(List<FieldChange> changes) {
+		return changes.stream().map(FieldChange::getField).toList();
+	}
+
+	/** 跑真实的 apis 导入腿：diff 算 changedNames → toImport 过滤 → batchImport。recordId 传 null 以跳过状态回写。 */
+	private void runStandaloneImport(ModulesDto fileSide, ModulesDto dbSide) {
+		ReflectionTestUtils.setField(groupInfoService, "metadataInstancesService", metadataInstancesService);
+		ReflectionTestUtils.setField(groupInfoService, "resourceHandlerRegistry", resourceHandlerRegistry);
+		when(resourceHandlerRegistry.getHandler(ResourceType.MODULE)).thenReturn(moduleResourceHandler);
+		when(resourceHandlerRegistry.getAllHandlers())
+				.thenReturn(Collections.<ResourceHandler>singletonList(moduleResourceHandler));
+		when(modulesService.findAllDto(any(Query.class), any(UserDetail.class)))
+				.thenReturn(new ArrayList<>(Collections.singletonList(dbSide)));
+
+		groupInfoService.executeImportApisStandaloneAsync(
+				payloadsOf(exportedJson(fileSide)), ImportModeEnum.REPLACE, user, null);
+	}
+
+	// --------------------------------------------------------- T4 播种改写
+
+	/** paths[0].fields —— 前端勾选字段的真值（plan §现状 5），不是顶层那份整表快照。 */
+	private static List<Field> exposed(ModulesDto m) {
+		return m.getPaths().get(0).getFields();
+	}
+
+	private static void dropExposed(ModulesDto m, String fieldName) {
+		assertTrue(exposed(m).removeIf(f -> fieldName.equals(f.getFieldName())),
+				"播种里没有字段 " + fieldName + "，用例前提已失效");
+	}
+
+	private static void renameAlias(ModulesDto m, String fieldName, String newAlias) {
+		assertTrue(exposed(m).stream().anyMatch(f -> fieldName.equals(f.getFieldName())),
+				"播种里没有字段 " + fieldName + "，用例前提已失效");
+		exposed(m).stream()
+				.filter(f -> fieldName.equals(f.getFieldName()))
+				.forEach(f -> f.setFieldAlias(newAlias));
+	}
+
+	/** 只把四处 Field 数组里「名与别名以外的一切」换成目标环境的样子，Module 的其余内容一字不动。 */
+	private static ModulesDto withTargetStyleFieldProperties(ModulesDto m) {
+		m.setFields(retyped(m.getFields()));
+		for (Path p : m.getPaths()) {
+			p.setFields(retyped(p.getFields()));
+			p.setAvailableQueryField(retyped(p.getAvailableQueryField()));
+			p.setRequiredQueryField(retyped(p.getRequiredQueryField()));
+		}
+		return m;
+	}
+
+	private static List<Field> retyped(List<Field> src) {
+		List<Field> out = new ArrayList<>();
+		for (int i = 0; i < src.size(); i++) {
+			out.add(field(src.get(i).getFieldName(), src.get(i).getFieldAlias(), Env.TARGET, i));
+		}
+		return out;
+	}
+
+	private static Param param(String name) {
+		Param p = new Param();
+		p.setName(name);
+		p.setType("string");
+		p.setDefaultvalue("");
+		p.setDescription(name);
+		p.setRequired(false);
+		return p;
 	}
 }

--- a/manager/tm/src/test/java/com/tapdata/tm/group/service/GroupInfoServiceModuleDiffScopeTest.java
+++ b/manager/tm/src/test/java/com/tapdata/tm/group/service/GroupInfoServiceModuleDiffScopeTest.java
@@ -1,0 +1,353 @@
+package com.tapdata.tm.group.service;
+
+import com.tapdata.tm.commons.schema.Field;
+import com.tapdata.tm.commons.schema.MetadataInstancesDto;
+import com.tapdata.tm.commons.schema.Tag;
+import com.tapdata.tm.commons.util.JsonUtil;
+import com.tapdata.tm.config.security.SimpleGrantedAuthority;
+import com.tapdata.tm.config.security.UserDetail;
+import com.tapdata.tm.group.constant.GroupConstants;
+import com.tapdata.tm.group.handler.ModuleResourceHandler;
+import com.tapdata.tm.group.repostitory.GroupInfoRepository;
+import com.tapdata.tm.group.vo.FieldChange;
+import com.tapdata.tm.group.vo.ResourceDiff;
+import com.tapdata.tm.group.vo.ResourceDiffItem;
+import com.tapdata.tm.module.dto.ModulesDto;
+import com.tapdata.tm.module.dto.Param;
+import com.tapdata.tm.module.dto.PathSetting;
+import com.tapdata.tm.module.dto.ServingIndex;
+import com.tapdata.tm.module.dto.ServingIndexField;
+import com.tapdata.tm.module.dto.ServingIndexNormalizer;
+import com.tapdata.tm.module.dto.Sort;
+import com.tapdata.tm.module.dto.Where;
+import com.tapdata.tm.module.entity.ApiAlarmConfig;
+import com.tapdata.tm.module.entity.Path;
+import com.tapdata.tm.modules.service.ModulesService;
+import com.tapdata.tm.task.bean.TaskUpAndLoadDto;
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * module-diff-scope · T1 实测：把「未改动的 API 为什么每次都被判成变更」从读码结论变成实测事实。
+ *
+ * <p>两个实验，收窄前都会红，<b>失败信息里那份清单就是实测产出</b>（回填
+ * {@code research/2026-08-module-diff-noise.md}）：</p>
+ * <ol>
+ *   <li>{@link #exportPipelineAloneProducesNoUpdate()} —— 两侧内容逐字相同、只有导出管道走过一遍。
+ *       报出来的每一条都是<b>管道自身的不对称</b>（strip / 就地置空 / 排序），与目标环境无关。</li>
+ *   <li>{@link #unchangedModuleAcrossEnvironmentsProducesNoUpdate()} —— DB 侧按「目标环境风格」另造实例
+ *       （时间戳、运行统计、发布状态、账号、字段 id 与类型细节都不同），<b>用户可编辑内容逐字相同</b>。
+ *       这就是 T4 用例 1，收窄后必须绿。</li>
+ * </ol>
+ *
+ * <p>⚠ 两侧必须是<b>两个独立实例</b>：{@code ModuleResourceHandler.buildExportPayload} 就地改传进去的
+ * DTO（{@code setCustomId(null)} / {@code setLastUpdBy(null)} / {@code setStatus(null)}，外加对 fields 排序），
+ * 复用同一引用会把 DB 侧这几项一起抹平 —— 用例测不到它要测的不对称、却照样绿。</p>
+ */
+@ExtendWith(MockitoExtension.class)
+class GroupInfoServiceModuleDiffScopeTest {
+
+	/** 播种口径：同一份 API 在源环境与目标环境各自的样子。用户可编辑内容两者逐字相同。 */
+	private enum Env { SOURCE, TARGET }
+
+	/** 两侧共享：连接 _id 跨环境保留（conMap 按 _id 查目标库，见 buildConMapFromPayload）。 */
+	private static final String CONNECTION_ID = "660000000000000000000001";
+
+	@Mock
+	private ModulesService modulesService;
+
+	private GroupInfoService groupInfoService;
+	private ModuleResourceHandler moduleResourceHandler;
+	private UserDetail user;
+
+	@BeforeEach
+	void setUp() {
+		groupInfoService = new GroupInfoService(mock(GroupInfoRepository.class));
+		ReflectionTestUtils.setField(groupInfoService, "modulesService", modulesService);
+		moduleResourceHandler = new ModuleResourceHandler();
+		user = new UserDetail("userId123", "customerId", "testuser", "password", "customerType",
+				"accessCode", false, false, false, false,
+				Collections.singletonList(new SimpleGrantedAuthority("role")));
+	}
+
+	// ------------------------------------------------------------------ 实验
+
+	@Test
+	@DisplayName("T1-A 导出管道自身的不对称：两侧内容逐字相同时 diff 必须为空（收窄前会红）")
+	void exportPipelineAloneProducesNoUpdate() {
+		ObjectId id = new ObjectId();
+		ResourceDiff diff = diffOf(fullModule(id, Env.SOURCE), fullModule(id, Env.SOURCE));
+
+		assertEquals(0, diff.getAdd().size(), "同 _id 的 Module 应落 update 而不是 add：" + report(diff));
+		assertTrue(diff.getUpdate().isEmpty(),
+				() -> "两侧内容逐字相同却报了变更 —— 下列每一条都是导出管道自身的不对称：\n" + report(diff));
+	}
+
+	@Test
+	@DisplayName("T1-B 未改动的 API 跨环境：目标环境派生字段不同，diff 仍必须为空（收窄前会红）")
+	void unchangedModuleAcrossEnvironmentsProducesNoUpdate() {
+		ObjectId id = new ObjectId();
+		ResourceDiff diff = diffOf(fullModule(id, Env.SOURCE), fullModule(id, Env.TARGET));
+
+		assertEquals(0, diff.getAdd().size(), "同 _id 的 Module 应落 update 而不是 add：" + report(diff));
+		assertTrue(diff.getUpdate().isEmpty(),
+				() -> "没人改过这个 API，却被判成有变更 —— 下列每一条都是「未改动也报变更」的实测噪声：\n"
+						+ report(diff));
+	}
+
+	@Test
+	@DisplayName("T1-C MODULE 导出载荷不带 MetadataInstances —— 第三个消费者今天推的本来就是空列表")
+	void moduleExportPayloadCarriesNoMetadataInstances() {
+		// executeImportApisStandaloneAsync:1205-1208 的 refreshMetadataLastUpdate + metadataInstancesService
+		// .batchImport 传的是 metadataByType.get(MODULE)，而那份列表只由 ModuleResourceHandler.collectPayload
+		// 从 Module.json 桶里的 MetadataInstances 条目填充。导出侧根本不往那个桶里放这种条目 ⇒ 恒空。
+		List<TaskUpAndLoadDto> payload = moduleResourceHandler.buildExportPayload(
+				new ArrayList<>(Collections.singletonList(fullModule(new ObjectId(), Env.SOURCE))), user, true);
+
+		Map<String, ModulesDto> resourceMap = new LinkedHashMap<>();
+		List<MetadataInstancesDto> metadata = new ArrayList<>();
+		moduleResourceHandler.collectPayload(payload, resourceMap, metadata);
+
+		assertEquals(1, resourceMap.size(), "Module 本体必须收得到");
+		assertTrue(metadata.isEmpty(),
+				"MODULE 载荷里出现了 MetadataInstances —— 那两句从此不再是空转，"
+						+ "「零变更 ⇒ 整块不跑」会真的停掉一次推送，ADR-0037 第 ⑦ 项要重判");
+	}
+
+	// -------------------------------------------------------------- 链路脚手架
+
+	/** 文件侧走真实导出路径（buildExportPayload → parseAndStripExportJson），DB 侧走 findAllDto。 */
+	private ResourceDiff diffOf(ModulesDto fileSide, ModulesDto dbSide) {
+		when(modulesService.findAllDto(any(Query.class), any(UserDetail.class)))
+				.thenReturn(new ArrayList<>(Collections.singletonList(dbSide)));
+		ResourceDiff diff = ReflectionTestUtils.invokeMethod(
+				groupInfoService, "buildApiDiff", payloadsOf(exportedJson(fileSide)), user);
+		assertNotNull(diff);
+		return diff;
+	}
+
+	private String exportedJson(ModulesDto dto) {
+		List<TaskUpAndLoadDto> payload = moduleResourceHandler.buildExportPayload(
+				new ArrayList<>(Collections.singletonList(dto)), user, true);
+		assertEquals(1, payload.size());
+		Object stripped = ReflectionTestUtils.invokeMethod(groupInfoService, "parseAndStripExportJson",
+				GroupConstants.COLLECTION_MODULES, payload.get(0).getJson());
+		return JsonUtil.toJsonUseJackson(stripped);
+	}
+
+	private static Map<String, List<TaskUpAndLoadDto>> payloadsOf(String fileJson) {
+		Map<String, List<TaskUpAndLoadDto>> payloads = new LinkedHashMap<>();
+		payloads.put("Module.json", new ArrayList<>(Collections.singletonList(
+				new TaskUpAndLoadDto(GroupConstants.COLLECTION_MODULES, fileJson))));
+		return payloads;
+	}
+
+	/** 实测清单本体：路径 + 两侧的值，直接抄进 research 笔记。 */
+	private static String report(ResourceDiff diff) {
+		StringBuilder sb = new StringBuilder();
+		sb.append("add=").append(diff.getAdd().size())
+				.append(" update=").append(diff.getUpdate().size()).append('\n');
+		for (ResourceDiffItem item : diff.getUpdate()) {
+			List<FieldChange> changes = item.getChanges() == null
+					? Collections.emptyList() : item.getChanges();
+			sb.append("update[").append(item.getName()).append("] changes=")
+					.append(changes.size()).append('\n');
+			for (FieldChange c : changes) {
+				sb.append("  - ").append(c.getField())
+						.append("\n      db   = ").append(abbrev(c.getFrom()))
+						.append("\n      file = ").append(abbrev(c.getTo())).append('\n');
+			}
+		}
+		return sb.toString();
+	}
+
+	private static String abbrev(Object v) {
+		String s = String.valueOf(v);
+		return s.length() <= 200 ? s : s.substring(0, 200) + "…(" + s.length() + " chars)";
+	}
+
+	// ------------------------------------------------------------------ 播种
+
+	/**
+	 * 一个字段齐全的 Module。<b>用户可编辑内容两个 Env 逐字相同</b>；不同的只有环境派生 / 运行时产物，
+	 * 每一处都在行内注明它凭什么会不同。
+	 */
+	private static ModulesDto fullModule(ObjectId id, Env env) {
+		boolean src = env == Env.SOURCE;
+		ModulesDto m = new ModulesDto();
+
+		// —— BaseDto ——
+		m.setId(id);
+		m.setCustomId(src ? "customer-sit" : "customer-uat");                 // 租户 id，导出置 null
+		m.setCreateAt(new Date(1_700_000_000_000L));
+		m.setLastUpdAt(new Date(src ? 1_700_000_111_000L : 1_800_000_222_000L)); // 导入必刷（refreshModuleLastUpdate）
+		m.setUserId(src ? "user-sit" : "user-uat");
+		m.setLastUpdBy(src ? "alice" : "bob");
+		m.setCreateUser(src ? "alice" : "bob");
+		m.setPermissionActions(new LinkedHashSet<>(
+				Collections.singletonList(src ? "Data_SIT" : "Data_UAT")));
+
+		// —— 用户可编辑：两侧必须逐字相同 ——
+		m.setName("policy_api");
+		m.setTableName("POLICY");
+		m.setApiVersion("v1");
+		m.setBasePath("api");
+		m.setPrefix("insurance");
+		m.setPath("/api/insurance/v1/policy");
+		m.setApiType("defaultApi");
+		m.setOperationType("GET");
+		m.setPathAccessMethod("default");
+		m.setLimit(500);
+		m.setDescription("保单查询 API");
+		m.setDescribtion("legacy description");
+		m.setProject("insurance");
+		m.setCreateType("manual");
+		m.setReadPreference("primary");
+		m.setReadPreferenceTag("");
+		m.setReadConcern("local");
+		m.setListtags(new ArrayList<>(Collections.singletonList(
+				new Tag("650000000000000000000009", "保险"))));
+		m.setPathSetting(new ArrayList<>(PathSetting.DEFAULT_PATH_SETTING));
+		ApiAlarmConfig alarm = new ApiAlarmConfig();
+		alarm.setEmailReceivers(new ArrayList<>(Collections.singletonList("ops@example.com")));
+		m.setApiAlarmConfig(alarm);
+		ServingIndex ix = new ServingIndex("ix_policy", true, new ArrayList<>(Arrays.asList(
+				new ServingIndexField("CUSTOMER_NO", true), new ServingIndexField("TS", false))));
+		ix.setCollected(Boolean.TRUE);
+		m.setServingIndexes(ServingIndexNormalizer.normalize(
+				new ArrayList<>(Collections.singletonList(ix))));
+		m.setPaths(new ArrayList<>(Collections.singletonList(apiPath(env))));
+		m.setFields(new ArrayList<>(Arrays.asList(
+				field("POLICY_ID", "保单号", env, 0),
+				field("CUSTOMER_NO", "客户号", env, 1),
+				field("TS", null, env, 2))));
+
+		// —— 连接：_id 跨环境保留（import 的 conMap 按 _id 查目标库），名字由目标连接覆写 ——
+		m.setDataSource(CONNECTION_ID);
+		m.setConnectionId(CONNECTION_ID);
+		m.setConnection(new ObjectId(CONNECTION_ID));
+		m.setConnectionType("postgres");
+		m.setConnectionName(src ? "PG_SIT" : "PG_UAT");   // updateConnectionIds 取目标连接的名字
+
+		// —— 环境派生 / 运行时 ——
+		m.setStatus(src ? "pending" : "active");           // 目标已发布
+		m.setPublishStatus(src ? "unpublished" : "published");
+		m.setLast_updated(new Date(src ? 1_700_000_111_000L : 1_800_000_222_000L));
+		m.setUser(src ? "sit-owner" : "uat-owner");
+		m.setAccess_token(src ? "token-sit" : "token-uat");
+		m.setEmail(src ? "sit@example.com" : "uat@example.com");
+		m.setIsDeleted(Boolean.FALSE);
+		m.setVisitCount(src ? 0L : 12_345L);               // 目标环境有流量
+		m.setLatency(src ? 0L : 37L);
+		m.setResponseTime(src ? 0L : 41L);
+		m.setReqBytes(src ? 0L : 8_192L);
+		m.setResRows(src ? 0L : 990L);
+		m.setFailRate(src ? 0 : 2);
+		return m;
+	}
+
+	private static Path apiPath(Env env) {
+		Path p = new Path();
+		p.setName("customerQuery");
+		p.setPath("/policy");
+		p.setMethod("POST");
+		p.setType("default");
+		p.setResult("");
+		p.setCreateType("manual");
+		p.setDescription("按客户号查保单");
+		p.setAcl(new ArrayList<>(Collections.singletonList("admin")));
+		p.setFullCustomQuery(Boolean.FALSE);
+		p.setCustomWhere("");
+		Param param = new Param();
+		param.setName("customerNo");
+		param.setType("string");
+		param.setDefaultvalue("");
+		param.setDescription("客户号");
+		param.setRequired(true);
+		p.setParams(new ArrayList<>(Collections.singletonList(param)));
+		Where where = new Where();
+		where.setFieldName("CUSTOMER_NO");
+		where.setParameter("customerNo");
+		where.setOperator("eq");
+		where.setCondition("and");
+		p.setWhere(new ArrayList<>(Collections.singletonList(where)));
+		Sort sort = new Sort();
+		sort.setFieldName("TS");
+		sort.setType("DESC");
+		p.setSort(new ArrayList<>(Collections.singletonList(sort)));
+		// 暴露集合（真值在 paths[0].fields）
+		p.setFields(new ArrayList<>(Arrays.asList(
+				field("POLICY_ID", "保单号", env, 0),
+				field("CUSTOMER_NO", "客户号", env, 1),
+				field("TS", null, env, 2))));
+		p.setAvailableQueryField(new ArrayList<>(Collections.singletonList(
+				field("CUSTOMER_NO", "客户号", env, 1))));
+		p.setRequiredQueryField(new ArrayList<>(Collections.singletonList(
+				field("CUSTOMER_NO", "客户号", env, 1))));
+		return p;
+	}
+
+	/**
+	 * 一个属性铺开的 Field。{@code field_name} 与 {@code field_alias} 两侧相同（那是用户编辑的东西），
+	 * 其余全是目标环境重新推演模型后会拿到自己一套的产物。
+	 */
+	private static Field field(String name, String alias, Env env, int position) {
+		boolean src = env == Env.SOURCE;
+		Field f = new Field();
+		// 用户可编辑
+		f.setFieldName(name);
+		f.setFieldAlias(alias);                                   // TS 故意无别名：覆盖「空别名不互报差异」
+		// 环境派生 / 模型推演
+		f.setId(src ? "sit-fid-" + name : "uat-fid-" + name);
+		f.setDataType(src ? "varchar(64)" : "character varying(64)");   // data_type  (String)
+		f.setDataType1(src ? 12 : 1);                                   // dataType   (Integer，另一个 key)
+		f.setPureDataType(src ? "varchar" : "character varying");
+		f.setPrecision(src ? 64 : 128);                                 // data_precision
+		f.setScale(src ? 0 : 2);                                        // data_scale
+		f.setLength(src ? 64 : 128);                                    // data_length
+		f.setColumnSize(src ? 64 : 128);
+		f.setColumnPosition(src ? position : position + 10);
+		f.setTapType(src ? "{\"type\":10}" : "{\"type\":11}");
+		f.setOriginalDataType(src ? "VARCHAR" : "TEXT");
+		f.setJavaType(src ? "String" : "java.lang.String");             // java_type
+		f.setJavaType1(src ? "String" : "java.lang.String");            // javaType
+		f.setOriginalJavaType(src ? "String" : "java.lang.String");
+		f.setOriPrecision(src ? 64 : 128);
+		f.setDataCode(src ? 1 : 2);
+		f.setNodeDataType(src ? "varchar" : "text");
+		f.setSource(src ? Field.SOURCE_AUTO : Field.SOURCE_JOB_ANALYZE);
+		// 两侧一致的其余属性
+		f.setTableName("POLICY");
+		f.setOriginalFieldName(name);
+		f.setPrimaryKey(position == 0);
+		f.setPrimaryKeyPosition(position == 0 ? 1 : 0);
+		f.setIsNullable(position != 0);
+		f.setVisible(Boolean.TRUE);
+		f.setComment(name + " 注释");
+		f.setKey(name);
+		return f;
+	}
+}

--- a/manager/tm/src/test/java/com/tapdata/tm/modules/util/FieldTypeUtilValidCustomWhereTest.java
+++ b/manager/tm/src/test/java/com/tapdata/tm/modules/util/FieldTypeUtilValidCustomWhereTest.java
@@ -1,0 +1,78 @@
+package com.tapdata.tm.modules.util;
+
+import com.tapdata.tm.commons.schema.Field;
+import com.tapdata.tm.commons.schema.enums.TableFieldTag;
+import com.tapdata.tm.module.dto.ModulesDto;
+import com.tapdata.tm.module.entity.Path;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * {@link FieldTypeUtil#validCustomWhereIfNeed(ModulesDto)} 的 {@code paths} 分支。
+ *
+ * <p>2026-08-10（{@code 3c663ab373}，#3418 新建该文件）起，那个分支的卫语句是写反的——
+ * {@code if (CollectionUtils.isEmpty(paths))} 之后紧接着 {@code for (Path path : paths)}。
+ * 两个后果方向相反，所以要两条用例才钉得住：
+ *
+ * <ul>
+ *   <li>{@code paths == null} ⇒ 直接 NPE。发布 API 时必炸（{@code ModulesService:413}）。</li>
+ *   <li>{@code paths} 非空 ⇒ 整块被跳过，<b>path 里的字段从来没被补过 tapType</b>——不报错、不留痕。</li>
+ * </ul>
+ *
+ * <p>第二条是本类存在的理由：只加一个 null 判断（而不改那个反掉的判断）同样能让 NPE 消失、
+ * 让既有的两条 {@code normalizesServingIndexes} 用例转绿，但**静默跳过**那半个 bug 原封不动。
+ * 那条用例必须在「错的修法」下也是红的，否则它判定不了自己所测的东西。
+ */
+class FieldTypeUtilValidCustomWhereTest {
+
+	private static Field userCreated(String name) {
+		Field f = new Field();
+		f.setFieldName(name);
+		f.setTag(TableFieldTag.USER_CREATE.getType());
+		f.setSimpleTypeName("String");   // FILED_TYPE 里有，且 tapType 留空 ⇒ 该被补上
+		return f;
+	}
+
+	private static ModulesDto moduleWithPaths(List<Path> paths) {
+		ModulesDto dto = new ModulesDto();
+		dto.setPaths(paths);
+		return dto;
+	}
+
+	@Test
+	@DisplayName("paths 为 null 不再抛 NPE —— 发布 API 走的就是这条路（ModulesService:413）")
+	void nullPathsDoesNotThrow() {
+		assertDoesNotThrow(() -> FieldTypeUtil.validCustomWhereIfNeed(moduleWithPaths(null)));
+	}
+
+	@Test
+	@DisplayName("paths 非空时，path 里的字段确实被补上 tapType —— 只加 null 判断的修法在这条上是红的")
+	void nonEmptyPathsAreActuallyProcessed() {
+		Field field = userCreated("amount");
+		Path path = new Path();
+		path.setFields(new ArrayList<>(Collections.singletonList(field)));
+
+		FieldTypeUtil.validCustomWhereIfNeed(moduleWithPaths(new ArrayList<>(Collections.singletonList(path))));
+
+		assertNotNull(field.getTapType(),
+				"paths 非空时那个分支必须真的跑起来；卫语句写反或只加 null 判断都会让它被静默跳过");
+		assertEquals(FieldTypeUtil.FILED_TYPE.get("String"), field.getTapType());
+	}
+
+	@Test
+	@DisplayName("paths 为空列表：不抛异常，也不该凭空造出 tapType")
+	void emptyPathsIsANoOp() {
+		Field orphan = userCreated("unused");
+		assertDoesNotThrow(() -> FieldTypeUtil.validCustomWhereIfNeed(moduleWithPaths(new ArrayList<>())));
+		assertNull(orphan.getTapType(), "空 paths 不该有任何字段被处理");
+	}
+}

--- a/manager/tm/src/test/java/com/tapdata/tm/servingindex/ServingIndexesExportDiffTest.java
+++ b/manager/tm/src/test/java/com/tapdata/tm/servingindex/ServingIndexesExportDiffTest.java
@@ -210,8 +210,12 @@ class ServingIndexesExportDiffTest {
 	}
 
 	@Test
-	@DisplayName("索引未变：changedFields 不得出现 servingIndexes 项（否则每次 CICD 都误报索引变更）")
+	@DisplayName("索引未变：整个 update 必须为空 —— 一条噪声都不许有（[ADR-0037] 收窄后抬硬）")
 	void unchangedIndexesProduceNoServingIndexChange() {
+		// 抬硬历史：本用例原先写成 `diff.getUpdate().isEmpty() ? emptyList : ...`，只断言「没有
+		// servingIndexes 前缀的变更」。那份容忍不是设计，是当时 update 里还躺着 last_updated /
+		// customId 这类管道噪声（module-diff-scope 的 bug 本身）。收窄之后噪声没有了，
+		// 断言随之抬到「整个 update 为空」——这一条同时守着索引与噪声两件事。
 		ObjectId id = new ObjectId();
 		ModulesDto inDb = moduleWith(id, index("ix_policy", "POLICY_ID", "TS"));
 		ModulesDto inFile = moduleWith(id, index("ix_policy", "POLICY_ID", "TS"));
@@ -222,11 +226,10 @@ class ServingIndexesExportDiffTest {
 				groupInfoService, "buildApiDiff", payloadsOf(exportedJson(inFile)), user);
 
 		assertNotNull(diff);
-		List<FieldChange> changes = diff.getUpdate().isEmpty()
-				? Collections.emptyList() : diff.getUpdate().get(0).getChanges();
-		List<String> paths = changes == null
-				? Collections.emptyList() : changes.stream().map(FieldChange::getField).toList();
-		assertTrue(paths.stream().noneMatch(p -> p.startsWith("servingIndexes")),
-				"索引未变却报了 servingIndexes 变更，changedFields=" + paths);
+		assertTrue(diff.getUpdate().isEmpty(), () -> {
+			List<FieldChange> changes = diff.getUpdate().get(0).getChanges();
+			return "索引与内容都没变，却报了变更：" + (changes == null
+					? "changes=null" : changes.stream().map(FieldChange::getField).toList());
+		});
 	}
 }


### PR DESCRIPTION
- **test(cicd): module-diff T1 实测——两条先红用例钉住噪声，外加 MODULE metadata 恒空的结构守卫**
- **fix(cicd): 收窄 Module 比对面——字段只比名与别名，环境派生字段两侧对称剔除**
- **test(cicd): module-diff T4 用例——增删改别名 / 四处数组归约 / 部署闸联动**
- **test(cluster): RawServerState 存活用例改钉阈值——原先那条边界判定不了自己所测之物**
