### PR TITLE
fix(datatrace): fix upstream condition rewriting and sibling table in…

### DIFF
--- a/manager/tm/src/main/java/com/tapdata/tm/trace/service/data/TraceDataService.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/trace/service/data/TraceDataService.java
@@ -115,6 +115,7 @@ public class TraceDataService {
             TraceValue filterTraceValue = hasCurrentRecords(traceValue) ? traceValue : step.getFilterTraceValue();
             Node filterNode = hasCurrentRecords(traceValue) ? currentNode : step.getFilterNode();
             TraceQueryCondition filterCondition = hasFilterCondition(step.getCondition()) ? step.getCondition() : step.getFilterCondition();
+            enqueueMergeSiblingsFromRecords(queue, visited, nodeMap, incomingEdges, step, traceValue, fieldNameMapping);
             for (Edge edge : incomingEdges.getOrDefault(currentNode.getId(), Collections.emptyList())) {
                 Node upstreamNode = nodeMap.get(edge.getSource());
                 if (upstreamNode != null) {
@@ -365,8 +366,10 @@ public class TraceDataService {
         condition.setTable(resolveTableName(upstreamNode));
         if (isMergeSubTable(upstreamNode, edge)) {
             condition.setFilters(buildMergeJoinFilters(upstreamNode, edge, currentTraceValue,
-                    currentCondition, fallbackTraceValue, fallbackCondition, errors));
-            addEmptyFilterError(condition, errors, upstreamNode, currentNode);
+                    currentCondition, fallbackTraceValue, fallbackCondition, errors, fieldNameMapping));
+            if (hasCurrentRecords(currentTraceValue) || !isMergeRelatedTable(upstreamNode)) {
+                addEmptyFilterError(condition, errors, upstreamNode, currentNode);
+            }
             return new TraceConditionBuildResult(condition, errors);
         }
 
@@ -377,7 +380,12 @@ public class TraceDataService {
                 : fieldNameMapping.getOrDefault(fallbackNode.getId(), Collections.emptyMap());
         condition.setFilters(buildNormalUpstreamFilters(condition,currentCondition, currentTraceValue,
                 upstreamFieldMapping, currentFieldMapping, fallbackCondition, fallbackTraceValue, fallbackFieldMapping, updateConditionFieldList, errors));
-        addEmptyFilterError(condition, errors, upstreamNode, currentNode);
+        if (!(CollectionUtils.isEmpty(condition.getFilters())
+                && !hasCurrentRecords(currentTraceValue)
+                && (TraceUpstreamConditionRewriter.onlyNestedFilterKeys(safeFilters(currentCondition))
+                || isMergeRelatedTable(upstreamNode)))) {
+            addEmptyFilterError(condition, errors, upstreamNode, currentNode);
+        }
         return new TraceConditionBuildResult(condition, errors);
     }
 
@@ -385,24 +393,43 @@ public class TraceDataService {
                                                             TraceQueryCondition downstreamCondition,
                                                             TraceValue fallbackTraceValue,
                                                             TraceQueryCondition fallbackCondition,
-                                                            List<TraceNodeError> errors) {
+                                                            List<TraceNodeError> errors,
+                                                            Map<String, Map<String, String>> fieldNameMapping) {
         List<Map<String, String>> joinKeys = extractJoinKeys(upstreamNode, edge);
-        if (CollectionUtils.isEmpty(joinKeys)) {
+        List<Map<String, Object>> filters = buildMergeJoinFiltersFromRecords(joinKeys, downstreamTraceValue, errors);
+        if (CollectionUtils.isEmpty(filters)) {
+            filters = rewriteMergeFiltersFromCondition(upstreamNode, edge, downstreamCondition, fieldNameMapping);
+        }
+        if (CollectionUtils.isEmpty(filters)) {
+            filters = buildMergeJoinFiltersFromRecords(joinKeys, fallbackTraceValue, errors);
+        }
+        if (CollectionUtils.isEmpty(filters)) {
+            filters = rewriteMergeFiltersFromCondition(upstreamNode, edge, fallbackCondition, fieldNameMapping);
+        }
+        if (CollectionUtils.isEmpty(filters) && CollectionUtils.isEmpty(joinKeys)) {
             errors.add(traceError(ERROR_MERGE_JOIN_KEY_NOT_FOUND,null, null, null, null, null,
                     "table=" + resolveTableName(upstreamNode)));
+        }
+        return distinctFilters(filters);
+    }
+
+    private List<Map<String, Object>> rewriteMergeFiltersFromCondition(Node upstreamNode, Edge edge,
+                                                                       TraceQueryCondition condition,
+                                                                       Map<String, Map<String, String>> fieldNameMapping) {
+        if (!hasFilterCondition(condition)) {
             return Collections.emptyList();
         }
-        List<Map<String, Object>> filters = buildMergeJoinFiltersFromRecords(joinKeys, downstreamTraceValue, errors);
-//        if (CollectionUtils.isEmpty(filters)) {
-//            filters = buildMergeJoinFiltersFromCondition(joinKeys, downstreamCondition, errors);
-//        }
-//        if (CollectionUtils.isEmpty(filters)) {
-//            filters = buildMergeJoinFiltersFromRecords(joinKeys, fallbackTraceValue, errors);
-//        }
-//        if (CollectionUtils.isEmpty(filters)) {
-//            filters = buildMergeJoinFiltersFromCondition(joinKeys, fallbackCondition, errors);
-//        }
-        return distinctFilters(filters);
+        TableProperties properties = resolveTableProperties(upstreamNode, edge);
+        Map<String, String> upstreamFieldMapping = fieldNameMapping == null
+                ? Collections.emptyMap()
+                : fieldNameMapping.getOrDefault(upstreamNode.getId(), Collections.emptyMap());
+        return TraceUpstreamConditionRewriter.rewriteMergeSubTableFilters(
+                safeFilters(condition),
+                properties == null ? null : properties.getPath(),
+                properties == null ? null : properties.getJoinKeys(),
+                properties == null ? null : properties.getTablePk(),
+                upstreamFieldMapping
+        );
     }
 
     private List<Map<String, Object>> buildMergeJoinFiltersFromRecords(List<Map<String, String>> joinKeys,
@@ -510,16 +537,14 @@ public class TraceDataService {
                                                                  List<TraceNodeError> errors) {
         List<Map<String, Object>> filters = rewriteFiltersByFieldMapping(buildCondition,currentCondition, currentTraceValue,
                 upstreamFieldMapping, currentFieldMapping, updateConditionFieldList, errors);
-//        if (CollectionUtils.isEmpty(filters)) {
-//            filters = rewriteRecordValuesByFieldMapping(currentTraceValue, upstreamFieldMapping, currentFieldMapping, errors);
-//        }
-//        if (CollectionUtils.isEmpty(filters) && fallbackCondition != null && !fallbackFieldMapping.isEmpty()) {
-//            filters = rewriteFiltersByFieldMapping(buildCondition,fallbackCondition, fallbackTraceValue,
-//                    upstreamFieldMapping, fallbackFieldMapping, updateConditionFieldList, errors);
-//        }
-//        if (CollectionUtils.isEmpty(filters) && !fallbackFieldMapping.isEmpty()) {
-//            filters = rewriteRecordValuesByFieldMapping(fallbackTraceValue, upstreamFieldMapping, fallbackFieldMapping, errors);
-//        }
+        if (CollectionUtils.isEmpty(filters) && !hasCurrentRecords(currentTraceValue)) {
+            filters = TraceUpstreamConditionRewriter.rewriteNormalUpstreamFilters(
+                    safeFilters(currentCondition), currentFieldMapping, upstreamFieldMapping);
+        }
+        if (CollectionUtils.isEmpty(filters) && fallbackCondition != null && !hasCurrentRecords(fallbackTraceValue)) {
+            filters = TraceUpstreamConditionRewriter.rewriteNormalUpstreamFilters(
+                    safeFilters(fallbackCondition), fallbackFieldMapping, upstreamFieldMapping);
+        }
         return distinctFilters(filters);
     }
 
@@ -611,21 +636,31 @@ public class TraceDataService {
             CollectionUtils.emptyIfNull(sourceKeys).forEach(key -> {
                 String originName = currentFieldMapping.get(key);
                 Object value = readRecordValue(record, key);
-                if (value != null) {
-                    filter.put(originName, value);
+                String upstreamField = resolveUpstreamFieldName(originName, key, upstreamByOrigin);
+                if (value != null && StringUtils.isNotBlank(upstreamField)) {
+                    filter.put(upstreamField, value);
                 }
             });
         }else{
             sourceFilter.forEach((currentField, currentValue) -> {
                 String originName = currentFieldMapping.get(currentField);
                 Object value = record == null ? currentValue : readRecordValue(record, currentField);
-                if (value != null) {
-                    filter.put(originName, value);
+                String upstreamField = resolveUpstreamFieldName(originName, currentField, upstreamByOrigin);
+                if (value != null && StringUtils.isNotBlank(upstreamField)) {
+                    filter.put(upstreamField, value);
                 }
             });
         }
 
         return filter;
+    }
+
+    private String resolveUpstreamFieldName(String originName, String currentField, Map<String, String> upstreamByOrigin) {
+        if (MapUtils.isEmpty(upstreamByOrigin)) {
+            return firstNotBlank(originName, currentField);
+        }
+        String origin = StringUtils.isNotBlank(originName) ? originName : currentField;
+        return firstNotBlank(upstreamByOrigin.get(origin), upstreamByOrigin.get(currentField));
     }
 
     private List<Map<String, Object>> rewriteRecordValuesByFieldMapping(TraceValue currentTraceValue,
@@ -944,6 +979,62 @@ public class TraceDataService {
     private boolean isMergeSubTable(Node node, Edge edge) {
         TableProperties properties = resolveTableProperties(node, edge);
         return properties != null && StringUtils.equalsIgnoreCase(properties.getTableType(), "subTable");
+    }
+
+    private boolean isMainTable(Node node) {
+        TableProperties properties = resolveTableProperties(node, null);
+        return properties != null && StringUtils.equalsIgnoreCase(properties.getTableType(), "mainTable");
+    }
+
+    private boolean isMergeRelatedTable(Node node) {
+        return isMainTable(node) || isMergeSubTable(node, null);
+    }
+
+    private void enqueueMergeSiblingsFromRecords(Queue<TraceNodeStep> queue, Set<String> visited,
+                                                 Map<String, Node> nodeMap, Map<String, List<Edge>> incomingEdges,
+                                                 TraceNodeStep step, TraceValue traceValue,
+                                                 Map<String, Map<String, String>> fieldNameMapping) {
+        if (!hasCurrentRecords(traceValue) || step == null || step.getDownstreamNode() == null) {
+            return;
+        }
+        Node currentNode = step.getCurrentNode();
+        if (currentNode == null || !isMergeRelatedTable(currentNode)) {
+            return;
+        }
+        TableProperties currentProperties = resolveTableProperties(currentNode, null);
+        if (currentProperties == null) {
+            return;
+        }
+        Node downstreamNode = step.getDownstreamNode();
+        for (Edge edge : incomingEdges.getOrDefault(downstreamNode.getId(), Collections.emptyList())) {
+            Node sibling = nodeMap.get(edge.getSource());
+            if (sibling == null || StringUtils.isBlank(sibling.getId())
+                    || StringUtils.equals(sibling.getId(), currentNode.getId())
+                    || visited.contains(sibling.getId())
+                    || !isMergeRelatedTable(sibling)) {
+                continue;
+            }
+            TableProperties siblingProperties = resolveTableProperties(sibling, null);
+            if (siblingProperties == null) {
+                continue;
+            }
+            List<Map<String, Object>> filters = TraceUpstreamConditionRewriter.rewriteSiblingFiltersFromRecords(
+                    traceValue.getCurrentRecords(),
+                    currentProperties.getJoinKeys(),
+                    currentProperties.getTablePk(),
+                    siblingProperties.getJoinKeys(),
+                    siblingProperties.getTablePk(),
+                    fieldNameMapping.getOrDefault(sibling.getId(), Collections.emptyMap())
+            );
+            if (CollectionUtils.isEmpty(filters)) {
+                continue;
+            }
+            TraceQueryCondition condition = new TraceQueryCondition();
+            condition.setConnectionId(resolveConnectionId(sibling));
+            condition.setTable(resolveTableName(sibling));
+            condition.setFilters(filters);
+            queue.add(new TraceNodeStep(sibling, downstreamNode, condition, traceValue, traceValue, currentNode, condition));
+        }
     }
 
     private TableProperties resolveTableProperties(Node node, Edge edge) {

--- a/manager/tm/src/main/java/com/tapdata/tm/trace/service/data/TraceUpstreamConditionRewriter.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/trace/service/data/TraceUpstreamConditionRewriter.java
@@ -1,0 +1,390 @@
+package com.tapdata.tm.trace.service.data;
+
+import com.tapdata.tm.trace.dto.boodline.FieldNameMapping;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Rewrites a wide-table filter onto an upstream table when the downstream node has no matched records.
+ * Merge sub-tables use nested path + join keys; normal tables only keep fields that exist upstream.
+ * After a merge table has records, siblings are filled from shared join keys / table PKs.
+ */
+public final class TraceUpstreamConditionRewriter {
+
+    private TraceUpstreamConditionRewriter() {
+    }
+
+    public static List<Map<String, Object>> rewriteMergeSubTableFilters(List<Map<String, Object>> downstreamFilters,
+                                                                        String nestedPath,
+                                                                        List<FieldNameMapping> joinKeys,
+                                                                        List<FieldNameMapping> tablePk,
+                                                                        Map<String, String> upstreamFieldMapping) {
+        if (CollectionUtils.isEmpty(downstreamFilters)) {
+            return Collections.emptyList();
+        }
+        List<Map<String, Object>> result = new ArrayList<>();
+        for (Map<String, Object> sourceFilter : downstreamFilters) {
+            if (MapUtils.isEmpty(sourceFilter)) {
+                continue;
+            }
+            Map<String, Object> rewritten = new LinkedHashMap<>();
+            appendJoinKeyValues(rewritten, sourceFilter, joinKeys);
+            appendJoinKeyValues(rewritten, sourceFilter, tablePk);
+            sourceFilter.forEach((field, value) -> {
+                if (StringUtils.isBlank(field) || value == null || rewritten.containsKey(field)) {
+                    return;
+                }
+                String localField = resolveLocalField(field, nestedPath, upstreamFieldMapping);
+                if (StringUtils.isNotBlank(localField) && !rewritten.containsKey(localField)) {
+                    rewritten.put(localField, value);
+                }
+            });
+            if (MapUtils.isNotEmpty(rewritten)) {
+                result.add(rewritten);
+            }
+        }
+        return result;
+    }
+
+    public static List<Map<String, Object>> rewriteNormalUpstreamFilters(List<Map<String, Object>> downstreamFilters,
+                                                                         Map<String, String> currentFieldMapping,
+                                                                         Map<String, String> upstreamFieldMapping) {
+        if (CollectionUtils.isEmpty(downstreamFilters) || MapUtils.isEmpty(upstreamFieldMapping)) {
+            return Collections.emptyList();
+        }
+        Map<String, String> upstreamByOrigin = invertOriginToField(upstreamFieldMapping);
+        List<Map<String, Object>> result = new ArrayList<>();
+        for (Map<String, Object> sourceFilter : downstreamFilters) {
+            if (MapUtils.isEmpty(sourceFilter)) {
+                continue;
+            }
+            Map<String, Object> rewritten = new LinkedHashMap<>();
+            sourceFilter.forEach((currentField, value) -> {
+                if (StringUtils.isBlank(currentField) || value == null) {
+                    return;
+                }
+                String originName = MapUtils.emptyIfNull(currentFieldMapping).get(currentField);
+                if (StringUtils.isBlank(originName)) {
+                    originName = currentField;
+                }
+                String upstreamField = firstNotBlank(
+                        upstreamByOrigin.get(originName),
+                        upstreamFieldMapping.containsKey(originName) ? originName : null,
+                        upstreamFieldMapping.containsKey(currentField) ? currentField : null
+                );
+                if (StringUtils.isNotBlank(upstreamField)) {
+                    rewritten.put(upstreamField, value);
+                }
+            });
+            if (MapUtils.isNotEmpty(rewritten)) {
+                result.add(rewritten);
+            }
+        }
+        return result;
+    }
+
+    public static List<Map<String, Object>> rewriteMainTableFiltersFromSubTableRecords(List<Map<String, Object>> subTableRecords,
+                                                                                       List<FieldNameMapping> joinKeys,
+                                                                                       Map<String, String> mainTableFieldMapping) {
+        if (CollectionUtils.isEmpty(subTableRecords) || CollectionUtils.isEmpty(joinKeys)
+                || MapUtils.isEmpty(mainTableFieldMapping)) {
+            return Collections.emptyList();
+        }
+        List<Map<String, Object>> result = new ArrayList<>();
+        Set<Map<String, Object>> seen = new HashSet<>();
+        for (Map<String, Object> record : subTableRecords) {
+            if (MapUtils.isEmpty(record)) {
+                continue;
+            }
+            Map<String, Object> filter = new LinkedHashMap<>();
+            for (FieldNameMapping joinKey : joinKeys) {
+                if (joinKey == null) {
+                    continue;
+                }
+                String subTableField = firstNotBlank(joinKey.getOriginName(), joinKey.getTargetName());
+                String mainTableField = pickMainTableField(joinKey, mainTableFieldMapping);
+                if (StringUtils.isAnyBlank(subTableField, mainTableField)) {
+                    continue;
+                }
+                Object value = record.get(subTableField);
+                if (value != null) {
+                    filter.put(mainTableField, value);
+                }
+            }
+            if (MapUtils.isNotEmpty(filter) && seen.add(filter)) {
+                result.add(filter);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Rebuilds filters for a merge sibling from the current node's records.
+     * Same-named join/PK fields are copied when they exist on the sibling.
+     * Renamed join keys are mapped (e.g. order.customer_no -&gt; customer.cust_no).
+     * Nested join targets stay on the merge-table origin (account.account_id can
+     * fill transaction; customer_id cannot).
+     */
+    public static List<Map<String, Object>> rewriteSiblingFiltersFromRecords(List<Map<String, Object>> currentRecords,
+                                                                             List<FieldNameMapping> currentJoinKeys,
+                                                                             List<FieldNameMapping> currentTablePk,
+                                                                             List<FieldNameMapping> siblingJoinKeys,
+                                                                             List<FieldNameMapping> siblingTablePk,
+                                                                             Map<String, String> siblingFieldMapping) {
+        if (CollectionUtils.isEmpty(currentRecords)) {
+            return Collections.emptyList();
+        }
+        Set<String> candidateFields = new LinkedHashSet<>();
+        collectLocalFieldNames(candidateFields, currentJoinKeys);
+        collectLocalFieldNames(candidateFields, currentTablePk);
+        collectLocalFieldNames(candidateFields, siblingJoinKeys);
+        collectLocalFieldNames(candidateFields, siblingTablePk);
+        Set<String> siblingKeyNames = new LinkedHashSet<>();
+        collectJoinOriginNames(siblingKeyNames, siblingJoinKeys);
+        collectLocalFieldNames(siblingKeyNames, siblingTablePk);
+        if (candidateFields.isEmpty()) {
+            return Collections.emptyList();
+        }
+        List<Map<String, Object>> result = new ArrayList<>();
+        Set<Map<String, Object>> seen = new HashSet<>();
+        for (Map<String, Object> record : currentRecords) {
+            if (MapUtils.isEmpty(record)) {
+                continue;
+            }
+            Map<String, Object> filter = new LinkedHashMap<>();
+            putJoinKeyMappedValues(filter, record, currentJoinKeys, siblingFieldMapping, siblingKeyNames);
+            putJoinKeyMappedValues(filter, record, siblingJoinKeys, siblingFieldMapping, siblingKeyNames);
+            for (String field : candidateFields) {
+                Object value = record.get(field);
+                if (value == null || filter.containsKey(field)
+                        || !siblingAcceptsField(field, siblingFieldMapping, siblingKeyNames)) {
+                    continue;
+                }
+                filter.put(field, value);
+            }
+            if (MapUtils.isNotEmpty(filter) && seen.add(filter)) {
+                result.add(filter);
+            }
+        }
+        return result;
+    }
+
+    public static boolean onlyNestedFilterKeys(List<Map<String, Object>> filters) {
+        if (CollectionUtils.isEmpty(filters)) {
+            return false;
+        }
+        boolean hasKey = false;
+        for (Map<String, Object> filter : filters) {
+            if (MapUtils.isEmpty(filter)) {
+                continue;
+            }
+            for (String key : filter.keySet()) {
+                if (StringUtils.isBlank(key)) {
+                    continue;
+                }
+                hasKey = true;
+                if (!key.contains(".")) {
+                    return false;
+                }
+            }
+        }
+        return hasKey;
+    }
+
+    static String resolveLocalField(String field, String nestedPath, Map<String, String> upstreamFieldMapping) {
+        if (StringUtils.isBlank(field)) {
+            return null;
+        }
+        if (upstreamHasField(field, upstreamFieldMapping)) {
+            return field;
+        }
+        String stripped = stripNestedPath(field, nestedPath);
+        if (StringUtils.isBlank(stripped)) {
+            return null;
+        }
+        if (MapUtils.isEmpty(upstreamFieldMapping) || upstreamHasField(stripped, upstreamFieldMapping)) {
+            return stripped;
+        }
+        return null;
+    }
+
+    static String stripNestedPath(String field, String nestedPath) {
+        if (StringUtils.isAnyBlank(field, nestedPath)) {
+            return null;
+        }
+        if (StringUtils.equals(field, nestedPath)) {
+            return null;
+        }
+        String prefix = nestedPath + ".";
+        if (field.startsWith(prefix)) {
+            return field.substring(prefix.length());
+        }
+        return null;
+    }
+
+    private static void appendJoinKeyValues(Map<String, Object> rewritten,
+                                            Map<String, Object> sourceFilter,
+                                            List<FieldNameMapping> mappings) {
+        if (CollectionUtils.isEmpty(mappings)) {
+            return;
+        }
+        for (FieldNameMapping mapping : mappings) {
+            if (mapping == null) {
+                continue;
+            }
+            String sourceField = firstNotBlank(mapping.getOriginName());
+            String targetField = firstNotBlank(mapping.getTargetName());
+            if (StringUtils.isBlank(sourceField)) {
+                continue;
+            }
+            Object value = null;
+            if (StringUtils.isNotBlank(targetField)) {
+                value = sourceFilter.get(targetField);
+            }
+            if (value == null) {
+                value = sourceFilter.get(sourceField);
+            }
+            if (value != null && !rewritten.containsKey(sourceField)) {
+                rewritten.put(sourceField, value);
+            }
+        }
+    }
+
+    private static void putJoinKeyMappedValues(Map<String, Object> filter,
+                                               Map<String, Object> record,
+                                               List<FieldNameMapping> joinKeys,
+                                               Map<String, String> siblingFieldMapping,
+                                               Set<String> siblingKeyNames) {
+        if (filter == null || MapUtils.isEmpty(record) || CollectionUtils.isEmpty(joinKeys)) {
+            return;
+        }
+        for (FieldNameMapping mapping : joinKeys) {
+            if (mapping == null) {
+                continue;
+            }
+            String originName = mapping.getOriginName();
+            String localTarget = localJoinField(mapping.getTargetName());
+            putIfSiblingAccepts(filter, record, originName, localTarget, siblingFieldMapping, siblingKeyNames);
+            putIfSiblingAccepts(filter, record, originName, originName, siblingFieldMapping, siblingKeyNames);
+            putIfSiblingAccepts(filter, record, localTarget, originName, siblingFieldMapping, siblingKeyNames);
+            putIfSiblingAccepts(filter, record, localTarget, localTarget, siblingFieldMapping, siblingKeyNames);
+        }
+    }
+
+    private static void putIfSiblingAccepts(Map<String, Object> filter,
+                                            Map<String, Object> record,
+                                            String sourceField,
+                                            String destField,
+                                            Map<String, String> siblingFieldMapping,
+                                            Set<String> siblingKeyNames) {
+        if (StringUtils.isAnyBlank(sourceField, destField) || filter.containsKey(destField)) {
+            return;
+        }
+        Object value = record.get(sourceField);
+        if (value != null && siblingAcceptsField(destField, siblingFieldMapping, siblingKeyNames)) {
+            filter.put(destField, value);
+        }
+    }
+
+    private static String localJoinField(String field) {
+        if (StringUtils.isBlank(field) || field.contains(".")) {
+            return null;
+        }
+        return field;
+    }
+
+    /**
+     * Join origin is the merge-table (sibling) field. The target is the parent/main
+     * field and must not be treated as a sibling column when names differ
+     * (e.g. order.customer_no -&gt; customer.cust_no).
+     */
+    private static void collectJoinOriginNames(Set<String> fields, List<FieldNameMapping> mappings) {
+        if (fields == null || CollectionUtils.isEmpty(mappings)) {
+            return;
+        }
+        for (FieldNameMapping mapping : mappings) {
+            if (mapping == null || StringUtils.isBlank(mapping.getOriginName())) {
+                continue;
+            }
+            fields.add(mapping.getOriginName());
+        }
+    }
+
+    private static void collectLocalFieldNames(Set<String> fields, List<FieldNameMapping> mappings) {
+        if (fields == null || CollectionUtils.isEmpty(mappings)) {
+            return;
+        }
+        for (FieldNameMapping mapping : mappings) {
+            if (mapping == null) {
+                continue;
+            }
+            if (StringUtils.isNotBlank(mapping.getOriginName())) {
+                fields.add(mapping.getOriginName());
+            }
+            String targetName = mapping.getTargetName();
+            if (StringUtils.isNotBlank(targetName) && !targetName.contains(".")) {
+                fields.add(targetName);
+            }
+        }
+    }
+
+    private static boolean siblingAcceptsField(String field, Map<String, String> siblingFieldMapping,
+                                               Set<String> siblingKeyNames) {
+        return upstreamHasField(field, siblingFieldMapping)
+                || (siblingKeyNames != null && siblingKeyNames.contains(field));
+    }
+
+    private static String pickMainTableField(FieldNameMapping joinKey, Map<String, String> mainTableFieldMapping) {
+        String originName = joinKey.getOriginName();
+        String targetName = joinKey.getTargetName();
+        if (upstreamHasField(originName, mainTableFieldMapping)) {
+            return originName;
+        }
+        if (upstreamHasField(targetName, mainTableFieldMapping)) {
+            return targetName;
+        }
+        return null;
+    }
+
+    private static boolean upstreamHasField(String field, Map<String, String> upstreamFieldMapping) {
+        if (StringUtils.isBlank(field)) {
+            return false;
+        }
+        if (MapUtils.isEmpty(upstreamFieldMapping)) {
+            return false;
+        }
+        return upstreamFieldMapping.containsKey(field) || upstreamFieldMapping.containsValue(field);
+    }
+
+    private static Map<String, String> invertOriginToField(Map<String, String> fieldToOrigin) {
+        Map<String, String> originToField = new LinkedHashMap<>();
+        fieldToOrigin.forEach((fieldName, originName) -> {
+            if (StringUtils.isNoneBlank(fieldName, originName)) {
+                originToField.putIfAbsent(originName, fieldName);
+            }
+        });
+        return originToField;
+    }
+
+    private static String firstNotBlank(String... values) {
+        if (values == null) {
+            return null;
+        }
+        for (String value : values) {
+            if (StringUtils.isNotBlank(value)) {
+                return value;
+            }
+        }
+        return null;
+    }
+}

--- a/manager/tm/src/test/java/com/tapdata/tm/trace/service/data/TraceDataServiceMergeSiblingTraceTest.java
+++ b/manager/tm/src/test/java/com/tapdata/tm/trace/service/data/TraceDataServiceMergeSiblingTraceTest.java
@@ -1,0 +1,238 @@
+package com.tapdata.tm.trace.service.data;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tapdata.tm.commons.dag.Edge;
+import com.tapdata.tm.commons.task.dto.Dag;
+import com.tapdata.tm.lineage.analyzer.entity.LineageTableNode;
+import com.tapdata.tm.trace.dto.TaskLineageDto;
+import com.tapdata.tm.trace.dto.TraceQueryCondition;
+import com.tapdata.tm.trace.dto.TraceStreamEvent;
+import com.tapdata.tm.trace.dto.boodline.FieldNameMapping;
+import com.tapdata.tm.trace.dto.boodline.TableProperties;
+import com.tapdata.tm.trace.enums.TraceEventType;
+import com.tapdata.tm.trace.param.TraceFilter;
+import com.tapdata.tm.trace.param.WideTableTraceRequest;
+import com.tapdata.tm.trace.service.bloodline.BloodlineFinder;
+import io.tapdata.pdk.apis.entity.QueryOperator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TraceDataServiceMergeSiblingTraceTest {
+
+    private static final String MDM_CONN = "mdm-conn";
+    private static final String FDM_CONN = "fdm-conn";
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Mock
+    private BloodlineFinder bloodlineFinder;
+    @Mock
+    private TraceDataQueryRpcAdapter queryAdapter;
+
+    private TraceDataService service;
+    private LineageTableNode target;
+    private LineageTableNode customer;
+    private LineageTableNode account;
+    private LineageTableNode transaction;
+
+    @BeforeEach
+    void setUp() {
+        service = new TraceDataService();
+        ReflectionTestUtils.setField(service, "bloodlineFinder", bloodlineFinder);
+        ReflectionTestUtils.setField(service, "objectMapper", MAPPER);
+        ReflectionTestUtils.setField(service, "traceDataQueryAdapter", queryAdapter);
+
+        target = table(MDM_CONN, "MDM_HBL_TT");
+        customer = mergeTable(FDM_CONN, "FDM_pg_hbl_customer", "mainTable", null,
+                List.of(), List.of(mapping("customer_id", "customer_id")));
+        account = mergeTable(FDM_CONN, "FDM_pg_hbl_account", "subTable", "ACCOUNT",
+                List.of(mapping("customer_id", "customer_id")),
+                List.of(mapping("account_id", "account_id")));
+        transaction = mergeTable(FDM_CONN, "FDM_pg_hbl_transaction", "subTable", "ACCOUNT.TRANSACTION",
+                List.of(mapping("account_id", "ACCOUNT.account_id")),
+                List.of(mapping("transaction_id", "transaction_id")));
+
+        TaskLineageDto lineage = new TaskLineageDto(new Dag(
+                List.of(
+                        new Edge(customer.getId(), target.getId()),
+                        new Edge(account.getId(), target.getId()),
+                        new Edge(transaction.getId(), target.getId())
+                ),
+                List.of(target, customer, account, transaction)
+        ));
+        lineage.setUpdateConditionFieldList(new HashMap<>());
+        lineage.setFieldNameMapping(Map.of(
+                target.getId(), Map.of(
+                        "customer_id", "customer_id",
+                        "ACCOUNT.account_id", "account_id",
+                        "ACCOUNT.TRANSACTION.transaction_id", "transaction_id"
+                ),
+                customer.getId(), Map.of("customer_id", "customer_id", "customer_type", "customer_type"),
+                account.getId(), Map.of("account_id", "account_id", "customer_id", "customer_id"),
+                transaction.getId(), Map.of("transaction_id", "transaction_id", "account_id", "account_id")
+        ));
+        when(bloodlineFinder.findTaskLineage(any())).thenReturn(lineage);
+    }
+
+    @Test
+    @DisplayName("M5: customer_id miss should fill account then transaction")
+    void customerIdMiss_shouldFillAccountAndTransaction() throws Exception {
+        when(queryAdapter.query(any())).thenAnswer(invocation -> recordsFor(invocation.getArgument(0)));
+
+        List<TraceStreamEvent> events = trace("customer_id", "cust-001775");
+
+        assertTrue(tracedTables(events).containsAll(List.of(
+                "MDM_HBL_TT", "FDM_pg_hbl_customer", "FDM_pg_hbl_account", "FDM_pg_hbl_transaction"
+        )));
+        assertFalse(hasFilterNotBuilt(events), () -> "unexpected errors: " + errorCodes(events));
+        assertTrue(matchedCount(events, "FDM_pg_hbl_transaction") > 0);
+    }
+
+    @Test
+    @DisplayName("M7: nested transaction_id miss should fill transaction then account and customer")
+    void nestedTransactionIdMiss_shouldFillAccountAndCustomer() throws Exception {
+        when(queryAdapter.query(any())).thenAnswer(invocation -> recordsFor(invocation.getArgument(0)));
+
+        List<TraceStreamEvent> events = trace("ACCOUNT.TRANSACTION.transaction_id", "txn-000211");
+
+        assertTrue(tracedTables(events).containsAll(List.of(
+                "MDM_HBL_TT", "FDM_pg_hbl_transaction", "FDM_pg_hbl_account", "FDM_pg_hbl_customer"
+        )));
+        assertFalse(hasFilterNotBuilt(events), () -> "unexpected errors: " + errorCodes(events));
+        assertTrue(matchedCount(events, "FDM_pg_hbl_account") > 0);
+        assertTrue(matchedCount(events, "FDM_pg_hbl_customer") > 0);
+    }
+
+    private List<Map<String, Object>> recordsFor(TraceQueryCondition condition) {
+        String table = condition.getTable();
+        if ("MDM_HBL_TT".equals(table)) {
+            return List.of();
+        }
+        if ("FDM_pg_hbl_customer".equals(table) && hasValue(condition, "customer_id", "cust-001775")) {
+            return List.of(Map.of("customer_id", "cust-001775", "customer_type", "BUSINESS"));
+        }
+        if ("FDM_pg_hbl_account".equals(table)
+                && (hasValue(condition, "customer_id", "cust-001775") || hasValue(condition, "account_id", "acc-000001"))) {
+            Map<String, Object> record = new LinkedHashMap<>();
+            record.put("account_id", "acc-000001");
+            record.put("customer_id", "cust-001775");
+            return List.of(record);
+        }
+        if ("FDM_pg_hbl_transaction".equals(table)
+                && (hasValue(condition, "account_id", "acc-000001") || hasValue(condition, "transaction_id", "txn-000211"))) {
+            Map<String, Object> record = new LinkedHashMap<>();
+            record.put("transaction_id", "txn-000211");
+            record.put("account_id", "acc-000001");
+            return List.of(record);
+        }
+        return List.of();
+    }
+
+    private List<TraceStreamEvent> trace(String key, String value) throws Exception {
+        WideTableTraceRequest request = new WideTableTraceRequest();
+        request.setConnectionId(MDM_CONN);
+        request.setTable("MDM_HBL_TT");
+        TraceFilter filters = new TraceFilter();
+        QueryOperator custom = new QueryOperator();
+        custom.setKey(key);
+        custom.setValue(value);
+        filters.setCustom(List.of(custom));
+        request.setFilters(filters);
+
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        service.traceData(request, "trace_test", output);
+        List<TraceStreamEvent> events = new ArrayList<>();
+        for (String line : output.toString(StandardCharsets.UTF_8).split("\n")) {
+            if (!line.isBlank()) {
+                events.add(MAPPER.readValue(line, TraceStreamEvent.class));
+            }
+        }
+        return events;
+    }
+
+    private static boolean hasValue(TraceQueryCondition condition, String key, Object value) {
+        if (condition == null || condition.getFilters() == null) {
+            return false;
+        }
+        return condition.getFilters().stream().anyMatch(filter -> Objects.equals(filter.get(key), value));
+    }
+
+    private static Set<String> tracedTables(List<TraceStreamEvent> events) {
+        return events.stream()
+                .filter(event -> event.getType() == TraceEventType.TRACE_VALUE)
+                .map(TraceStreamEvent::getTable)
+                .collect(Collectors.toSet());
+    }
+
+    private static boolean hasFilterNotBuilt(List<TraceStreamEvent> events) {
+        return events.stream()
+                .filter(event -> event.getType() == TraceEventType.NODE_ERROR)
+                .map(TraceStreamEvent::getError)
+                .filter(Objects::nonNull)
+                .anyMatch(error -> "Trace.Filter.NotBuilt".equals(error.getCode()));
+    }
+
+    private static List<String> errorCodes(List<TraceStreamEvent> events) {
+        return events.stream()
+                .filter(event -> event.getType() == TraceEventType.NODE_ERROR)
+                .map(event -> event.getTable() + ":" + (event.getError() == null ? null : event.getError().getCode()))
+                .collect(Collectors.toList());
+    }
+
+    private static long matchedCount(List<TraceStreamEvent> events, String table) {
+        return events.stream()
+                .filter(event -> event.getType() == TraceEventType.TRACE_VALUE)
+                .filter(event -> table.equals(event.getTable()))
+                .map(TraceStreamEvent::getTraceValue)
+                .filter(Objects::nonNull)
+                .mapToLong(value -> value.getMatchedCount())
+                .sum();
+    }
+
+    private static LineageTableNode table(String connectionId, String tableName) {
+        return new LineageTableNode(tableName, connectionId, connectionId, null, null);
+    }
+
+    private static LineageTableNode mergeTable(String connectionId, String tableName, String tableType, String path,
+                                               List<FieldNameMapping> joinKeys, List<FieldNameMapping> tablePk) {
+        LineageTableNode node = table(connectionId, tableName);
+        TableProperties properties = new TableProperties();
+        properties.setNodeType("MERGE");
+        properties.setTableType(tableType);
+        properties.setPath(path);
+        properties.setJoinKeys(joinKeys);
+        properties.setTablePk(tablePk);
+        Map<String, Object> attrs = new HashMap<>();
+        attrs.put("merge", properties);
+        node.setAttrs(attrs);
+        return node;
+    }
+
+    private static FieldNameMapping mapping(String originName, String targetName) {
+        FieldNameMapping mapping = new FieldNameMapping();
+        mapping.setOriginName(originName);
+        mapping.setTargetName(targetName);
+        return mapping;
+    }
+}

--- a/manager/tm/src/test/java/com/tapdata/tm/trace/service/data/TraceUpstreamConditionRewriterTest.java
+++ b/manager/tm/src/test/java/com/tapdata/tm/trace/service/data/TraceUpstreamConditionRewriterTest.java
@@ -1,0 +1,462 @@
+package com.tapdata.tm.trace.service.data;
+
+import com.tapdata.tm.trace.dto.boodline.FieldNameMapping;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * DataTrace reverse-filter cases aligned with:
+ * <ul>
+ *   <li>MDM merge task 6a8e4e95b2c69173e185978c (FDM_* -&gt; MDM_HBL_TT)</li>
+ *   <li>FDM clone task 6a90f52fe409db2ba24a7fc7 (pg_fdm.hbl_* -&gt; FDM_pg_hbl_*)</li>
+ * </ul>
+ */
+class TraceUpstreamConditionRewriterTest {
+
+    private static final Map<String, String> ACCOUNT_FIELDS = Map.of(
+            "account_id", "account_id",
+            "customer_id", "customer_id",
+            "account_number", "account_number"
+    );
+    private static final Map<String, String> TXN_FIELDS = Map.of(
+            "transaction_id", "transaction_id",
+            "account_id", "account_id",
+            "amount", "amount"
+    );
+    private static final Map<String, String> CUSTOMER_FIELDS = Map.of(
+            "customer_id", "customer_id",
+            "customer_type", "customer_type",
+            "first_name", "first_name"
+    );
+    private static final Map<String, String> WIDE_TABLE_FIELDS = Map.of(
+            "customer_id", "customer_id",
+            "ACCOUNT.account_id", "account_id",
+            "ACCOUNT.TRANSACTION.transaction_id", "transaction_id"
+    );
+
+    @Nested
+    @DisplayName("MDM 6a8e4e95: merge sub-table reverse when wide table misses")
+    class MdmMergeSubTable {
+
+        @Test
+        void accountPath_shouldMapNestedAccountId() {
+            assertEquals(
+                    List.of(Map.of("account_id", "acc-000001")),
+                    TraceUpstreamConditionRewriter.rewriteMergeSubTableFilters(
+                            List.of(filter("ACCOUNT.account_id", "acc-000001")),
+                            "ACCOUNT",
+                            List.of(mapping("customer_id", "customer_id")),
+                            List.of(mapping("account_id", "account_id")),
+                            ACCOUNT_FIELDS
+                    )
+            );
+        }
+
+        @Test
+        void transactionJoinKey_shouldMapWideTableAccountId() {
+            assertEquals(
+                    List.of(Map.of("account_id", "acc-000001")),
+                    TraceUpstreamConditionRewriter.rewriteMergeSubTableFilters(
+                            List.of(filter("ACCOUNT.account_id", "acc-000001")),
+                            "ACCOUNT.TRANSACTION",
+                            List.of(mapping("account_id", "ACCOUNT.account_id")),
+                            List.of(mapping("transaction_id", "transaction_id")),
+                            TXN_FIELDS
+                    )
+            );
+        }
+
+        @Test
+        void transactionPath_shouldMapNestedTransactionId() {
+            assertEquals(
+                    List.of(Map.of("transaction_id", "txn-000211")),
+                    TraceUpstreamConditionRewriter.rewriteMergeSubTableFilters(
+                            List.of(filter("ACCOUNT.TRANSACTION.transaction_id", "txn-000211")),
+                            "ACCOUNT.TRANSACTION",
+                            List.of(mapping("account_id", "ACCOUNT.account_id")),
+                            Collections.emptyList(),
+                            TXN_FIELDS
+                    )
+            );
+        }
+
+        @Test
+        void accountPath_shouldIgnoreTransactionOnlyField() {
+            assertTrue(TraceUpstreamConditionRewriter.rewriteMergeSubTableFilters(
+                    List.of(filter("ACCOUNT.TRANSACTION.transaction_id", "txn-000211")),
+                    "ACCOUNT",
+                    List.of(mapping("customer_id", "customer_id")),
+                    Collections.emptyList(),
+                    ACCOUNT_FIELDS
+            ).isEmpty());
+        }
+
+        @Test
+        void tablePk_shouldMapWhenJoinKeyDoesNotMatch() {
+            assertEquals(
+                    List.of(Map.of("account_id", "acc-000001")),
+                    TraceUpstreamConditionRewriter.rewriteMergeSubTableFilters(
+                            List.of(filter("ACCOUNT.account_id", "acc-000001")),
+                            null,
+                            Collections.emptyList(),
+                            List.of(mapping("account_id", "ACCOUNT.account_id")),
+                            ACCOUNT_FIELDS
+                    )
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("MDM 6a8e4e95: main table must not inherit sub-table filters")
+    class MdmMainTable {
+
+        @Test
+        void customer_shouldSkipNestedAccountId() {
+            assertTrue(TraceUpstreamConditionRewriter.rewriteNormalUpstreamFilters(
+                    List.of(filter("ACCOUNT.account_id", "acc-000001")),
+                    WIDE_TABLE_FIELDS,
+                    CUSTOMER_FIELDS
+            ).isEmpty());
+        }
+
+        @Test
+        void customer_shouldKeepCustomerId() {
+            assertEquals(
+                    List.of(Map.of("customer_id", "cust-000001")),
+                    TraceUpstreamConditionRewriter.rewriteNormalUpstreamFilters(
+                            List.of(filter("customer_id", "cust-000001")),
+                            WIDE_TABLE_FIELDS,
+                            CUSTOMER_FIELDS
+                    )
+            );
+        }
+
+        @Test
+        void nestedOnlyFilter_shouldBeDetected() {
+            assertTrue(TraceUpstreamConditionRewriter.onlyNestedFilterKeys(
+                    List.of(filter("ACCOUNT.account_id", "acc-000001"))));
+            assertFalse(TraceUpstreamConditionRewriter.onlyNestedFilterKeys(
+                    List.of(filter("customer_id", "cust-000001"))));
+            assertFalse(TraceUpstreamConditionRewriter.onlyNestedFilterKeys(Collections.emptyList()));
+        }
+
+        @Test
+        void accountRecords_shouldRebuildCustomerFilterByJoinKey() {
+            Map<String, Object> account = new LinkedHashMap<>();
+            account.put("account_id", "acc-000001");
+            account.put("customer_id", "cust-001775");
+            assertEquals(
+                    List.of(Map.of("customer_id", "cust-001775")),
+                    TraceUpstreamConditionRewriter.rewriteMainTableFiltersFromSubTableRecords(
+                            List.of(account),
+                            List.of(mapping("customer_id", "customer_id")),
+                            CUSTOMER_FIELDS
+                    )
+            );
+        }
+
+        @Test
+        void transactionRecords_shouldNotRebuildCustomerFilter() {
+            Map<String, Object> txn = new LinkedHashMap<>();
+            txn.put("account_id", "acc-000001");
+            txn.put("transaction_id", "txn-000211");
+            assertTrue(TraceUpstreamConditionRewriter.rewriteMainTableFiltersFromSubTableRecords(
+                    List.of(txn),
+                    List.of(mapping("account_id", "ACCOUNT.account_id")),
+                    CUSTOMER_FIELDS
+            ).isEmpty());
+        }
+
+        @Test
+        void duplicateAccountRecords_shouldDedupCustomerFilter() {
+            Map<String, Object> a1 = filter("customer_id", "cust-001775");
+            a1.put("account_id", "acc-000001");
+            Map<String, Object> a2 = filter("customer_id", "cust-001775");
+            a2.put("account_id", "acc-002095");
+            List<Map<String, Object>> result = TraceUpstreamConditionRewriter.rewriteMainTableFiltersFromSubTableRecords(
+                    List.of(a1, a2),
+                    List.of(mapping("customer_id", "customer_id")),
+                    CUSTOMER_FIELDS
+            );
+            assertEquals(1, result.size());
+            assertEquals("cust-001775", result.get(0).get("customer_id"));
+        }
+    }
+
+    @Nested
+    @DisplayName("MDM 6a8e4e95: merge siblings fill each other from records")
+    class MdmMergeSiblings {
+
+        private static final List<FieldNameMapping> ACCOUNT_JOIN_KEYS = List.of(mapping("customer_id", "customer_id"));
+        private static final List<FieldNameMapping> ACCOUNT_PK = List.of(mapping("account_id", "account_id"));
+        private static final List<FieldNameMapping> TXN_JOIN_KEYS = List.of(mapping("account_id", "ACCOUNT.account_id"));
+        private static final List<FieldNameMapping> TXN_PK = List.of(mapping("transaction_id", "transaction_id"));
+        private static final List<FieldNameMapping> CUSTOMER_PK = List.of(mapping("customer_id", "customer_id"));
+
+        @Test
+        void accountRecords_shouldRebuildTransactionFilterByAccountId() {
+            Map<String, Object> account = new LinkedHashMap<>();
+            account.put("account_id", "acc-000001");
+            account.put("customer_id", "cust-001775");
+            account.put("status", "ACTIVE");
+            assertEquals(
+                    List.of(Map.of("account_id", "acc-000001")),
+                    TraceUpstreamConditionRewriter.rewriteSiblingFiltersFromRecords(
+                            List.of(account),
+                            ACCOUNT_JOIN_KEYS,
+                            ACCOUNT_PK,
+                            TXN_JOIN_KEYS,
+                            TXN_PK,
+                            TXN_FIELDS
+                    )
+            );
+        }
+
+        @Test
+        void transactionRecords_shouldRebuildAccountFilterByAccountId() {
+            Map<String, Object> txn = new LinkedHashMap<>();
+            txn.put("account_id", "acc-000001");
+            txn.put("transaction_id", "txn-000211");
+            txn.put("amount", 12.5);
+            assertEquals(
+                    List.of(Map.of("account_id", "acc-000001")),
+                    TraceUpstreamConditionRewriter.rewriteSiblingFiltersFromRecords(
+                            List.of(txn),
+                            TXN_JOIN_KEYS,
+                            TXN_PK,
+                            ACCOUNT_JOIN_KEYS,
+                            ACCOUNT_PK,
+                            ACCOUNT_FIELDS
+                    )
+            );
+        }
+
+        @Test
+        void customerRecords_shouldRebuildAccountFilterByCustomerId() {
+            assertEquals(
+                    List.of(Map.of("customer_id", "cust-001775")),
+                    TraceUpstreamConditionRewriter.rewriteSiblingFiltersFromRecords(
+                            List.of(filter("customer_id", "cust-001775")),
+                            Collections.emptyList(),
+                            CUSTOMER_PK,
+                            ACCOUNT_JOIN_KEYS,
+                            ACCOUNT_PK,
+                            ACCOUNT_FIELDS
+                    )
+            );
+        }
+
+        @Test
+        void customerRecords_shouldNotRebuildTransactionFilter() {
+            assertTrue(TraceUpstreamConditionRewriter.rewriteSiblingFiltersFromRecords(
+                    List.of(filter("customer_id", "cust-001775")),
+                    Collections.emptyList(),
+                    CUSTOMER_PK,
+                    TXN_JOIN_KEYS,
+                    TXN_PK,
+                    TXN_FIELDS
+            ).isEmpty());
+        }
+
+        @Test
+        void transactionRecords_shouldNotRebuildCustomerFilter() {
+            Map<String, Object> txn = new LinkedHashMap<>();
+            txn.put("account_id", "acc-000001");
+            txn.put("transaction_id", "txn-000211");
+            assertTrue(TraceUpstreamConditionRewriter.rewriteSiblingFiltersFromRecords(
+                    List.of(txn),
+                    TXN_JOIN_KEYS,
+                    TXN_PK,
+                    Collections.emptyList(),
+                    CUSTOMER_PK,
+                    CUSTOMER_FIELDS
+            ).isEmpty());
+        }
+
+        @Test
+        void accountRecords_shouldStillRebuildCustomerFilter() {
+            Map<String, Object> account = new LinkedHashMap<>();
+            account.put("account_id", "acc-000001");
+            account.put("customer_id", "cust-001775");
+            assertEquals(
+                    List.of(Map.of("customer_id", "cust-001775")),
+                    TraceUpstreamConditionRewriter.rewriteSiblingFiltersFromRecords(
+                            List.of(account),
+                            ACCOUNT_JOIN_KEYS,
+                            ACCOUNT_PK,
+                            Collections.emptyList(),
+                            CUSTOMER_PK,
+                            CUSTOMER_FIELDS
+                    )
+            );
+        }
+
+        @Test
+        void duplicateAccountIds_shouldDedupTransactionFilter() {
+            Map<String, Object> a1 = filter("account_id", "acc-000001");
+            a1.put("customer_id", "cust-001775");
+            Map<String, Object> a2 = filter("account_id", "acc-000001");
+            a2.put("customer_id", "cust-001775");
+            List<Map<String, Object>> result = TraceUpstreamConditionRewriter.rewriteSiblingFiltersFromRecords(
+                    List.of(a1, a2),
+                    ACCOUNT_JOIN_KEYS,
+                    ACCOUNT_PK,
+                    TXN_JOIN_KEYS,
+                    TXN_PK,
+                    TXN_FIELDS
+            );
+            assertEquals(1, result.size());
+            assertEquals("acc-000001", result.get(0).get("account_id"));
+        }
+    }
+
+    @Nested
+    @DisplayName("OMS DT: renamed join key customer_no -> cust_no")
+    class OmsRenamedJoinKey {
+
+        private static final Map<String, String> OMS_CUSTOMER_FIELDS = Map.of(
+                "cust_no", "cust_no",
+                "member_level", "member_level",
+                "full_name", "full_name"
+        );
+        private static final Map<String, String> OMS_ORDER_FIELDS = Map.of(
+                "order_no", "order_no",
+                "customer_no", "customer_no",
+                "pay_amount", "pay_amount"
+        );
+
+        @Test
+        void orderRecords_shouldRebuildCustomerFilterByRenamedJoinKey() {
+            Map<String, Object> order = new LinkedHashMap<>();
+            order.put("order_no", "oms-o-0140");
+            order.put("customer_no", "oms-c-0060");
+            assertEquals(
+                    List.of(Map.of("cust_no", "oms-c-0060")),
+                    TraceUpstreamConditionRewriter.rewriteSiblingFiltersFromRecords(
+                            List.of(order),
+                            List.of(mapping("customer_no", "cust_no")),
+                            List.of(mapping("order_no", "order_no")),
+                            Collections.emptyList(),
+                            List.of(mapping("cust_no", "cust_no")),
+                            OMS_CUSTOMER_FIELDS
+                    )
+            );
+        }
+
+        @Test
+        void customerRecords_shouldRebuildOrderFilterByRenamedJoinKey() {
+            assertEquals(
+                    List.of(Map.of("customer_no", "oms-c-0060")),
+                    TraceUpstreamConditionRewriter.rewriteSiblingFiltersFromRecords(
+                            List.of(filter("cust_no", "oms-c-0060")),
+                            Collections.emptyList(),
+                            List.of(mapping("cust_no", "cust_no")),
+                            List.of(mapping("customer_no", "cust_no")),
+                            List.of(mapping("order_no", "order_no")),
+                            OMS_ORDER_FIELDS
+                    )
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("FDM 6a90f52f: 1:1 clone pg_fdm.hbl_* -> FDM_pg_hbl_*")
+    class FdmClone {
+
+        @Test
+        void account_shouldKeepAccountIdOnSameField() {
+            assertEquals(
+                    List.of(Map.of("account_id", "acc-000001")),
+                    TraceUpstreamConditionRewriter.rewriteNormalUpstreamFilters(
+                            List.of(filter("account_id", "acc-000001")),
+                            ACCOUNT_FIELDS,
+                            ACCOUNT_FIELDS
+                    )
+            );
+        }
+
+        @Test
+        void customer_shouldKeepCustomerIdOnSameField() {
+            assertEquals(
+                    List.of(Map.of("customer_id", "cust-001775")),
+                    TraceUpstreamConditionRewriter.rewriteNormalUpstreamFilters(
+                            List.of(filter("customer_id", "cust-001775")),
+                            CUSTOMER_FIELDS,
+                            CUSTOMER_FIELDS
+                    )
+            );
+        }
+
+        @Test
+        void transaction_shouldKeepAccountIdJoinFromParent() {
+            assertEquals(
+                    List.of(Map.of("account_id", "acc-000001")),
+                    TraceUpstreamConditionRewriter.rewriteNormalUpstreamFilters(
+                            List.of(filter("account_id", "acc-000001")),
+                            TXN_FIELDS,
+                            TXN_FIELDS
+                    )
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("Guard / empty inputs")
+    class Guards {
+
+        @Test
+        void emptyFilters_shouldReturnEmpty() {
+            assertTrue(TraceUpstreamConditionRewriter.rewriteMergeSubTableFilters(
+                    Collections.emptyList(), "ACCOUNT", Collections.emptyList(), Collections.emptyList(), ACCOUNT_FIELDS
+            ).isEmpty());
+            assertTrue(TraceUpstreamConditionRewriter.rewriteNormalUpstreamFilters(
+                    Collections.emptyList(), WIDE_TABLE_FIELDS, CUSTOMER_FIELDS
+            ).isEmpty());
+            assertTrue(TraceUpstreamConditionRewriter.rewriteMainTableFiltersFromSubTableRecords(
+                    Collections.emptyList(), List.of(mapping("customer_id", "customer_id")), CUSTOMER_FIELDS
+            ).isEmpty());
+            assertTrue(TraceUpstreamConditionRewriter.rewriteSiblingFiltersFromRecords(
+                    Collections.emptyList(),
+                    List.of(mapping("customer_id", "customer_id")),
+                    List.of(mapping("account_id", "account_id")),
+                    List.of(mapping("account_id", "ACCOUNT.account_id")),
+                    List.of(mapping("transaction_id", "transaction_id")),
+                    TXN_FIELDS
+            ).isEmpty());
+        }
+
+        @Test
+        void stripNestedPath_shouldCoverEdges() {
+            assertEquals("account_id", TraceUpstreamConditionRewriter.stripNestedPath("ACCOUNT.account_id", "ACCOUNT"));
+            assertEquals("TRANSACTION.transaction_id",
+                    TraceUpstreamConditionRewriter.stripNestedPath("ACCOUNT.TRANSACTION.transaction_id", "ACCOUNT"));
+            assertNull(TraceUpstreamConditionRewriter.stripNestedPath("ACCOUNT", "ACCOUNT"));
+            assertNull(TraceUpstreamConditionRewriter.stripNestedPath("customer_id", "ACCOUNT"));
+            assertNull(TraceUpstreamConditionRewriter.stripNestedPath("ACCOUNT.account_id", null));
+        }
+    }
+
+    private static Map<String, Object> filter(String key, Object value) {
+        Map<String, Object> filter = new LinkedHashMap<>();
+        filter.put(key, value);
+        return filter;
+    }
+
+    private static FieldNameMapping mapping(String originName, String targetName) {
+        FieldNameMapping mapping = new FieldNameMapping();
+        mapping.setOriginName(originName);
+        mapping.setTargetName(targetName);
+        return mapping;
+    }
+}


### PR DESCRIPTION
…ference on wide table misses

- Fix `Trace.Filter.NotBuilt` errors when wide-table records are missed due to upstream row filtering or conditions.
- Support bidirectional condition rewriting for renamed join keys across nested sub-tables and parent entities.
- Enhance nested path resolution (e.g. `A.B.c`) for multi-tier array and 1:1 embedded updateWrite documents.
- Implement sibling inference to automatically backfill sibling and downstream sub-tables from retrieved records.