### PR TITLE
fix(TAP-12745): inspect MongoDB collections on sync TableNode

### DIFF
--- a/manager/tm/src/main/java/com/tapdata/tm/metadatainstance/service/MetadataInstancesServiceImpl.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/metadatainstance/service/MetadataInstancesServiceImpl.java
@@ -1604,10 +1604,6 @@ public class MetadataInstancesServiceImpl extends MetadataInstancesService {
                     }
                 }
             }
-            String tableName = ((TableNode) node).getTableName();
-            if (StringUtils.isNotBlank(tableName) && !kv.containsKey(tableName)) {
-                kv.put(tableName, getQualifiedNameByNodeId(node, user, null, null, taskDto.getId().toHexString()));
-            }
         } else {
 			boolean need2Parse = true;
 			if (node instanceof LogCollectorNode) {

--- a/manager/tm/src/main/java/com/tapdata/tm/metadatainstance/service/MetadataInstancesServiceImpl.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/metadatainstance/service/MetadataInstancesServiceImpl.java
@@ -1594,7 +1594,20 @@ public class MetadataInstancesServiceImpl extends MetadataInstancesService {
                 }
             }
         } else if (node instanceof TableNode) {
-            kv.put(((TableNode) node).getTableName(), getQualifiedNameByNodeId(node, user, null, null, taskDto.getId().toHexString()));
+            // TAP-12745: align with migrate DatabaseNode -- inspect looks up originalName.
+            List<MetadataInstancesDto> tableMetadatas = findByNodeId(node.getId(), Lists.of(ORIGINAL_NAME, QUALIFIED_NAME), user, taskDto);
+            if (CollectionUtils.isNotEmpty(tableMetadatas)) {
+                for (MetadataInstancesDto metadata : tableMetadatas) {
+                    if (metadata != null && StringUtils.isNotBlank(metadata.getOriginalName())
+                            && StringUtils.isNotBlank(metadata.getQualifiedName())) {
+                        kv.put(metadata.getOriginalName(), metadata.getQualifiedName());
+                    }
+                }
+            }
+            String tableName = ((TableNode) node).getTableName();
+            if (StringUtils.isNotBlank(tableName) && !kv.containsKey(tableName)) {
+                kv.put(tableName, getQualifiedNameByNodeId(node, user, null, null, taskDto.getId().toHexString()));
+            }
         } else {
 			boolean need2Parse = true;
 			if (node instanceof LogCollectorNode) {

--- a/manager/tm/src/test/java/com/tapdata/tm/metadatainstance/service/MetadataInstancesServiceImplTest.java
+++ b/manager/tm/src/test/java/com/tapdata/tm/metadatainstance/service/MetadataInstancesServiceImplTest.java
@@ -2126,6 +2126,51 @@ public class MetadataInstancesServiceImplTest {
 			doReturn(metadatas).when(metadataInstancesService).findByNodeId(anyString(), anyList(), any(UserDetail.class), any(TaskDto.class));
 			assertThrows(RuntimeException.class, () -> metadataInstancesService.getNodeMapping(userDetail, taskDto, kv, node));
 		}
+
+		@Test
+		@DisplayName("TAP-12745 TableNode inspect table uses stored originalName/qualifiedName like migrate")
+		void tableNodeMapsOriginalNameToStoredQualifiedName() {
+			kv = new HashMap<>();
+			TableNode tableNode = new TableNode();
+			tableNode.setId("mongo-target");
+			tableNode.setTableName("i83_12741_finspect");
+			tableNode.setConnectionId(new ObjectId().toHexString());
+			node = tableNode;
+			taskDto = new TaskDto();
+			taskDto.setId(new ObjectId());
+			MetadataInstancesDto meta = new MetadataInstancesDto();
+			meta.setOriginalName("i83_12741_finspect");
+			meta.setQualifiedName("MC_mongodb_official_v1_i83_12741_finspect_conn_task");
+			doReturn(List.of(meta)).when(metadataInstancesService).findByNodeId(eq("mongo-target"), anyList(), any(UserDetail.class), any(TaskDto.class));
+
+			Map<String, String> actual = metadataInstancesService.getNodeMapping(userDetail, taskDto, kv, node);
+
+			assertEquals("MC_mongodb_official_v1_i83_12741_finspect_conn_task", actual.get("i83_12741_finspect"));
+			verify(metadataInstancesService, never()).getQualifiedNameByNodeId(any(), any(), any(), any(), any());
+		}
+
+		@Test
+		@DisplayName("TAP-12745 TableNode keeps node tableName key when it differs from originalName")
+		void tableNodeKeepsTableNameKeyWhenDifferentFromOriginalName() {
+			kv = new HashMap<>();
+			TableNode tableNode = new TableNode();
+			tableNode.setId("mongo-target");
+			tableNode.setTableName("node_table");
+			tableNode.setConnectionId(new ObjectId().toHexString());
+			node = tableNode;
+			taskDto = new TaskDto();
+			taskDto.setId(new ObjectId());
+			MetadataInstancesDto meta = new MetadataInstancesDto();
+			meta.setOriginalName("i83_12741_finspect");
+			meta.setQualifiedName("MC_stored_collection");
+			doReturn(List.of(meta)).when(metadataInstancesService).findByNodeId(eq("mongo-target"), anyList(), any(UserDetail.class), any(TaskDto.class));
+			doReturn("T_recomputed").when(metadataInstancesService).getQualifiedNameByNodeId(any(), any(), any(), any(), any());
+
+			Map<String, String> actual = metadataInstancesService.getNodeMapping(userDetail, taskDto, kv, node);
+
+			assertEquals("MC_stored_collection", actual.get("i83_12741_finspect"));
+			assertEquals("T_recomputed", actual.get("node_table"));
+		}
 	}
 
 	@Nested

--- a/manager/tm/src/test/java/com/tapdata/tm/metadatainstance/service/MetadataInstancesServiceImplTest.java
+++ b/manager/tm/src/test/java/com/tapdata/tm/metadatainstance/service/MetadataInstancesServiceImplTest.java
@@ -2150,8 +2150,8 @@ public class MetadataInstancesServiceImplTest {
 		}
 
 		@Test
-		@DisplayName("TAP-12745 TableNode keeps node tableName key when it differs from originalName")
-		void tableNodeKeepsTableNameKeyWhenDifferentFromOriginalName() {
+		@DisplayName("TAP-12745 TableNode does not recompute QN when tableName differs from originalName")
+		void tableNodeDoesNotRecomputeQualifiedNameWhenTableNameDiffers() {
 			kv = new HashMap<>();
 			TableNode tableNode = new TableNode();
 			tableNode.setId("mongo-target");
@@ -2162,14 +2162,32 @@ public class MetadataInstancesServiceImplTest {
 			taskDto.setId(new ObjectId());
 			MetadataInstancesDto meta = new MetadataInstancesDto();
 			meta.setOriginalName("i83_12741_finspect");
-			meta.setQualifiedName("MC_stored_collection");
+			meta.setQualifiedName("T_stored_collection");
 			doReturn(List.of(meta)).when(metadataInstancesService).findByNodeId(eq("mongo-target"), anyList(), any(UserDetail.class), any(TaskDto.class));
-			doReturn("T_recomputed").when(metadataInstancesService).getQualifiedNameByNodeId(any(), any(), any(), any(), any());
 
 			Map<String, String> actual = metadataInstancesService.getNodeMapping(userDetail, taskDto, kv, node);
 
-			assertEquals("MC_stored_collection", actual.get("i83_12741_finspect"));
-			assertEquals("T_recomputed", actual.get("node_table"));
+			assertEquals("T_stored_collection", actual.get("i83_12741_finspect"));
+			assertNull(actual.get("node_table"));
+			verify(metadataInstancesService, never()).getQualifiedNameByNodeId(any(), any(), any(), any(), any());
+		}
+
+		@Test
+		@DisplayName("TAP-12745 TableNode empty metadata does not invent recomputed QN")
+		void tableNodeEmptyMetadataDoesNotRecomputeQualifiedName() {
+			kv = new HashMap<>();
+			TableNode tableNode = new TableNode();
+			tableNode.setId("mongo-target");
+			tableNode.setTableName("i83_12741_finspect");
+			node = tableNode;
+			taskDto = new TaskDto();
+			taskDto.setId(new ObjectId());
+			doReturn(List.of()).when(metadataInstancesService).findByNodeId(eq("mongo-target"), anyList(), any(UserDetail.class), any(TaskDto.class));
+
+			Map<String, String> actual = metadataInstancesService.getNodeMapping(userDetail, taskDto, kv, node);
+
+			assertTrue(actual.isEmpty());
+			verify(metadataInstancesService, never()).getQualifiedNameByNodeId(any(), any(), any(), any(), any());
 		}
 	}
 


### PR DESCRIPTION
## Summary
- TAP-12745: data-dev tasks (`syncType=sync`) with MongoDB as target fail field inspect with `Table not exists`.
- Root cause: `TableNode.getNodeMapping` recomputed qualifiedName (`T_` vs Mongo `MC_`); inspect hit the wrong metadata. `PdkResult` also invented an empty `TapTable` and opened a missing collection.
- Fix (TM): `MetadataInstancesServiceImpl.getNodeMapping` for TableNode uses stored `originalName → qualifiedName` only; no `getQualifiedNameByNodeId` fallback.
- Companion EE change is on tapdata-enterprise same branch (`7ef79633`).

## Test plan
- [x] `MetadataInstancesServiceImplTest$GetNodeMappingTest` 4 passed
- [x] Taptest `83.12815` / TAP-12815 PASS (session `20260903_045958`): Inspect `done`/`passed`, source_total=100, target_total=100, difference_number=0