### PR TITLE
fix: lazy-resolve ClientMongoOperator for task alert publisher

### DIFF
--- a/iengine/modules/observable-module/src/main/java/io/tapdata/observable/alert/HttpTaskAlertPublisher.java
+++ b/iengine/modules/observable-module/src/main/java/io/tapdata/observable/alert/HttpTaskAlertPublisher.java
@@ -3,6 +3,7 @@ package io.tapdata.observable.alert;
 import com.tapdata.constant.BeanUtil;
 import com.tapdata.constant.ConnectorConstant;
 import com.tapdata.mongo.ClientMongoOperator;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
 
@@ -11,28 +12,36 @@ import java.util.Map;
 
 /**
  * Posts structured task alerts to TM through the existing engine HTTP operator.
+ *
+ * The JVM dispatcher singleton can be created during {@code SpringApplication.run()},
+ * before {@link BeanUtil#configurableApplicationContext} is assigned. Resolve the
+ * operator lazily so a boot-time null does not permanently disable publishing.
  */
 public class HttpTaskAlertPublisher implements TaskAlertPublisher {
     public static final String RESOURCE = ConnectorConstant.TASK_ALARM + "/task-alerts";
+    static final String CLIENT_MONGO_OPERATOR_BEAN = "clientMongoOperator";
 
-    private final ClientMongoOperator clientMongoOperator;
+    private volatile ClientMongoOperator clientMongoOperator;
+    private final boolean operatorInjected;
 
     public HttpTaskAlertPublisher() {
-        this(BeanUtil.getBean(ClientMongoOperator.class));
+        this.operatorInjected = false;
     }
 
     public HttpTaskAlertPublisher(ClientMongoOperator clientMongoOperator) {
         this.clientMongoOperator = clientMongoOperator;
+        this.operatorInjected = true;
     }
 
     @Override
     public PublishResult publish(TaskAlertEvent event) {
-        if (clientMongoOperator == null) {
+        ClientMongoOperator operator = resolveOperator();
+        if (operator == null) {
             TaskAlertAudit.publishFailed(typeName(event), event.getCode(), "operator_unavailable", null);
             return PublishResult.RETRYABLE;
         }
         try {
-            clientMongoOperator.insertOne(toRequestBody(event), RESOURCE);
+            operator.insertOne(toRequestBody(event), RESOURCE);
             return PublishResult.SUCCESS;
         } catch (RuntimeException runtimeException) {
             HttpClientErrorException clientErrorException = findHttpClientError(runtimeException);
@@ -58,6 +67,37 @@ public class HttpTaskAlertPublisher implements TaskAlertPublisher {
                 return PublishResult.NON_RETRYABLE;
             }
             return PublishResult.RETRYABLE;
+        }
+    }
+
+    ClientMongoOperator resolveOperator() {
+        if (operatorInjected) {
+            return this.clientMongoOperator;
+        }
+        ClientMongoOperator current = this.clientMongoOperator;
+        if (current != null) {
+            return current;
+        }
+        ClientMongoOperator resolved = lookupOperator();
+        if (resolved != null) {
+            this.clientMongoOperator = resolved;
+        }
+        return resolved;
+    }
+
+    private static ClientMongoOperator lookupOperator() {
+        try {
+            ConfigurableApplicationContext context = BeanUtil.configurableApplicationContext;
+            if (context != null) {
+                if (context.containsBean(CLIENT_MONGO_OPERATOR_BEAN)) {
+                    return context.getBean(CLIENT_MONGO_OPERATOR_BEAN, ClientMongoOperator.class);
+                }
+                return context.getBean(ClientMongoOperator.class);
+            }
+            return BeanUtil.getBean(ClientMongoOperator.class);
+        } catch (RuntimeException runtimeException) {
+            TaskAlertAudit.publishFailed(null, null, "operator_lookup", runtimeException);
+            return null;
         }
     }
 

--- a/iengine/modules/observable-module/src/main/java/io/tapdata/observable/alert/HttpTaskAlertPublisher.java
+++ b/iengine/modules/observable-module/src/main/java/io/tapdata/observable/alert/HttpTaskAlertPublisher.java
@@ -9,6 +9,7 @@ import org.springframework.web.client.HttpServerErrorException;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Posts structured task alerts to TM through the existing engine HTTP operator.
@@ -21,7 +22,7 @@ public class HttpTaskAlertPublisher implements TaskAlertPublisher {
     public static final String RESOURCE = ConnectorConstant.TASK_ALARM + "/task-alerts";
     static final String CLIENT_MONGO_OPERATOR_BEAN = "clientMongoOperator";
 
-    private volatile ClientMongoOperator clientMongoOperator;
+    private final AtomicReference<ClientMongoOperator> clientMongoOperator = new AtomicReference<>();
     private final boolean operatorInjected;
 
     public HttpTaskAlertPublisher() {
@@ -29,7 +30,7 @@ public class HttpTaskAlertPublisher implements TaskAlertPublisher {
     }
 
     public HttpTaskAlertPublisher(ClientMongoOperator clientMongoOperator) {
-        this.clientMongoOperator = clientMongoOperator;
+        this.clientMongoOperator.set(clientMongoOperator);
         this.operatorInjected = true;
     }
 
@@ -72,17 +73,21 @@ public class HttpTaskAlertPublisher implements TaskAlertPublisher {
 
     ClientMongoOperator resolveOperator() {
         if (operatorInjected) {
-            return this.clientMongoOperator;
+            return this.clientMongoOperator.get();
         }
-        ClientMongoOperator current = this.clientMongoOperator;
+        ClientMongoOperator current = this.clientMongoOperator.get();
         if (current != null) {
             return current;
         }
         ClientMongoOperator resolved = lookupOperator();
-        if (resolved != null) {
-            this.clientMongoOperator = resolved;
+        if (resolved == null) {
+            return null;
         }
-        return resolved;
+        if (this.clientMongoOperator.compareAndSet(null, resolved)) {
+            return resolved;
+        }
+        ClientMongoOperator winner = this.clientMongoOperator.get();
+        return winner != null ? winner : resolved;
     }
 
     private static ClientMongoOperator lookupOperator() {

--- a/iengine/modules/observable-module/src/test/java/io/tapdata/observable/alert/HttpTaskAlertPublisherTest.java
+++ b/iengine/modules/observable-module/src/test/java/io/tapdata/observable/alert/HttpTaskAlertPublisherTest.java
@@ -1,9 +1,11 @@
 package io.tapdata.observable.alert;
 
+import com.tapdata.constant.BeanUtil;
 import com.tapdata.mongo.ClientMongoOperator;
 import io.tapdata.entity.logger.alert.TapAlertType;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.client.HttpClientErrorException;
@@ -12,9 +14,12 @@ import java.nio.charset.StandardCharsets;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class HttpTaskAlertPublisherTest {
 
@@ -68,6 +73,45 @@ class HttpTaskAlertPublisherTest {
     void missingOperatorShouldBeRetryable() {
         HttpTaskAlertPublisher publisher = new HttpTaskAlertPublisher(null);
         Assertions.assertEquals(TaskAlertPublisher.PublishResult.RETRYABLE, publisher.publish(sampleEvent()));
+    }
+
+    @Test
+    void shouldResolveOperatorAfterSpringContextAppears() {
+        ClientMongoOperator operator = mock(ClientMongoOperator.class);
+        ConfigurableApplicationContext context = mock(ConfigurableApplicationContext.class);
+        when(context.containsBean(HttpTaskAlertPublisher.CLIENT_MONGO_OPERATOR_BEAN)).thenReturn(true);
+        when(context.getBean(HttpTaskAlertPublisher.CLIENT_MONGO_OPERATOR_BEAN, ClientMongoOperator.class))
+                .thenReturn(operator);
+
+        HttpTaskAlertPublisher publisher = new HttpTaskAlertPublisher();
+        ConfigurableApplicationContext previous = BeanUtil.configurableApplicationContext;
+        try {
+            BeanUtil.configurableApplicationContext = null;
+            Assertions.assertEquals(TaskAlertPublisher.PublishResult.RETRYABLE, publisher.publish(sampleEvent()));
+            verify(operator, never()).insertOne(any(), anyString());
+
+            BeanUtil.configurableApplicationContext = context;
+            Assertions.assertEquals(TaskAlertPublisher.PublishResult.SUCCESS, publisher.publish(sampleEvent()));
+            verify(operator).insertOne(any(), eq(HttpTaskAlertPublisher.RESOURCE));
+        } finally {
+            BeanUtil.configurableApplicationContext = previous;
+        }
+    }
+
+    @Test
+    void injectedOperatorShouldNotBeReplacedByLaterBeanLookup() {
+        ClientMongoOperator injected = mock(ClientMongoOperator.class);
+        ConfigurableApplicationContext context = mock(ConfigurableApplicationContext.class);
+        HttpTaskAlertPublisher publisher = new HttpTaskAlertPublisher(injected);
+        ConfigurableApplicationContext previous = BeanUtil.configurableApplicationContext;
+        try {
+            BeanUtil.configurableApplicationContext = context;
+            Assertions.assertEquals(TaskAlertPublisher.PublishResult.SUCCESS, publisher.publish(sampleEvent()));
+            verify(injected).insertOne(any(), anyString());
+            verify(context, never()).getBean(anyString(), eq(ClientMongoOperator.class));
+        } finally {
+            BeanUtil.configurableApplicationContext = previous;
+        }
     }
 
     private TaskAlertEvent sampleEvent() {


### PR DESCRIPTION
## Summary
- `Log.alert()` wrote `[alert=true]` task logs but never created `AlarmInfo` / email, because `HttpTaskAlertPublisher` eagerly called `BeanUtil.getBean(ClientMongoOperator.class)` while constructing the JVM `TaskAlertDispatcher` singleton.
- That can happen inside `SpringApplication.run()` (for example `ApplicationReadyEvent` HTTP fallback starting tasks) **before** `BeanUtil.configurableApplicationContext` is assigned in `Application.main`, so the operator was cached as `null` forever (`operator_unavailable`).
- Resolve `clientMongoOperator` lazily on `publish()`, retry until the Spring context is ready, prefer the named `clientMongoOperator` bean, and keep an explicitly injected operator unchanged.

## Test Plan
- [x] `mvn -Dtest=HttpTaskAlertPublisherTest test` in `iengine/modules/observable-module` (8 tests)
- [x] After engine restart, Db2i CDC `tapLogger.alert` (`seq=24566`) created `AlarmInfo` `TASK_DATA_INTEGRITY_RISK` and SMTP mail to `hardy@tapdata.io` within ~30s
- [ ] Reviewer: restart iengine (publisher is a JVM singleton)

## Notes
Unrelated local dirty files (`ConnectorManager` license comment-out, `RegisterMain`, etc.) are **not** in this PR.