### PR TITLE
fix(TAP-12572): stop duplicate table rows when searching field-edit tables

### DIFF
--- a/manager/tm/src/main/java/com/tapdata/tm/task/service/impl/TaskNodeServiceImpl.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/task/service/impl/TaskNodeServiceImpl.java
@@ -174,7 +174,8 @@ public class TaskNodeServiceImpl implements TaskNodeService {
         });
         List<String> currentTableList = tableNames.stream().map(s -> convertTableNameMap.getOrDefault(s, s)).collect(Collectors.toList());
         if (StringUtils.isNotBlank(searchTableName)) {
-            currentTableList.add(searchTableName);
+            // Do not add searchTableName itself into the list: it always matches the filter and
+            // duplicates an existing table when the keyword equals a real table name (TAP-12572).
             currentTableList = currentTableList.stream().filter(s -> s.toUpperCase().contains(searchTableName.toUpperCase())).collect(Collectors.toList());
         }
         if (MapUtils.isNotEmpty(reverseConvertTableNameMap)) {

--- a/manager/tm/src/main/java/com/tapdata/tm/task/service/impl/TaskNodeServiceImpl.java
+++ b/manager/tm/src/main/java/com/tapdata/tm/task/service/impl/TaskNodeServiceImpl.java
@@ -178,6 +178,10 @@ public class TaskNodeServiceImpl implements TaskNodeService {
             // duplicates an existing table when the keyword equals a real table name (TAP-12572).
             currentTableList = currentTableList.stream().filter(s -> s.toUpperCase().contains(searchTableName.toUpperCase())).collect(Collectors.toList());
         }
+        // Without TableRename, tableNames is not cleared after an empty search filter; partition would NPE/IOOBE.
+        if (CollectionUtils.isEmpty(currentTableList)) {
+            return result;
+        }
         if (MapUtils.isNotEmpty(reverseConvertTableNameMap)) {
             tableNames.clear();
         }

--- a/manager/tm/src/test/java/com/tapdata/tm/task/service/impl/TaskNodeServiceImplTest.java
+++ b/manager/tm/src/test/java/com/tapdata/tm/task/service/impl/TaskNodeServiceImplTest.java
@@ -520,6 +520,25 @@ class TaskNodeServiceImplTest {
         }
 
         @Test
+        void testGetNodeInfoByMigrate_SearchNoMatchReturnsEmptyPage() {
+            // TAP-12572 R1 Important: empty search must not hit ListUtils.partition IOOBE
+            List<String> tableNames = new ArrayList<>(Arrays.asList("orders", "users", "products"));
+            when(taskNodeService.getMigrateTableNames(sourceNode, userDetail)).thenReturn(tableNames);
+            when(dag.getPreNodes("nodeId")).thenReturn(new LinkedList<>());
+
+            Page<MetadataTransformerItemDto> result = new Page<>();
+            Page<MetadataTransformerItemDto> actualResult = Assertions.assertDoesNotThrow(() ->
+                taskNodeService.getNodeInfoByMigrate(
+                    "taskId", "nodeId", "zzz_not_exist",
+                    new PageParameter(1, 10), userDetail, result, dag));
+
+            Assertions.assertSame(result, actualResult);
+            Assertions.assertTrue(actualResult.getItems() == null || actualResult.getItems().isEmpty());
+            verify(taskNodeService, never()).getMetadataTransformerItemDtoPage(
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any());
+        }
+
+        @Test
         void testGetNodeInfoByMigrate_WithJsNode() {
             List<String> tableNames = Arrays.asList("table1");
             when(taskNodeService.getMigrateTableNames(sourceNode, userDetail)).thenReturn(tableNames);

--- a/manager/tm/src/test/java/com/tapdata/tm/task/service/impl/TaskNodeServiceImplTest.java
+++ b/manager/tm/src/test/java/com/tapdata/tm/task/service/impl/TaskNodeServiceImplTest.java
@@ -472,7 +472,7 @@ class TaskNodeServiceImplTest {
 
         @Test
         void testGetNodeInfoByMigrate_WithSearchTableName() {
-            List<String> tableNames = Arrays.asList("user_table", "order_table", "product_table");
+            List<String> tableNames = new ArrayList<>(Arrays.asList("user_table", "order_table", "product_table"));
             when(taskNodeService.getMigrateTableNames(sourceNode, userDetail)).thenReturn(tableNames);
             when(dag.getPreNodes("nodeId")).thenReturn(new LinkedList<>());
 
@@ -486,6 +486,37 @@ class TaskNodeServiceImplTest {
                 new PageParameter(1, 10), userDetail, result, dag);
 
             Assertions.assertNotNull(actualResult);
+            org.mockito.ArgumentCaptor<List> currentTableCaptor = org.mockito.ArgumentCaptor.forClass(List.class);
+            verify(taskNodeService).getMetadataTransformerItemDtoPage(
+                any(), any(), any(), any(), any(), currentTableCaptor.capture(), any(), any(), any(), any(), any(), any());
+            List<?> currentTables = currentTableCaptor.getValue();
+            Assertions.assertEquals(1, currentTables.size());
+            Assertions.assertEquals("user_table", currentTables.get(0));
+            Assertions.assertEquals(1, currentTables.stream().distinct().count());
+        }
+
+        @Test
+        void testGetNodeInfoByMigrate_SearchExactTableNameNoDuplicate() {
+            // TAP-12572: searching an existing table name must not return the same table twice
+            List<String> tableNames = new ArrayList<>(Arrays.asList("orders", "users", "products"));
+            when(taskNodeService.getMigrateTableNames(sourceNode, userDetail)).thenReturn(tableNames);
+            when(dag.getPreNodes("nodeId")).thenReturn(new LinkedList<>());
+
+            Page<MetadataTransformerItemDto> result = new Page<>();
+            when(taskNodeService.getMetadataTransformerItemDtoPage(
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(result);
+
+            taskNodeService.getNodeInfoByMigrate(
+                "taskId", "nodeId", "users",
+                new PageParameter(1, 10), userDetail, result, dag);
+
+            org.mockito.ArgumentCaptor<List> currentTableCaptor = org.mockito.ArgumentCaptor.forClass(List.class);
+            verify(taskNodeService).getMetadataTransformerItemDtoPage(
+                any(), any(), any(), any(), any(), currentTableCaptor.capture(), any(), any(), any(), any(), any(), any());
+            List<?> currentTables = currentTableCaptor.getValue();
+            Assertions.assertEquals(List.of("users"), currentTables);
+            Assertions.assertEquals(1, currentTables.size());
         }
 
         @Test


### PR DESCRIPTION
## Summary
- Cherry-pick TAP-12572 fix onto `develop` (from #3470 / `release-v4.21.0`).
- Field-edit table search no longer injects the search name into `currentTableList`, and empty search results return an empty page instead of IOOBE.

## Test plan
- [ ] Xray TAP-12839 / Taptest `82.12839` (already PASS on v4.21.0 env)
- [ ] Smoke: field-edit node table search shows single row; empty search does not 500

Related: https://github.com/tapdata/tapdata/pull/3470
Jira: TAP-12572