### PR TITLE
fix(TAP-12823): keep masked Mongo uri on overwrite import [release-v4.22.0]

### DIFF
--- a/manager/tm/src/main/java/com/tapdata/tm/ds/service/impl/DataSourceServiceImpl.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/ds/service/impl/DataSourceServiceImpl.java
@@ -48,6 +48,7 @@ import com.tapdata.tm.ds.vo.SupportListVo;
 import com.tapdata.tm.ds.vo.ValidateTableVo;
 import com.tapdata.tm.externalStorage.service.ExternalStorageService;
 import com.tapdata.tm.file.service.FileService;
+import com.tapdata.tm.group.handler.ResourceHandler;
 import com.tapdata.tm.job.dto.JobDto;
 import com.tapdata.tm.job.service.JobService;
 import com.tapdata.tm.libSupported.entity.LibSupportedsEntity;
@@ -1208,14 +1209,15 @@ public class DataSourceServiceImpl extends DataSourceService{
         //schema 不能入库，应该是通过update接口存在metadataInstance里面
         connection.setSchema(null);
 
-        //mongo的特殊处理
+        //mongo的特殊处理。导出脱敏会把 host/uri 抹成空串，此时拼出来是 mongodb:///db，
+        //ConnectionString 解析失败会变成「无效参数: {0}」。host 为空说明 URI 在 config 里，不要发明非法串。
         if ((DataSourceEnum.isMongoDB(connection.getDatabase_type()) || DataSourceEnum.isGridFs(connection.getDatabase_type()))
                 && StringUtils.isBlank(connection.getDatabase_uri())) {
-            log.debug("set the uri of the mongo type data source");
-
-            connection.setDatabase_uri(UriRootConvertUtils.constructUri(connection));
-            parserMongo(connection);
-
+            if (StringUtils.isNotBlank(connection.getDatabase_host())) {
+                log.debug("set the uri of the mongo type data source");
+                connection.setDatabase_uri(UriRootConvertUtils.constructUri(connection));
+                parserMongo(connection);
+            }
         } else if (StringUtils.isNotBlank(connection.getDatabase_uri())) {
             parserMongo(connection);
         }
@@ -2046,6 +2048,7 @@ public class DataSourceServiceImpl extends DataSourceService{
                         // 替换模式：保留现有ID，使用导入数据覆盖
                         ObjectId existingId = existingConnectionByName.getId();
                         connectionDto.setId(existingId);
+                        restoreMaskedSecretsForOverwrite(connectionDto, user);
 
                         if (StringUtils.isNotBlank(connectionDto.getShareCDCExternalStorageId())) {
                             ExternalStorageDto externalStorageDto = externalStorageService.findById(MongoUtils.toObjectId(connectionDto.getShareCDCExternalStorageId()));
@@ -2158,6 +2161,7 @@ public class DataSourceServiceImpl extends DataSourceService{
 
         if (existingById != null) {
             // 已存在相同 _id，覆盖更新（保留原始 userId）
+            restoreMaskedSecretsForOverwrite(connectionDto, user);
             log.info("[handleGroupImportConnection] existing found for id={}, calling importSave, connectionDto.userId={}", connectionDto.getId(), connectionDto.getUserId());
             DataSourceConnectionDto result = importSave(connectionDto, user);
             log.info("[handleGroupImportConnection] importSave returned, result.userId={}", result.getUserId());
@@ -2493,6 +2497,29 @@ public class DataSourceServiceImpl extends DataSourceService{
         DataSourceEntity entity = convertToEntity(DataSourceEntity.class, dto);
         entity = repository.importSave(entity, userDetail);
         return convertToDto(entity, DataSourceConnectionDto.class);
+    }
+
+    /**
+     * 覆盖导入时包内敏感字段已被导出脱敏抹空，不能整文档覆盖成空。
+     * 缺值则沿用目标环境已有连接的凭据（与分组导入 {@link ResourceHandler#restoreMissingSecretsFromExisting} 同一套规则）。
+     */
+    protected void restoreMaskedSecretsForOverwrite(DataSourceConnectionDto incoming, UserDetail user) {
+        if (incoming == null || incoming.getId() == null) {
+            return;
+        }
+        DataSourceConnectionDto existing = findById(incoming.getId(), user);
+        if (existing == null) {
+            return;
+        }
+        DataSourceDefinitionDto definition = null;
+        if (StringUtils.isNotBlank(incoming.getPdkHash()) && dataSourceDefinitionService != null) {
+            definition = dataSourceDefinitionService.findByPdkHash(incoming.getPdkHash(), Integer.MAX_VALUE, user);
+        }
+        List<String> preserved = ResourceHandler.restoreMissingSecretsFromExisting(incoming, existing, definition);
+        if (CollectionUtils.isNotEmpty(preserved)) {
+            log.warn("Import overwrite: package omits secret field(s) for connection '{}', kept existing value(s): {}",
+                    incoming.getName(), preserved);
+        }
     }
 
     public List<TaskDto> findUsingDigginTaskByConnectionId(String connectionId, UserDetail user) {

--- a/manager/tm/src/test/java/com/tapdata/tm/ds/service/impl/DataSourceServiceImplTest.java
+++ b/manager/tm/src/test/java/com/tapdata/tm/ds/service/impl/DataSourceServiceImplTest.java
@@ -967,6 +967,8 @@ class DataSourceServiceImplTest {
 
             ReflectionTestUtils.setField(dataSourceService, "agentGroupService", agentGroupService);
             ReflectionTestUtils.setField(dataSourceService, "externalStorageService", externalStorageService);
+            // overwrite import may load the existing connection to restore masked secrets
+            doReturn(null).when(dataSourceService).findById(any(ObjectId.class), eq(user));
         }
 
         @Test
@@ -1103,6 +1105,131 @@ class DataSourceServiceImplTest {
             assertEquals(1, result.size());
             verify(dataSourceService, times(1)).handleImportAsCopyConnection(connectionDto, user);
         }
+
+        @Test
+        @DisplayName("REPLACE existing Mongo connection restores masked uri from target before importSave")
+        void replaceExistingMongo_restoresMaskedUriFromExisting() {
+            ObjectId existingId = existingConnection.getId();
+            connectionDto.setDatabase_type("mongodb");
+            connectionDto.setPdkHash("mongo-pdk-hash");
+            connectionDto.setDatabase_uri("");
+            connectionDto.setDatabase_host("");
+            connectionDto.setDatabase_username("");
+            connectionDto.setDatabase_password("");
+            Map<String, Object> incomingConfig = new LinkedHashMap<>();
+            incomingConfig.put("isUri", true);
+            incomingConfig.put("uri", "");
+            connectionDto.setConfig(incomingConfig);
+
+            DataSourceConnectionDto existingFull = new DataSourceConnectionDto();
+            existingFull.setId(existingId);
+            existingFull.setName("test_connection");
+            existingFull.setDatabase_uri("mongodb://real-host:27017/dmp");
+            existingFull.setDatabase_host("real-host:27017");
+            existingFull.setDatabase_password("s3cr3t");
+            Map<String, Object> existingConfig = new LinkedHashMap<>();
+            existingConfig.put("isUri", true);
+            existingConfig.put("uri", "mongodb://real-host:27017/dmp");
+            existingFull.setConfig(existingConfig);
+
+            DataSourceDefinitionDto definition = mongoDefinitionWithUri();
+            DataSourceDefinitionService definitionService = mock(DataSourceDefinitionService.class);
+            ReflectionTestUtils.setField(dataSourceService, "dataSourceDefinitionService", definitionService);
+            when(definitionService.findByPdkHash(eq("mongo-pdk-hash"), eq(Integer.MAX_VALUE), eq(user)))
+                    .thenReturn(definition);
+
+            doReturn(existingConnection).when(dataSourceService).findOne(any(Query.class), eq(user));
+            doReturn(existingFull).when(dataSourceService).findById(eq(existingId), eq(user));
+            doReturn(connectionDto).when(dataSourceService).importSave(connectionDto, user);
+            doNothing().when(agentGroupService).importAgentInfo(connectionDto);
+
+            dataSourceService.batchImport(connectionDtos, user, ImportModeEnum.REPLACE);
+
+            assertEquals("mongodb://real-host:27017/dmp", connectionDto.getDatabase_uri());
+            assertEquals("real-host:27017", connectionDto.getDatabase_host());
+            assertEquals("s3cr3t", connectionDto.getDatabase_password());
+            assertEquals("mongodb://real-host:27017/dmp", connectionDto.getConfig().get("uri"));
+            verify(dataSourceService, times(1)).importSave(connectionDto, user);
+        }
+    }
+
+    @Nested
+    @DisplayName("beforeSave Mongo import (TAP-12823)")
+    class BeforeSaveMongoImportTest {
+        private DataSourceDefinitionService definitionService;
+        private UserDetail user;
+
+        @BeforeEach
+        void setUp() {
+            dataSourceService = spy(new DataSourceServiceImpl(mock(DataSourceRepository.class)));
+            user = mock(UserDetail.class);
+            definitionService = mock(DataSourceDefinitionService.class);
+            ReflectionTestUtils.setField(dataSourceService, "dataSourceDefinitionService", definitionService);
+            doNothing().when(dataSourceService).checkConn(any(), any());
+        }
+
+        @Test
+        @DisplayName("masked Mongo connection with blank host/uri does not throw IllegalArgument")
+        void maskedMongoBlankHost_doesNotThrowIllegalArgument() {
+            DataSourceConnectionDto connection = maskedMongoConnection();
+            DataSourceDefinitionDto definition = mongoDefinitionWithUri();
+            when(definitionService.findByPdkHash(any(), anyInt(), eq(user))).thenReturn(definition);
+
+            assertDoesNotThrow(() -> dataSourceService.beforeSave(connection, user, true));
+        }
+
+        @Test
+        @DisplayName("Mongo with host still constructs uri and parses it")
+        void mongoWithHost_stillConstructsAndParsesUri() {
+            DataSourceConnectionDto connection = maskedMongoConnection();
+            connection.setDatabase_host("127.0.0.1:27017");
+            connection.setDatabase_username("tap");
+            connection.setPlain_password("tap");
+            connection.setDatabase_name("dmp");
+            DataSourceDefinitionDto definition = mongoDefinitionWithUri();
+            when(definitionService.findByPdkHash(any(), anyInt(), eq(user))).thenReturn(definition);
+
+            assertDoesNotThrow(() -> dataSourceService.beforeSave(connection, user, true));
+            assertNotNull(connection.getDatabase_uri());
+            assertFalse(connection.getDatabase_uri().isBlank());
+            assertTrue(connection.getDatabase_uri().startsWith("mongodb://"));
+            assertTrue(connection.getDatabase_uri().contains("127.0.0.1:27017"));
+        }
+    }
+
+    private static DataSourceConnectionDto maskedMongoConnection() {
+        DataSourceConnectionDto connection = new DataSourceConnectionDto();
+        connection.setName("mongo_conn");
+        connection.setDatabase_type("mongodb");
+        connection.setPdkHash("mongo-pdk-hash");
+        connection.setDatabase_uri("");
+        connection.setDatabase_host("");
+        connection.setDatabase_username("");
+        connection.setDatabase_password("");
+        connection.setDatabase_name("dmp");
+        Map<String, Object> config = new LinkedHashMap<>();
+        config.put("isUri", true);
+        config.put("uri", "");
+        connection.setConfig(config);
+        return connection;
+    }
+
+    private static DataSourceDefinitionDto mongoDefinitionWithUri() {
+        Map<String, Object> uriMeta = new LinkedHashMap<>();
+        uriMeta.put("apiServerKey", "database_uri");
+        Map<String, Object> connProps = new LinkedHashMap<>();
+        connProps.put("uri", uriMeta);
+        Map<String, Object> connection = new LinkedHashMap<>();
+        connection.put("properties", connProps);
+        LinkedHashMap<String, Object> properties = new LinkedHashMap<>();
+        properties.put("connection", connection);
+        DataSourceDefinitionDto definition = new DataSourceDefinitionDto();
+        definition.setBuildNumber(1);
+        definition.setVersion("1.0");
+        definition.setGroup("mongodb");
+        definition.setPdkId("mongodb");
+        definition.setProperties(properties);
+        return definition;
     }
 
     @Nested


### PR DESCRIPTION
Backport of cd367f24a68bddf1e1f4e3ce9d9c25fa501e7fd0 onto release-v4.22.0 for TAP-12823.