### PR TITLE
fix(TAP-12745): drop TableNode QN recompute fallback [release-v4.21.0]

### DIFF
--- a/manager/tm/src/main/java/com/tapdata/tm/metadatainstance/service/MetadataInstancesServiceImpl.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/metadatainstance/service/MetadataInstancesServiceImpl.java
@@ -1583,9 +1583,19 @@ public class MetadataInstancesServiceImpl extends MetadataInstancesService {
                     getNodeMapping(user, taskDto, kv, predecessor);
                 }
             }
-        } else if (node instanceof TableNode) {
-            kv.put(((TableNode) node).getTableName(), getQualifiedNameByNodeId(node, user, null, null, taskDto.getId().toHexString()));
+                } else if (node instanceof TableNode) {
+            // TAP-12745: align with migrate DatabaseNode -- inspect looks up originalName.
+            List<MetadataInstancesDto> tableMetadatas = findByNodeId(node.getId(), Lists.of(ORIGINAL_NAME, QUALIFIED_NAME), user, taskDto);
+            if (CollectionUtils.isNotEmpty(tableMetadatas)) {
+                for (MetadataInstancesDto metadata : tableMetadatas) {
+                    if (metadata != null && StringUtils.isNotBlank(metadata.getOriginalName())
+                            && StringUtils.isNotBlank(metadata.getQualifiedName())) {
+                        kv.put(metadata.getOriginalName(), metadata.getQualifiedName());
+                    }
+                }
+            }
         } else {
+
 			boolean need2Parse = true;
 			if (node instanceof LogCollectorNode) {
 				LogCollectorNode logCollectorNode = (LogCollectorNode) node;

--- a/manager/tm/src/test/java/com/tapdata/tm/metadatainstance/service/MetadataInstancesServiceImplTest.java
+++ b/manager/tm/src/test/java/com/tapdata/tm/metadatainstance/service/MetadataInstancesServiceImplTest.java
@@ -2126,6 +2126,69 @@ public class MetadataInstancesServiceImplTest {
 			doReturn(metadatas).when(metadataInstancesService).findByNodeId(anyString(), anyList(), any(UserDetail.class), any(TaskDto.class));
 			assertThrows(RuntimeException.class, () -> metadataInstancesService.getNodeMapping(userDetail, taskDto, kv, node));
 		}
+
+		@Test
+		@DisplayName("TAP-12745 TableNode inspect table uses stored originalName/qualifiedName like migrate")
+		void tableNodeMapsOriginalNameToStoredQualifiedName() {
+			kv = new HashMap<>();
+			TableNode tableNode = new TableNode();
+			tableNode.setId("mongo-target");
+			tableNode.setTableName("i83_12741_finspect");
+			tableNode.setConnectionId(new ObjectId().toHexString());
+			node = tableNode;
+			taskDto = new TaskDto();
+			taskDto.setId(new ObjectId());
+			MetadataInstancesDto meta = new MetadataInstancesDto();
+			meta.setOriginalName("i83_12741_finspect");
+			meta.setQualifiedName("MC_mongodb_official_v1_i83_12741_finspect_conn_task");
+			doReturn(List.of(meta)).when(metadataInstancesService).findByNodeId(eq("mongo-target"), anyList(), any(UserDetail.class), any(TaskDto.class));
+
+			Map<String, String> actual = metadataInstancesService.getNodeMapping(userDetail, taskDto, kv, node);
+
+			assertEquals("MC_mongodb_official_v1_i83_12741_finspect_conn_task", actual.get("i83_12741_finspect"));
+			verify(metadataInstancesService, never()).getQualifiedNameByNodeId(any(), any(), any(), any(), any());
+		}
+
+		@Test
+		@DisplayName("TAP-12745 TableNode does not recompute QN when tableName differs from originalName")
+		void tableNodeDoesNotRecomputeQualifiedNameWhenTableNameDiffers() {
+			kv = new HashMap<>();
+			TableNode tableNode = new TableNode();
+			tableNode.setId("mongo-target");
+			tableNode.setTableName("node_table");
+			tableNode.setConnectionId(new ObjectId().toHexString());
+			node = tableNode;
+			taskDto = new TaskDto();
+			taskDto.setId(new ObjectId());
+			MetadataInstancesDto meta = new MetadataInstancesDto();
+			meta.setOriginalName("i83_12741_finspect");
+			meta.setQualifiedName("T_stored_collection");
+			doReturn(List.of(meta)).when(metadataInstancesService).findByNodeId(eq("mongo-target"), anyList(), any(UserDetail.class), any(TaskDto.class));
+
+			Map<String, String> actual = metadataInstancesService.getNodeMapping(userDetail, taskDto, kv, node);
+
+			assertEquals("T_stored_collection", actual.get("i83_12741_finspect"));
+			assertNull(actual.get("node_table"));
+			verify(metadataInstancesService, never()).getQualifiedNameByNodeId(any(), any(), any(), any(), any());
+		}
+
+		@Test
+		@DisplayName("TAP-12745 TableNode empty metadata does not invent recomputed QN")
+		void tableNodeEmptyMetadataDoesNotRecomputeQualifiedName() {
+			kv = new HashMap<>();
+			TableNode tableNode = new TableNode();
+			tableNode.setId("mongo-target");
+			tableNode.setTableName("i83_12741_finspect");
+			node = tableNode;
+			taskDto = new TaskDto();
+			taskDto.setId(new ObjectId());
+			doReturn(List.of()).when(metadataInstancesService).findByNodeId(eq("mongo-target"), anyList(), any(UserDetail.class), any(TaskDto.class));
+
+			Map<String, String> actual = metadataInstancesService.getNodeMapping(userDetail, taskDto, kv, node);
+
+			assertTrue(actual.isEmpty());
+			verify(metadataInstancesService, never()).getQualifiedNameByNodeId(any(), any(), any(), any(), any());
+		}
 	}
 
 	@Nested


### PR DESCRIPTION
Backport of d45230c8b4b181bfba241ed6f0193bae31d587ef onto release-v4.21.0 for TAP-12745. Conflict resolved by applying develop TableNode originalName to qualifiedName mapping.