### PR TITLE
fix(TAP-12578): hide leftover workers after cluster node delete

### DIFF
--- a/manager/tm/src/main/java/com/tapdata/tm/cluster/service/ClusterStateService.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/cluster/service/ClusterStateService.java
@@ -424,11 +424,16 @@ public class ClusterStateService extends BaseService<ClusterStateDto, ClusterSta
                 status = "stopped";
             }
 
+            ClusterStateDto clusterStateDto = processIdClusterStateMap.get(worker.getProcessId());
+            // Cluster management delete only removes ClusterState; leftover Workers
+            // would otherwise still appear as unavailable preferred nodes.
+            if (clusterStateDto == null) {
+                return;
+            }
             AccessNodeInfo accessNodeInfo = new AccessNodeInfo(worker.getProcessId(), hostname.get(), worker.getProcessId(), status);
             accessNodeInfo.setAccessNodeName(worker.getProcessId());
             accessNodeInfo.setAccessNodeType(AccessNodeTypeEnum.MANUALLY_SPECIFIED_BY_THE_USER.name());
-            ClusterStateDto clusterStateDto = processIdClusterStateMap.get(worker.getProcessId());
-            if (null != clusterStateDto && null != clusterStateDto.getAgentName()) {
+            if (null != clusterStateDto.getAgentName()) {
                 accessNodeInfo.setAgentName(clusterStateDto.getAgentName());
             }
             result.add(accessNodeInfo);
@@ -528,6 +533,13 @@ public class ClusterStateService extends BaseService<ClusterStateDto, ClusterSta
             }
         }
         if (unBind) {
+            if (null != clusterStateDto && null != clusterStateDto.getSystemInfo()
+                    && StringUtils.isNotBlank(clusterStateDto.getSystemInfo().getProcess_id())) {
+                String pid = clusterStateDto.getSystemInfo().getProcess_id();
+                workerService.updateAll(
+                        Query.query(Criteria.where("process_id").is(pid)),
+                        Update.update("isDeleted", true).set("ping_time", 0L));
+            }
             return deleteById(id);
         }
         return false;

--- a/manager/tm/src/test/java/com/tapdata/tm/cluster/service/ClusterStateServiceTest.java
+++ b/manager/tm/src/test/java/com/tapdata/tm/cluster/service/ClusterStateServiceTest.java
@@ -26,7 +26,9 @@ import org.mockito.MockedStatic;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.mockito.ArgumentCaptor;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -192,6 +194,18 @@ class ClusterStateServiceTest {
                     1, 2, 5,
                     1);
         }
+
+        @Test
+        void testSkipOrphanWorkerWithoutClusterState() {
+            when(clusterStateService.findAll(any(Query.class))).thenReturn(new ArrayList<>());
+            ArgumentCaptor<List> captor = ArgumentCaptor.forClass(List.class);
+            when(agentGroupService.filterGroupList(captor.capture(), any(UserDetail.class))).thenReturn(new ArrayList<>());
+            try (MockedStatic<SettingUtil> su = mockStatic(SettingUtil.class)) {
+                su.when(() -> SettingUtil.getValue(CategoryEnum.WORKER.getValue(), KeyEnum.WORKER_HEART_TIMEOUT.getValue())).thenReturn("30");
+                clusterStateService.findAccessNodeInfo(userDetail);
+            }
+            Assertions.assertTrue(captor.getValue().isEmpty());
+        }
     }
     @Nested
     class deleteClusterTest{
@@ -224,6 +238,7 @@ class ClusterStateServiceTest {
             when(workerService.unbindByProcessId("123")).thenReturn(true);
             result = clusterStateService.deleteCluster(id, user);
             assertTrue(result);
+            verify(workerService).updateAll(any(Query.class), any(Update.class));
         }
 
         @Test


### PR DESCRIPTION
Cluster UI only deleted ClusterState; preferred-node list still read Workers. Soft-delete Workers on cluster delete and skip workers with no ClusterState in findAccessNodeInfo.